### PR TITLE
[feat] fase7 — alertas email de stock bajo y auditoría de cambios

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,11 @@ APP_URL=http://localhost:8080
 
 # --- Stock mínimo por defecto ---
 STOCK_MINIMO_ALERTA=5
+
+# --- Email / Alertas de stock ---
+ALERT_EMAIL=admin@example.com
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=noreply@example.com
+SMTP_PASS=secret
+SMTP_FROM_NAME=es21plus Inventario

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "type": "project",
     "require": {
         "php": "^8.1",
-        "setasign/fpdf": "^1.9"
+        "setasign/fpdf": ">=1.7",
+        "phpmailer/phpmailer": "^6.9"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5"

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,1926 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "b1ccafc8fb9243185a547409b5a55fbe",
+    "packages": [
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "v6.12.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "d1ac35d784bf9f5e61b424901d5a014967f15b12"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/d1ac35d784bf9f5e61b424901d5a014967f15b12",
+                "reference": "d1ac35d784bf9f5e61b424901d5a014967f15b12",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "doctrine/annotations": "^1.2.6 || ^1.13.3",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.3.5",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.7.2",
+                "yoast/phpunit-polyfills": "^1.0.4"
+            },
+            "suggest": {
+                "decomplexity/SendOauth2": "Adapter for using XOAUTH2 authentication",
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "ext-openssl": "Needed for secure SMTP sending and DKIM signing",
+                "greew/oauth2-azure-provider": "Needed for Microsoft Azure XOAUTH2 authentication",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+                "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.12.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Synchro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-10-15T16:49:08+00:00"
+        },
+        {
+            "name": "setasign/fpdf",
+            "version": "1.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Setasign/FPDF.git",
+                "reference": "d77904018090c17dc9f3ab6e944679a7a47e710a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Setasign/FPDF/zipball/d77904018090c17dc9f3ab6e944679a7a47e710a",
+                "reference": "d77904018090c17dc9f3ab6e944679a7a47e710a",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "fpdf.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Olivier Plathey",
+                    "email": "oliver@fpdf.org",
+                    "homepage": "http://fpdf.org/"
+                }
+            ],
+            "description": "FPDF is a PHP class which allows to generate PDF files with pure PHP. F from FPDF stands for Free: you may use it for any kind of usage and modify it to suit your needs.",
+            "homepage": "http://www.fpdf.org",
+            "keywords": [
+                "fpdf",
+                "pdf"
+            ],
+            "support": {
+                "source": "https://github.com/Setasign/FPDF/tree/1.8.2"
+            },
+            "time": "2019-12-08T10:32:10+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "reference": "dca41cd15c2ac9d055ad70dbfd011130757d1f82",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.7.0"
+            },
+            "time": "2025-12-06T11:56:16+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "11.0.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.2",
+                "phpunit/php-file-iterator": "^5.1.0",
+                "phpunit/php-text-template": "^4.0.1",
+                "sebastian/code-unit-reverse-lookup": "^4.0.1",
+                "sebastian/complexity": "^4.0.1",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/lines-of-code": "^3.0.1",
+                "sebastian/version": "^5.0.2",
+                "theseer/tokenizer": "^1.3.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5.46"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-code-coverage",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-12-24T07:01:01+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/php-file-iterator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-02T13:52:54+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:07:44+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:08:43+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "7.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:09:35+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "11.5.55",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.2",
+                "phpunit/php-code-coverage": "^11.0.12",
+                "phpunit/php-file-iterator": "^5.1.1",
+                "phpunit/php-invoker": "^5.0.1",
+                "phpunit/php-text-template": "^4.0.1",
+                "phpunit/php-timer": "^7.0.1",
+                "sebastian/cli-parser": "^3.0.2",
+                "sebastian/code-unit": "^3.0.3",
+                "sebastian/comparator": "^6.3.3",
+                "sebastian/diff": "^6.0.2",
+                "sebastian/environment": "^7.2.1",
+                "sebastian/exporter": "^6.3.2",
+                "sebastian/global-state": "^7.0.2",
+                "sebastian/object-enumerator": "^6.0.1",
+                "sebastian/recursion-context": "^6.0.3",
+                "sebastian/type": "^5.1.3",
+                "sebastian/version": "^5.0.2",
+                "staabm/side-effects-detector": "^1.0.5"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "11.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsors.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-02-18T12:37:06+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:41:36+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-19T07:56:08+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
+                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:45:54+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "6.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/diff": "^6.0",
+                "sebastian/exporter": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.4"
+            },
+            "suggest": {
+                "ext-bcmath": "For comparing BcMath\\Number objects"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:26:40+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
+                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:49:50+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0",
+                "symfony/process": "^4.2 || ^5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:53:05+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "7.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/environment",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-05-21T11:55:47+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "6.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
+                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.2",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.3-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:12:51+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "7.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
+                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "7.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:57:36+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.0",
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T04:58:38+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "6.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
+                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "sebastian/object-reflector": "^4.0",
+                "sebastian/recursion-context": "^6.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:00:13+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-03T05:01:32+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-13T04:42:22+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "5.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^11.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "security": "https://github.com/sebastianbergmann/type/security/policy",
+                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/type",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-09T06:55:48+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "5.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "security": "https://github.com/sebastianbergmann/version/security/policy",
+                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-09T05:16:32+00:00"
+        },
+        {
+            "name": "staabm/side-effects-detector",
+            "version": "1.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/staabm/side-effects-detector.git",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/staabm/side-effects-detector/zipball/d8334211a140ce329c13726d4a715adbddd0a163",
+                "reference": "d8334211a140ce329c13726d4a715adbddd0a163",
+                "shasum": ""
+            },
+            "require": {
+                "ext-tokenizer": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^1.12.6",
+                "phpunit/phpunit": "^9.6.21",
+                "symfony/var-dumper": "^5.4.43",
+                "tomasvotruba/type-coverage": "1.0.0",
+                "tomasvotruba/unused-public": "1.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A static analysis tool to detect side effects in PHP code",
+            "keywords": [
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/staabm/side-effects-detector/issues",
+                "source": "https://github.com/staabm/side-effects-detector/tree/1.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
+        }
+    ],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {
+        "php": "^8.1"
+    },
+    "platform-dev": {},
+    "plugin-api-version": "2.9.0"
+}

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -35,7 +35,8 @@ CREATE TABLE IF NOT EXISTS productos (
     categoria_id INT,
     created_at   TIMESTAMP      DEFAULT CURRENT_TIMESTAMP,
     updated_at   TIMESTAMP      DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-    deleted_at   TIMESTAMP      NULL DEFAULT NULL,
+    deleted_at     TIMESTAMP      NULL DEFAULT NULL,
+    alertas_email  TINYINT(1)     DEFAULT 1,
     FOREIGN KEY (categoria_id) REFERENCES categorias(id) ON DELETE SET NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
@@ -50,6 +51,17 @@ CREATE TABLE IF NOT EXISTS movimientos (
     observaciones TEXT,
     usuario       VARCHAR(100) DEFAULT 'admin',
     fecha         TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (producto_id) REFERENCES productos(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------------------------------------------
+-- Tabla: alertas_stock (deduplicación de alertas de email)
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS alertas_stock (
+    id              INT AUTO_INCREMENT PRIMARY KEY,
+    producto_id     INT NOT NULL,
+    enviada_at      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    stock_al_enviar INT,
     FOREIGN KEY (producto_id) REFERENCES productos(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -54,6 +54,9 @@ CREATE TABLE IF NOT EXISTS movimientos (
     FOREIGN KEY (producto_id) REFERENCES productos(id) ON DELETE CASCADE
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+-- Migración: añadir alertas_email a productos (para instalaciones existentes)
+ALTER TABLE productos ADD COLUMN IF NOT EXISTS alertas_email TINYINT(1) DEFAULT 1;
+
 -- -------------------------------------------------------------
 -- Tabla: alertas_stock (deduplicación de alertas de email)
 -- -------------------------------------------------------------

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -76,6 +76,21 @@ INSERT IGNORE INTO categorias (id, nombre, descripcion) VALUES
 (5, 'Carrocería',  'Carenados, retrovisores, manillares y accesorios');
 
 -- -------------------------------------------------------------
+-- Tabla: auditoria (historial de cambios en entidades)
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS auditoria (
+    id               BIGINT       AUTO_INCREMENT PRIMARY KEY,
+    tabla            VARCHAR(50)  NOT NULL,
+    registro_id      INT          NOT NULL,
+    accion           ENUM('crear','actualizar','eliminar') NOT NULL,
+    datos_anteriores JSON,
+    datos_nuevos     JSON,
+    usuario          VARCHAR(100) DEFAULT 'admin',
+    ip               VARCHAR(45),
+    fecha            TIMESTAMP    DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------------------------------------------
 -- Tabla: usuarios (autenticación)
 -- -------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS usuarios (

--- a/src/auditoria.php
+++ b/src/auditoria.php
@@ -1,0 +1,335 @@
+<?php
+/**
+ * Historial de auditoría de cambios en el inventario.
+ *
+ * Muestra un log paginado y filtrable de todas las operaciones de
+ * crear, actualizar y eliminar realizadas sobre productos y categorías.
+ * Los registros son de solo lectura: no existe ninguna ruta de borrado.
+ *
+ * @package  Es21Plus
+ * @author   Carlitos6712
+ * @version  1.0.0
+ */
+session_start();
+require_once __DIR__ . '/includes/AppException.php';
+require_once __DIR__ . '/includes/Database.php';
+require_once __DIR__ . '/includes/Auditoria.php';
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+// ── Parámetros de filtro y paginación ────────────────────────────────────────
+$filtroTabla  = trim($_GET['tabla']       ?? '');
+$filtroAccion = trim($_GET['accion']      ?? '');
+$fechaDesde   = trim($_GET['fecha_desde'] ?? '');
+$fechaHasta   = trim($_GET['fecha_hasta'] ?? '');
+$pagina       = max(1, (int) ($_GET['pagina'] ?? 1));
+$porPagina    = 25;
+
+$registros     = [];
+$total         = 0;
+$totalPaginas  = 1;
+$error         = '';
+
+try {
+    $auditoria = new Auditoria(Database::getInstance());
+
+    $filtroTablaVal  = $filtroTabla  !== '' ? $filtroTabla  : null;
+    $filtroAccionVal = $filtroAccion !== '' ? $filtroAccion : null;
+    $fechaDesdeVal   = $fechaDesde   !== '' ? $fechaDesde   : null;
+    $fechaHastaVal   = $fechaHasta   !== '' ? $fechaHasta   : null;
+
+    $total        = $auditoria->contar($filtroTablaVal, $filtroAccionVal, $fechaDesdeVal, $fechaHastaVal);
+    $totalPaginas = max(1, (int) ceil($total / $porPagina));
+    $pagina       = min($pagina, $totalPaginas);
+
+    $registros    = $auditoria->listar($filtroTablaVal, $filtroAccionVal, $fechaDesdeVal, $fechaHastaVal, $pagina, $porPagina);
+} catch (\Throwable $e) {
+    $error = 'Error al cargar la auditoría: ' . htmlspecialchars($e->getMessage());
+}
+
+// ── Helper: decodifica y formatea un JSON para mostrar diff ──────────────────
+function formatearDiff(?string $json): string
+{
+    if ($json === null || $json === '') {
+        return '<span class="audit-null">—</span>';
+    }
+    $data = json_decode($json, true);
+    if (!is_array($data)) {
+        return htmlspecialchars($json);
+    }
+    $lines = [];
+    foreach ($data as $k => $v) {
+        $val    = is_null($v) ? 'null' : htmlspecialchars((string) $v);
+        $lines[] = '<span class="audit-key">' . htmlspecialchars($k) . '</span>: ' . $val;
+    }
+    return implode('<br>', $lines);
+}
+
+function urlFiltros(array $overrides = []): string
+{
+    global $filtroTabla, $filtroAccion, $fechaDesde, $fechaHasta, $pagina;
+    $params = [
+        'tabla'       => $filtroTabla,
+        'accion'      => $filtroAccion,
+        'fecha_desde' => $fechaDesde,
+        'fecha_hasta' => $fechaHasta,
+        'pagina'      => $pagina,
+    ];
+    $params = array_merge($params, $overrides);
+    $params = array_filter($params, fn($v) => $v !== '' && $v !== null);
+    return 'auditoria.php?' . http_build_query($params);
+}
+
+$badgeAccion = [
+    'crear'     => 'badge-success',
+    'actualizar'=> 'badge-warning',
+    'eliminar'  => 'badge-danger',
+];
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Auditoría – es21plus</title>
+    <link rel="stylesheet" href="css/estilos.css">
+    <style>
+        .audit-key    { font-weight: 600; color: var(--color-primary, #3b82f6); }
+        .audit-null   { color: var(--color-muted, #9ca3af); font-style: italic; }
+        .audit-diff   { font-size: .78rem; line-height: 1.6; font-family: monospace; }
+        .badge        { display: inline-block; padding: .2em .55em; border-radius: 9999px; font-size: .72rem; font-weight: 700; text-transform: uppercase; }
+        .badge-success{ background: #d1fae5; color: #065f46; }
+        .badge-warning{ background: #fef3c7; color: #92400e; }
+        .badge-danger { background: #fee2e2; color: #991b1b; }
+        .diff-grid    { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem; }
+        .diff-col h4  { margin: 0 0 .25rem; font-size: .72rem; text-transform: uppercase; color: var(--color-muted, #9ca3af); }
+        .filters-bar  { display: flex; flex-wrap: wrap; gap: .75rem; align-items: flex-end; margin-bottom: 1.25rem; }
+        .filters-bar label { display: flex; flex-direction: column; gap: .25rem; font-size: .82rem; font-weight: 600; }
+        .filters-bar input,
+        .filters-bar select { padding: .4rem .6rem; border: 1px solid var(--color-border,#e5e7eb); border-radius: .375rem; font-size: .85rem; }
+    </style>
+</head>
+<body class="layout">
+
+<!-- ===== SIDEBAR ===== -->
+<aside class="sidebar" id="sidebar">
+    <div class="sidebar-header">
+        <div class="sidebar-logo">
+            <svg class="logo-icon" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/>
+            </svg>
+            <span class="logo-text">es21<strong>plus</strong></span>
+        </div>
+        <button class="sidebar-close" id="sidebarClose" aria-label="Cerrar menú">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+        </button>
+    </div>
+
+    <nav class="sidebar-nav">
+        <div class="nav-section">
+            <span class="nav-section-label">Principal</span>
+            <a href="index.php" class="nav-item <?= in_array(basename($_SERVER['PHP_SELF']), ['index.php','dashboard.php']) ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Dashboard</span>
+            </a>
+            <a href="productos.php" class="nav-item <?= in_array(basename($_SERVER['PHP_SELF']), ['productos.php','nuevo_producto.php','editar_producto.php','eliminar_producto.php']) ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Productos</span>
+            </a>
+            <a href="categorias.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'categorias.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Categorías</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Operaciones</span>
+            <a href="movimientos.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'movimientos.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Movimientos</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+        </div>
+    </nav>
+
+    <div class="sidebar-footer">
+        <div class="sidebar-user">
+            <div class="user-avatar-sm">CV</div>
+            <div class="sidebar-user-info">
+                <span class="user-name-sm">Carlos Vico</span>
+                <span class="user-role">Administrador</span>
+            </div>
+        </div>
+    </div>
+</aside>
+
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<div class="main-wrapper">
+    <header class="topbar">
+        <div class="topbar-left">
+            <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+                </svg>
+            </button>
+            <h1 class="topbar-title">Auditoría de cambios</h1>
+        </div>
+    </header>
+
+    <main class="main-content">
+
+        <?php if ($error !== ''): ?>
+            <div class="alert alert-danger"><?= $error ?></div>
+        <?php endif; ?>
+
+        <?php if ($flashSuccess !== ''): ?>
+            <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+        <?php endif; ?>
+
+        <!-- ── Filtros ──────────────────────────────────────────────── -->
+        <section class="card" style="margin-bottom:1.5rem;">
+            <div class="card-body">
+                <form method="GET" action="auditoria.php" class="filters-bar">
+                    <label>
+                        Tabla
+                        <select name="tabla">
+                            <option value="">Todas</option>
+                            <option value="productos"  <?= $filtroTabla === 'productos'   ? 'selected' : '' ?>>Productos</option>
+                            <option value="categorias" <?= $filtroTabla === 'categorias'  ? 'selected' : '' ?>>Categorías</option>
+                        </select>
+                    </label>
+                    <label>
+                        Acción
+                        <select name="accion">
+                            <option value="">Todas</option>
+                            <option value="crear"      <?= $filtroAccion === 'crear'      ? 'selected' : '' ?>>Crear</option>
+                            <option value="actualizar" <?= $filtroAccion === 'actualizar' ? 'selected' : '' ?>>Actualizar</option>
+                            <option value="eliminar"   <?= $filtroAccion === 'eliminar'   ? 'selected' : '' ?>>Eliminar</option>
+                        </select>
+                    </label>
+                    <label>
+                        Desde
+                        <input type="date" name="fecha_desde" value="<?= htmlspecialchars($fechaDesde) ?>">
+                    </label>
+                    <label>
+                        Hasta
+                        <input type="date" name="fecha_hasta" value="<?= htmlspecialchars($fechaHasta) ?>">
+                    </label>
+                    <button type="submit" class="btn btn-primary" style="align-self:flex-end;">Filtrar</button>
+                    <a href="auditoria.php" class="btn btn-secondary" style="align-self:flex-end;">Limpiar</a>
+                </form>
+            </div>
+        </section>
+
+        <!-- ── Tabla de registros ───────────────────────────────────── -->
+        <section class="card">
+            <div class="card-header">
+                <h2 class="card-title">
+                    Registros de auditoría
+                    <span style="font-size:.85rem;font-weight:400;color:var(--color-muted,#9ca3af);">(<?= number_format($total) ?> total)</span>
+                </h2>
+            </div>
+            <div class="card-body" style="overflow-x:auto;">
+                <?php if (empty($registros)): ?>
+                    <p style="text-align:center;color:var(--color-muted,#9ca3af);padding:2rem;">
+                        No hay registros de auditoría con los filtros seleccionados.
+                    </p>
+                <?php else: ?>
+                <table class="table">
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Fecha</th>
+                            <th>Tabla</th>
+                            <th>ID</th>
+                            <th>Acción</th>
+                            <th>Diff (anterior → nuevo)</th>
+                            <th>IP</th>
+                            <th>Usuario</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <?php foreach ($registros as $r): ?>
+                        <tr>
+                            <td><?= (int) $r['id'] ?></td>
+                            <td style="white-space:nowrap;"><?= htmlspecialchars($r['fecha']) ?></td>
+                            <td><?= htmlspecialchars($r['tabla']) ?></td>
+                            <td><?= (int) $r['registro_id'] ?></td>
+                            <td>
+                                <span class="badge <?= $badgeAccion[$r['accion']] ?? 'badge-secondary' ?>">
+                                    <?= htmlspecialchars($r['accion']) ?>
+                                </span>
+                            </td>
+                            <td class="audit-diff">
+                                <div class="diff-grid">
+                                    <div class="diff-col">
+                                        <h4>Anterior</h4>
+                                        <?= formatearDiff($r['datos_anteriores']) ?>
+                                    </div>
+                                    <div class="diff-col">
+                                        <h4>Nuevo</h4>
+                                        <?= formatearDiff($r['datos_nuevos']) ?>
+                                    </div>
+                                </div>
+                            </td>
+                            <td><?= htmlspecialchars($r['ip'] ?? '') ?></td>
+                            <td><?= htmlspecialchars($r['usuario'] ?? 'admin') ?></td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+                <?php endif; ?>
+            </div>
+
+            <!-- ── Paginación ──────────────────────────────────────── -->
+            <?php if ($totalPaginas > 1): ?>
+            <div class="card-footer" style="display:flex;justify-content:center;gap:.5rem;padding:1rem;">
+                <?php if ($pagina > 1): ?>
+                    <a href="<?= htmlspecialchars(urlFiltros(['pagina' => $pagina - 1])) ?>" class="btn btn-secondary btn-sm">← Anterior</a>
+                <?php endif; ?>
+                <span style="display:flex;align-items:center;font-size:.85rem;">
+                    Página <?= $pagina ?> de <?= $totalPaginas ?>
+                </span>
+                <?php if ($pagina < $totalPaginas): ?>
+                    <a href="<?= htmlspecialchars(urlFiltros(['pagina' => $pagina + 1])) ?>" class="btn btn-secondary btn-sm">Siguiente →</a>
+                <?php endif; ?>
+            </div>
+            <?php endif; ?>
+        </section>
+
+    </main>
+</div>
+
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/src/buscar.php
+++ b/src/buscar.php
@@ -463,6 +463,13 @@ $hayFiltros = $termino !== '' || $categoriaId !== null || $precioMin !== null
                 <span class="nav-label">Búsqueda</span>
             </a>
         </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+        </div>
     </nav>
     <div class="sidebar-footer">
         <div class="sidebar-user">

--- a/src/categorias.php
+++ b/src/categorias.php
@@ -138,6 +138,17 @@ try {
                 <span class="nav-label">Movimientos</span>
             </a>
         </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+        </div>
     </nav>
 
     <div class="sidebar-footer">

--- a/src/editar_producto.php
+++ b/src/editar_producto.php
@@ -143,6 +143,17 @@ try {
                 <span class="nav-label">Movimientos</span>
             </a>
         </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+        </div>
     </nav>
 
     <div class="sidebar-footer">

--- a/src/eliminar_producto.php
+++ b/src/eliminar_producto.php
@@ -115,6 +115,17 @@ try {
                 <span class="nav-label">Movimientos</span>
             </a>
         </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+        </div>
     </nav>
 
     <div class="sidebar-footer">

--- a/src/includes/AlertaStock.php
+++ b/src/includes/AlertaStock.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * Servicio de alertas de stock bajo por email.
+ *
+ * Verifica tras cada salida si el stock ha caído por debajo del mínimo
+ * y envía un email de alerta al destinatario configurado en ALERT_EMAIL.
+ * Usa la tabla alertas_stock para evitar duplicados dentro del mismo
+ * episodio de stock bajo (entre una alerta y la siguiente entrada que
+ * recupere el stock).
+ *
+ * @package  Es21Plus\Includes
+ * @author   Carlitos6712
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/AppException.php';
+require_once __DIR__ . '/Database.php';
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception as MailException;
+
+class AlertaStock
+{
+    /** @var callable(string $to, string $subject, string $body): void */
+    private $transport;
+
+    /**
+     * @param PDO           $pdo       Conexión PDO inyectada.
+     * @param callable|null $transport Función de envío; si es null, usa PHPMailer SMTP.
+     * @author Carlitos6712
+     */
+    public function __construct(private PDO $pdo, ?callable $transport = null)
+    {
+        $this->transport = $transport ?? $this->crearTransportPhpMailer();
+    }
+
+    /**
+     * Verifica si el stock bajó del mínimo y envía la alerta si procede.
+     *
+     * No envía si: stock >= stock_minimo, alertas desactivadas para el
+     * producto, ya hay una alerta activa en el mismo episodio, o ALERT_EMAIL
+     * no está configurado.
+     *
+     * @param int $productoId  ID del producto afectado.
+     * @param int $stockActual Stock tras el movimiento de salida.
+     * @return void
+     * @author Carlitos6712
+     */
+    public function verificarYEnviar(int $productoId, int $stockActual): void
+    {
+        $producto = $this->obtenerProducto($productoId);
+        if ($producto === null) {
+            return;
+        }
+
+        if ($stockActual > (int) $producto['stock_minimo']) {
+            return;
+        }
+
+        if (!(bool) $producto['alertas_email']) {
+            return;
+        }
+
+        if ($this->hayAlertaActivaParaEpisodio($productoId)) {
+            return;
+        }
+
+        $alertEmail = $_ENV['ALERT_EMAIL'] ?? '';
+        if ($alertEmail === '') {
+            return;
+        }
+
+        $appUrl  = rtrim($_ENV['APP_URL'] ?? 'http://localhost:8080', '/');
+        $subject = "Alerta de stock bajo: {$producto['nombre']}";
+        $body    = $this->construirCuerpoEmail($producto['nombre'], $stockActual, (int) $producto['stock_minimo'], $appUrl);
+
+        ($this->transport)($alertEmail, $subject, $body);
+        $this->registrarAlerta($productoId, $stockActual);
+    }
+
+    /**
+     * Obtiene los datos básicos del producto necesarios para la alerta.
+     *
+     * @param int $productoId
+     * @return array<string,mixed>|null
+     * @author Carlitos6712
+     */
+    public function obtenerProducto(int $productoId): ?array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT nombre, stock_minimo, alertas_email
+             FROM productos
+             WHERE id = :id AND deleted_at IS NULL"
+        );
+        $stmt->execute([':id' => $productoId]);
+        $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        return ($row !== false) ? $row : null;
+    }
+
+    /**
+     * Determina si hay una alerta activa para el episodio actual de stock bajo.
+     *
+     * Un episodio es activo si existe una alerta previa Y no ha habido
+     * ningún movimiento de entrada desde esa alerta (la entrada indica
+     * posible recuperación de stock).
+     *
+     * @param int $productoId
+     * @return bool
+     * @author Carlitos6712
+     */
+    public function hayAlertaActivaParaEpisodio(int $productoId): bool
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM alertas_stock a
+             WHERE a.producto_id = :id
+             AND NOT EXISTS (
+                 SELECT 1 FROM movimientos m
+                 WHERE m.producto_id = :id2
+                   AND m.tipo = 'entrada'
+                   AND m.fecha > a.enviada_at
+             )"
+        );
+        $stmt->execute([':id' => $productoId, ':id2' => $productoId]);
+        return (int) $stmt->fetchColumn() > 0;
+    }
+
+    /**
+     * Registra que se ha enviado una alerta para el producto.
+     *
+     * @param int $productoId
+     * @param int $stockActual
+     * @return void
+     * @author Carlitos6712
+     */
+    public function registrarAlerta(int $productoId, int $stockActual): void
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO alertas_stock (producto_id, stock_al_enviar)
+             VALUES (:id, :stock)"
+        );
+        $stmt->execute([':id' => $productoId, ':stock' => $stockActual]);
+    }
+
+    /**
+     * Construye el cuerpo de texto plano del email de alerta.
+     *
+     * @param string $nombre      Nombre del producto.
+     * @param int    $stock       Stock actual tras el movimiento.
+     * @param int    $stockMinimo Umbral mínimo configurado.
+     * @param string $appUrl      URL base del panel de administración.
+     * @return string
+     * @author Carlitos6712
+     */
+    private function construirCuerpoEmail(string $nombre, int $stock, int $stockMinimo, string $appUrl): string
+    {
+        return "ALERTA: Stock bajo en el inventario de es21plus.\n\n"
+            . "Producto  : {$nombre}\n"
+            . "Stock actual : {$stock} unidades\n"
+            . "Stock mínimo : {$stockMinimo} unidades\n\n"
+            . "Accede al panel para gestionar el inventario:\n"
+            . "{$appUrl}/productos.php\n";
+    }
+
+    /**
+     * Crea el transport PHPMailer usando las variables de entorno SMTP.
+     *
+     * @return callable
+     * @author Carlitos6712
+     */
+    private function crearTransportPhpMailer(): callable
+    {
+        return function (string $to, string $subject, string $body): void {
+            $mail = new PHPMailer(true);
+            try {
+                $mail->isSMTP();
+                $mail->Host       = $_ENV['SMTP_HOST'] ?? 'localhost';
+                $mail->Port       = (int) ($_ENV['SMTP_PORT'] ?? 587);
+                $mail->SMTPAuth   = true;
+                $mail->Username   = $_ENV['SMTP_USER'] ?? '';
+                $mail->Password   = $_ENV['SMTP_PASS'] ?? '';
+                $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+
+                $from     = $_ENV['SMTP_USER']      ?? 'noreply@es21plus.local';
+                $fromName = $_ENV['SMTP_FROM_NAME'] ?? 'es21plus Inventario';
+                $mail->setFrom($from, $fromName);
+                $mail->addAddress($to);
+
+                $mail->Subject = $subject;
+                $mail->Body    = $body;
+                $mail->send();
+            } catch (MailException $e) {
+                error_log("AlertaStock: fallo al enviar email – {$mail->ErrorInfo}");
+            }
+        };
+    }
+}

--- a/src/includes/Auditoria.php
+++ b/src/includes/Auditoria.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Modelo de auditoría de cambios en el inventario.
+ *
+ * Registra cada operación de crear, actualizar y eliminar en las entidades
+ * principales (productos, categorias), almacenando los datos anteriores y
+ * nuevos en formato JSON para permitir visualizar el diff de cambios.
+ * Los registros de auditoría son inmutables: no se expone ningún método
+ * de borrado.
+ *
+ * @package  Es21Plus\Includes
+ * @author   Carlitos6712
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/AppException.php';
+require_once __DIR__ . '/Database.php';
+
+class Auditoria
+{
+    /**
+     * @param PDO $pdo Conexión PDO inyectada.
+     * @author Carlitos6712
+     */
+    public function __construct(private PDO $pdo) {}
+
+    /**
+     * Crea una instancia usando la conexión singleton.
+     *
+     * @return self
+     * @author Carlitos6712
+     */
+    public static function instancia(): self
+    {
+        return new self(Database::getInstance());
+    }
+
+    /**
+     * Registra una operación de auditoría con diff JSON.
+     *
+     * @param string     $tabla           Tabla afectada ('productos', 'categorias').
+     * @param int        $registroId      PK del registro afectado.
+     * @param string     $accion          'crear' | 'actualizar' | 'eliminar'.
+     * @param array|null $datosAnteriores Estado antes de la operación (null en crear).
+     * @param array|null $datosNuevos     Estado después de la operación (null en eliminar).
+     * @return void
+     * @author Carlitos6712
+     */
+    public function registrar(
+        string $tabla,
+        int $registroId,
+        string $accion,
+        ?array $datosAnteriores,
+        ?array $datosNuevos
+    ): void {
+        $ip = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO auditoria
+             (tabla, registro_id, accion, datos_anteriores, datos_nuevos, ip)
+             VALUES (:tabla, :registro_id, :accion, :datos_anteriores, :datos_nuevos, :ip)"
+        );
+        $stmt->execute([
+            ':tabla'            => $tabla,
+            ':registro_id'      => $registroId,
+            ':accion'           => $accion,
+            ':datos_anteriores' => $datosAnteriores !== null
+                ? json_encode($datosAnteriores, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+                : null,
+            ':datos_nuevos'     => $datosNuevos !== null
+                ? json_encode($datosNuevos, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+                : null,
+            ':ip'               => $ip,
+        ]);
+    }
+
+    /**
+     * Lista registros de auditoría con filtros opcionales y paginación.
+     *
+     * @param string|null $tabla      Filtrar por tabla afectada.
+     * @param string|null $accion     Filtrar por tipo de acción.
+     * @param string|null $fechaDesde Fecha inicio ISO (YYYY-MM-DD).
+     * @param string|null $fechaHasta Fecha fin ISO (YYYY-MM-DD).
+     * @param int         $pagina     Página actual (1-indexed).
+     * @param int         $porPagina  Registros por página.
+     * @return array<int, array<string, mixed>>
+     * @author Carlitos6712
+     */
+    public function listar(
+        ?string $tabla = null,
+        ?string $accion = null,
+        ?string $fechaDesde = null,
+        ?string $fechaHasta = null,
+        int $pagina = 1,
+        int $porPagina = 25
+    ): array {
+        [$sql, $params] = $this->construirQuery($tabla, $accion, $fechaDesde, $fechaHasta);
+
+        $sql   .= " ORDER BY fecha DESC";
+        $offset = ($pagina - 1) * $porPagina;
+        $sql   .= " LIMIT :limite OFFSET :offset";
+
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $k => $v) {
+            $stmt->bindValue($k, $v);
+        }
+        $stmt->bindValue(':limite', $porPagina, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset,    PDO::PARAM_INT);
+        $stmt->execute();
+
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Cuenta registros de auditoría aplicando los mismos filtros que listar().
+     *
+     * @param string|null $tabla
+     * @param string|null $accion
+     * @param string|null $fechaDesde
+     * @param string|null $fechaHasta
+     * @return int
+     * @author Carlitos6712
+     */
+    public function contar(
+        ?string $tabla = null,
+        ?string $accion = null,
+        ?string $fechaDesde = null,
+        ?string $fechaHasta = null
+    ): int {
+        [$sql, $params] = $this->construirQuery($tabla, $accion, $fechaDesde, $fechaHasta, true);
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute($params);
+        return (int) $stmt->fetchColumn();
+    }
+
+    /**
+     * Construye la cláusula SQL base con todos los filtros aplicados.
+     *
+     * @param string|null $tabla
+     * @param string|null $accion
+     * @param string|null $fechaDesde
+     * @param string|null $fechaHasta
+     * @param bool        $contar     Si true, genera SELECT COUNT(*).
+     * @return array{0: string, 1: array<string, mixed>}
+     * @author Carlitos6712
+     */
+    private function construirQuery(
+        ?string $tabla,
+        ?string $accion,
+        ?string $fechaDesde,
+        ?string $fechaHasta,
+        bool $contar = false
+    ): array {
+        $select = $contar ? "SELECT COUNT(*) FROM auditoria" : "SELECT * FROM auditoria";
+        $where  = [];
+        $params = [];
+
+        if ($tabla !== null && $tabla !== '') {
+            $where[]         = "tabla = :tabla";
+            $params[':tabla'] = $tabla;
+        }
+        if ($accion !== null && $accion !== '') {
+            $where[]          = "accion = :accion";
+            $params[':accion'] = $accion;
+        }
+        if ($fechaDesde !== null && $fechaDesde !== '') {
+            $where[]               = "fecha >= :fecha_desde";
+            $params[':fecha_desde'] = $fechaDesde . ' 00:00:00';
+        }
+        if ($fechaHasta !== null && $fechaHasta !== '') {
+            $where[]               = "fecha <= :fecha_hasta";
+            $params[':fecha_hasta'] = $fechaHasta . ' 23:59:59';
+        }
+
+        $sql = $select;
+        if ($where) {
+            $sql .= " WHERE " . implode(" AND ", $where);
+        }
+
+        return [$sql, $params];
+    }
+}

--- a/src/includes/Categoria.php
+++ b/src/includes/Categoria.php
@@ -95,7 +95,9 @@ class Categoria
             "UPDATE categorias SET nombre = :nombre, descripcion = :descripcion WHERE id = :id"
         );
         $resultado = $stmt->execute([':nombre' => $nombre, ':descripcion' => $descripcion, ':id' => $id]);
-        $this->auditarOperacion('actualizar', $id, $anterior, compact('nombre', 'descripcion'));
+        if ($resultado && $stmt->rowCount() > 0) {
+            $this->auditarOperacion('actualizar', $id, $anterior, compact('nombre', 'descripcion'));
+        }
         return $resultado;
     }
 

--- a/src/includes/Categoria.php
+++ b/src/includes/Categoria.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/AppException.php';
 require_once __DIR__ . '/Database.php';
+require_once __DIR__ . '/Auditoria.php';
 
 /**
  * Modelo de gestión de categorías del inventario.
@@ -13,13 +14,17 @@ require_once __DIR__ . '/Database.php';
 class Categoria
 {
     private PDO $pdo;
+    private Auditoria $auditoria;
 
     /**
+     * @param Auditoria|null $auditoria Modelo de auditoría; si es null, se crea con la conexión singleton.
      * @throws AppException Si falla la conexión.
+     * @author Carlitos6712
      */
-    public function __construct()
+    public function __construct(?Auditoria $auditoria = null)
     {
-        $this->pdo = Database::getInstance();
+        $this->pdo       = Database::getInstance();
+        $this->auditoria = $auditoria ?? new Auditoria($this->pdo);
     }
 
     /**
@@ -70,7 +75,9 @@ class Categoria
             "INSERT INTO categorias (nombre, descripcion) VALUES (:nombre, :descripcion)"
         );
         $stmt->execute([':nombre' => $nombre, ':descripcion' => $descripcion]);
-        return (int) $this->pdo->lastInsertId();
+        $id = (int) $this->pdo->lastInsertId();
+        $this->auditarOperacion('crear', $id, null, compact('nombre', 'descripcion'));
+        return $id;
     }
 
     /**
@@ -83,10 +90,13 @@ class Categoria
      */
     public function actualizar(int $id, string $nombre, string $descripcion = ''): bool
     {
+        $anterior  = $this->obtenerPorId($id);
         $stmt = $this->pdo->prepare(
             "UPDATE categorias SET nombre = :nombre, descripcion = :descripcion WHERE id = :id"
         );
-        return $stmt->execute([':nombre' => $nombre, ':descripcion' => $descripcion, ':id' => $id]);
+        $resultado = $stmt->execute([':nombre' => $nombre, ':descripcion' => $descripcion, ':id' => $id]);
+        $this->auditarOperacion('actualizar', $id, $anterior, compact('nombre', 'descripcion'));
+        return $resultado;
     }
 
     /**
@@ -105,7 +115,31 @@ class Categoria
         if ((int) $stmt->fetchColumn() > 0) {
             throw new AppException('No se puede eliminar: la categoría tiene productos activos.', 409);
         }
+        $anterior = $this->obtenerPorId($id);
         $del = $this->pdo->prepare("DELETE FROM categorias WHERE id = :id");
-        return $del->execute([':id' => $id]);
+        $resultado = $del->execute([':id' => $id]);
+        if ($resultado) {
+            $this->auditarOperacion('eliminar', $id, $anterior, null);
+        }
+        return $resultado;
+    }
+
+    /**
+     * Registra una operación en el log de auditoría sin propagar errores.
+     *
+     * @param string     $accion   'crear' | 'actualizar' | 'eliminar'.
+     * @param int        $id       PK de la categoría.
+     * @param array|null $anterior Datos antes de la operación.
+     * @param array|null $nuevo    Datos después de la operación.
+     * @return void
+     * @author Carlitos6712
+     */
+    private function auditarOperacion(string $accion, int $id, ?array $anterior, ?array $nuevo): void
+    {
+        try {
+            $this->auditoria->registrar('categorias', $id, $accion, $anterior, $nuevo);
+        } catch (\Throwable $e) {
+            error_log("Auditoria::categorias: {$e->getMessage()}");
+        }
     }
 }

--- a/src/includes/Movimiento.php
+++ b/src/includes/Movimiento.php
@@ -2,6 +2,7 @@
 require_once __DIR__ . '/AppException.php';
 require_once __DIR__ . '/Database.php';
 require_once __DIR__ . '/Producto.php';
+require_once __DIR__ . '/AlertaStock.php';
 
 /**
  * Modelo de gestión de movimientos de stock (entradas/salidas).
@@ -15,14 +16,18 @@ class Movimiento
 {
     private PDO $pdo;
     private Producto $productoModel;
+    private AlertaStock $alertaStock;
 
     /**
+     * @param AlertaStock|null $alertaStock Servicio de alertas; si es null, se crea con PHPMailer.
      * @throws AppException Si falla la conexión.
+     * @author Carlitos6712
      */
-    public function __construct()
+    public function __construct(?AlertaStock $alertaStock = null)
     {
         $this->pdo           = Database::getInstance();
         $this->productoModel = new Producto();
+        $this->alertaStock   = $alertaStock ?? new AlertaStock($this->pdo);
     }
 
     /**
@@ -61,6 +66,12 @@ class Movimiento
             ]);
             $id = (int) $this->pdo->lastInsertId();
             $this->pdo->commit();
+
+            if ($tipo === 'salida') {
+                $productoActual = $this->productoModel->obtener($productoId);
+                $this->alertaStock->verificarYEnviar($productoId, (int) $productoActual['stock']);
+            }
+
             return $id;
         } catch (\Throwable $e) {
             $this->pdo->rollBack();

--- a/src/includes/Producto.php
+++ b/src/includes/Producto.php
@@ -1,6 +1,7 @@
 <?php
 require_once __DIR__ . '/AppException.php';
 require_once __DIR__ . '/Database.php';
+require_once __DIR__ . '/Auditoria.php';
 
 /**
  * Modelo de gestión de productos del inventario.
@@ -13,13 +14,17 @@ require_once __DIR__ . '/Database.php';
 class Producto
 {
     private PDO $pdo;
+    private Auditoria $auditoria;
 
     /**
+     * @param Auditoria|null $auditoria Modelo de auditoría; si es null, se crea con la conexión singleton.
      * @throws AppException Si falla la conexión.
+     * @author Carlitos6712
      */
-    public function __construct()
+    public function __construct(?Auditoria $auditoria = null)
     {
-        $this->pdo = Database::getInstance();
+        $this->pdo       = Database::getInstance();
+        $this->auditoria = $auditoria ?? new Auditoria($this->pdo);
     }
 
     /**
@@ -99,7 +104,12 @@ class Producto
             ':stock_minimo' => $stockMinimo,
             ':codigo_ref'   => $codigoRef,
         ]);
-        return (int) $this->pdo->lastInsertId();
+        $id = (int) $this->pdo->lastInsertId();
+        $this->auditarOperacion(
+            'crear', $id, null,
+            compact('nombre', 'descripcion', 'precio', 'categoriaId', 'stock', 'stockMinimo', 'codigoRef')
+        );
+        return $id;
     }
 
     /**
@@ -136,7 +146,8 @@ class Producto
                  codigo_ref = :codigo_ref
              WHERE id = :id AND deleted_at IS NULL"
         );
-        return $stmt->execute([
+        $anterior = $this->obtener($id);
+        $resultado = $stmt->execute([
             ':id'           => $id,
             ':nombre'       => $nombre,
             ':descripcion'  => $descripcion,
@@ -145,6 +156,11 @@ class Producto
             ':stock_minimo' => $stockMinimo,
             ':codigo_ref'   => $codigoRef,
         ]);
+        $this->auditarOperacion(
+            'actualizar', $id, $anterior,
+            compact('nombre', 'descripcion', 'precio', 'categoriaId', 'stockMinimo', 'codigoRef')
+        );
+        return $resultado;
     }
 
     /**
@@ -161,11 +177,16 @@ class Producto
                 409
             );
         }
+        $anterior = $this->obtener($id);
         $stmt = $this->pdo->prepare(
             "UPDATE productos SET deleted_at = NOW() WHERE id = :id AND deleted_at IS NULL"
         );
         $stmt->execute([':id' => $id]);
-        return $stmt->rowCount() > 0;
+        $afectado = $stmt->rowCount() > 0;
+        if ($afectado) {
+            $this->auditarOperacion('eliminar', $id, $anterior, null);
+        }
+        return $afectado;
     }
 
     /**
@@ -276,6 +297,25 @@ class Producto
             "SELECT COUNT(*) FROM productos WHERE deleted_at IS NULL"
         );
         return (int) $stmt->fetchColumn();
+    }
+
+    /**
+     * Registra una operación en el log de auditoría sin propagar errores.
+     *
+     * @param string     $accion    'crear' | 'actualizar' | 'eliminar'.
+     * @param int        $id        PK del producto.
+     * @param array|null $anterior  Datos antes de la operación.
+     * @param array|null $nuevo     Datos después de la operación.
+     * @return void
+     * @author Carlitos6712
+     */
+    private function auditarOperacion(string $accion, int $id, ?array $anterior, ?array $nuevo): void
+    {
+        try {
+            $this->auditoria->registrar('productos', $id, $accion, $anterior, $nuevo);
+        } catch (\Throwable $e) {
+            error_log("Auditoria::productos: {$e->getMessage()}");
+        }
     }
 
     // ── Constantes de imagen ──────────────────────────────────────────────────

--- a/src/includes/Producto.php
+++ b/src/includes/Producto.php
@@ -156,10 +156,12 @@ class Producto
             ':stock_minimo' => $stockMinimo,
             ':codigo_ref'   => $codigoRef,
         ]);
-        $this->auditarOperacion(
-            'actualizar', $id, $anterior,
-            compact('nombre', 'descripcion', 'precio', 'categoriaId', 'stockMinimo', 'codigoRef')
-        );
+        if ($resultado && $stmt->rowCount() > 0) {
+            $this->auditarOperacion(
+                'actualizar', $id, $anterior,
+                compact('nombre', 'descripcion', 'precio', 'categoriaId', 'stockMinimo', 'codigoRef')
+            );
+        }
         return $resultado;
     }
 

--- a/src/index.php
+++ b/src/index.php
@@ -111,6 +111,17 @@ try {
                 <span class="nav-label">Movimientos</span>
             </a>
         </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+        </div>
     </nav>
 
     <div class="sidebar-footer">

--- a/src/movimientos.php
+++ b/src/movimientos.php
@@ -134,6 +134,17 @@ $balance  = $entradas - $salidas;
                 <span class="nav-label">Movimientos</span>
             </a>
         </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+        </div>
     </nav>
 
     <div class="sidebar-footer">

--- a/src/nuevo_producto.php
+++ b/src/nuevo_producto.php
@@ -121,6 +121,17 @@ try {
                 <span class="nav-label">Movimientos</span>
             </a>
         </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+        </div>
     </nav>
 
     <div class="sidebar-footer">

--- a/src/productos.php
+++ b/src/productos.php
@@ -110,6 +110,17 @@ try {
                 <span class="nav-label">Movimientos</span>
             </a>
         </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
+                    </svg>
+                </span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+        </div>
     </nav>
 
     <div class="sidebar-footer">

--- a/src/tests/bootstrap.php
+++ b/src/tests/bootstrap.php
@@ -28,6 +28,8 @@ foreach ($defaults as $key => $value) {
 
 require_once __DIR__ . '/../includes/AppException.php';
 require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/Auditoria.php';
+require_once __DIR__ . '/../includes/AlertaStock.php';
 require_once __DIR__ . '/../includes/Producto.php';
 require_once __DIR__ . '/../includes/Movimiento.php';
 require_once __DIR__ . '/../includes/Categoria.php';

--- a/tests/Unit/AlertaStockTest.php
+++ b/tests/Unit/AlertaStockTest.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Tests unitarios para el servicio AlertaStock.
+ *
+ * Usa SQLite en memoria y un transport callable capturado para
+ * verificar el comportamiento de envío de alertas sin necesidad
+ * de conexión MySQL ni servidor SMTP real.
+ *
+ * @package  Es21Plus\Tests\Unit
+ * @author   Carlitos6712
+ */
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class AlertaStockTest extends TestCase
+{
+    private PDO $pdo;
+    /** @var array<int, array{to: string, subject: string, body: string}> */
+    private array $emailsSent = [];
+    private AlertaStock $service;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        $this->crearTablas();
+        $this->emailsSent = [];
+
+        $capturado = &$this->emailsSent;
+        $transport = static function (string $to, string $subject, string $body) use (&$capturado): void {
+            $capturado[] = ['to' => $to, 'subject' => $subject, 'body' => $body];
+        };
+
+        $this->service = new AlertaStock($this->pdo, $transport);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private function crearTablas(): void
+    {
+        $this->pdo->exec("
+            CREATE TABLE productos (
+                id            INTEGER PRIMARY KEY AUTOINCREMENT,
+                nombre        TEXT    NOT NULL,
+                stock         INTEGER DEFAULT 0,
+                stock_minimo  INTEGER DEFAULT 5,
+                alertas_email INTEGER DEFAULT 1,
+                deleted_at    TEXT    NULL
+            )
+        ");
+        $this->pdo->exec("
+            CREATE TABLE alertas_stock (
+                id              INTEGER PRIMARY KEY AUTOINCREMENT,
+                producto_id     INTEGER NOT NULL,
+                enviada_at      TEXT    DEFAULT CURRENT_TIMESTAMP,
+                stock_al_enviar INTEGER
+            )
+        ");
+        $this->pdo->exec("
+            CREATE TABLE movimientos (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                producto_id INTEGER NOT NULL,
+                tipo        TEXT    NOT NULL,
+                cantidad    INTEGER NOT NULL,
+                fecha       TEXT    DEFAULT CURRENT_TIMESTAMP
+            )
+        ");
+    }
+
+    /**
+     * Inserta un producto de prueba y devuelve su ID.
+     *
+     * @param array<string, mixed> $overrides
+     * @return int
+     */
+    private function insertarProducto(array $overrides = []): int
+    {
+        $defaults = [
+            'nombre'        => 'Freno Premium',
+            'stock'         => 10,
+            'stock_minimo'  => 5,
+            'alertas_email' => 1,
+        ];
+        $data = array_merge($defaults, $overrides);
+        $this->pdo->exec(
+            "INSERT INTO productos (nombre, stock, stock_minimo, alertas_email)
+             VALUES ('{$data['nombre']}', {$data['stock']}, {$data['stock_minimo']}, {$data['alertas_email']})"
+        );
+        return (int) $this->pdo->lastInsertId();
+    }
+
+    private function insertarAlerta(int $productoId, int $stockAlEnviar): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO alertas_stock (producto_id, stock_al_enviar)
+             VALUES ({$productoId}, {$stockAlEnviar})"
+        );
+    }
+
+    private function insertarMovimiento(int $productoId, string $tipo, string $fecha = 'now'): void
+    {
+        $this->pdo->exec(
+            "INSERT INTO movimientos (producto_id, tipo, cantidad, fecha)
+             VALUES ({$productoId}, '{$tipo}', 1, datetime('{$fecha}'))"
+        );
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_sends_email_when_stock_drops_below_minimum_after_salida(): void
+    {
+        $_ENV['ALERT_EMAIL'] = 'admin@test.com';
+        $productoId = $this->insertarProducto(['stock' => 3, 'stock_minimo' => 5]);
+
+        $this->service->verificarYEnviar($productoId, 3);
+
+        $this->assertCount(1, $this->emailsSent, 'Debe enviar exactamente un email');
+        $this->assertSame('admin@test.com', $this->emailsSent[0]['to']);
+    }
+
+    #[Test]
+    public function it_does_not_send_duplicate_alert_for_same_stock_low_episode(): void
+    {
+        $_ENV['ALERT_EMAIL'] = 'admin@test.com';
+        $productoId = $this->insertarProducto(['stock' => 3, 'stock_minimo' => 5]);
+        // Simular que ya se envió una alerta y no ha habido entradas desde entonces
+        $this->insertarAlerta($productoId, 3);
+
+        $this->service->verificarYEnviar($productoId, 2);
+
+        $this->assertCount(0, $this->emailsSent, 'No debe enviar alerta duplicada en el mismo episodio');
+    }
+
+    #[Test]
+    public function it_sends_new_alert_after_stock_recovered_via_entrada(): void
+    {
+        $_ENV['ALERT_EMAIL'] = 'admin@test.com';
+        $productoId = $this->insertarProducto(['stock' => 3, 'stock_minimo' => 5]);
+
+        // Primera alerta enviada ayer
+        $this->pdo->exec(
+            "INSERT INTO alertas_stock (producto_id, stock_al_enviar, enviada_at)
+             VALUES ({$productoId}, 3, datetime('now', '-1 day'))"
+        );
+        // Entrada de stock HOY (stock recuperado)
+        $this->insertarMovimiento($productoId, 'entrada', 'now');
+
+        // Nueva salida vuelve a poner el stock bajo
+        $this->service->verificarYEnviar($productoId, 2);
+
+        $this->assertCount(1, $this->emailsSent, 'Debe enviar alerta nueva tras recuperación de stock');
+    }
+
+    #[Test]
+    public function it_does_not_send_alert_when_product_has_alerts_disabled(): void
+    {
+        $_ENV['ALERT_EMAIL'] = 'admin@test.com';
+        $productoId = $this->insertarProducto([
+            'stock'         => 3,
+            'stock_minimo'  => 5,
+            'alertas_email' => 0,
+        ]);
+
+        $this->service->verificarYEnviar($productoId, 3);
+
+        $this->assertCount(0, $this->emailsSent, 'No debe enviar alerta cuando el producto la tiene desactivada');
+    }
+
+    #[Test]
+    public function it_does_not_send_alert_when_salida_keeps_stock_above_minimum(): void
+    {
+        $_ENV['ALERT_EMAIL'] = 'admin@test.com';
+        $productoId = $this->insertarProducto(['stock' => 10, 'stock_minimo' => 5]);
+
+        $this->service->verificarYEnviar($productoId, 8);
+
+        $this->assertCount(0, $this->emailsSent, 'No debe enviar alerta cuando el stock sigue sobre el mínimo');
+    }
+
+    #[Test]
+    public function it_includes_product_name_and_current_stock_in_email_body(): void
+    {
+        $_ENV['ALERT_EMAIL'] = 'admin@test.com';
+        $productoId = $this->insertarProducto(['nombre' => 'Cadena 520', 'stock' => 2, 'stock_minimo' => 5]);
+
+        $this->service->verificarYEnviar($productoId, 2);
+
+        $this->assertCount(1, $this->emailsSent);
+        $body = $this->emailsSent[0]['body'];
+        $this->assertStringContainsString('Cadena 520', $body, 'El email debe incluir el nombre del producto');
+        $this->assertStringContainsString('2', $body, 'El email debe incluir el stock actual');
+    }
+
+    #[Test]
+    public function it_does_not_send_alert_when_alert_email_env_is_not_set(): void
+    {
+        unset($_ENV['ALERT_EMAIL']);
+        $productoId = $this->insertarProducto(['stock' => 3, 'stock_minimo' => 5]);
+
+        $this->service->verificarYEnviar($productoId, 3);
+
+        $this->assertCount(0, $this->emailsSent, 'No debe enviar si ALERT_EMAIL no está configurado');
+    }
+}

--- a/tests/Unit/AuditoriaTest.php
+++ b/tests/Unit/AuditoriaTest.php
@@ -1,0 +1,166 @@
+<?php
+/**
+ * Tests unitarios para el modelo Auditoria.
+ *
+ * Usa SQLite en memoria: autocontenido, sin depender de la DB MySQL
+ * de Docker ni de ningún servicio externo.
+ *
+ * @package  Es21Plus\Tests\Unit
+ * @author   Carlitos6712
+ */
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class AuditoriaTest extends TestCase
+{
+    private PDO $pdo;
+    private Auditoria $auditoria;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+        $this->pdo->exec("
+            CREATE TABLE auditoria (
+                id               INTEGER PRIMARY KEY AUTOINCREMENT,
+                tabla            TEXT    NOT NULL,
+                registro_id      INTEGER NOT NULL,
+                accion           TEXT    NOT NULL,
+                datos_anteriores TEXT    NULL,
+                datos_nuevos     TEXT    NULL,
+                usuario          TEXT    DEFAULT 'admin',
+                ip               TEXT,
+                fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
+            )
+        ");
+        $this->auditoria = new Auditoria($this->pdo);
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /** Obtiene el último registro de auditoría insertado. */
+    private function ultimoRegistro(): array
+    {
+        $stmt = $this->pdo->query("SELECT * FROM auditoria ORDER BY id DESC LIMIT 1");
+        return $stmt->fetch() ?: [];
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_logs_crear_action_with_new_data_in_json(): void
+    {
+        $nuevos = ['nombre' => 'Freno X', 'precio' => 12.50];
+        $this->auditoria->registrar('productos', 1, 'crear', null, $nuevos);
+
+        $row = $this->ultimoRegistro();
+        $this->assertSame('productos', $row['tabla']);
+        $this->assertSame(1, (int) $row['registro_id']);
+        $this->assertSame('crear', $row['accion']);
+        $this->assertNull($row['datos_anteriores']);
+        $decoded = json_decode($row['datos_nuevos'], true);
+        $this->assertSame('Freno X', $decoded['nombre']);
+        $this->assertSame(12.50, (float) $decoded['precio']);
+    }
+
+    #[Test]
+    public function it_logs_actualizar_action_with_previous_and_new_data(): void
+    {
+        $anterior = ['nombre' => 'Freno Viejo', 'precio' => 10.00];
+        $nuevo    = ['nombre' => 'Freno Nuevo', 'precio' => 15.00];
+        $this->auditoria->registrar('productos', 5, 'actualizar', $anterior, $nuevo);
+
+        $row = $this->ultimoRegistro();
+        $this->assertSame('actualizar', $row['accion']);
+        $this->assertSame(5, (int) $row['registro_id']);
+
+        $decAnterior = json_decode($row['datos_anteriores'], true);
+        $decNuevo    = json_decode($row['datos_nuevos'], true);
+        $this->assertSame('Freno Viejo', $decAnterior['nombre']);
+        $this->assertSame('Freno Nuevo', $decNuevo['nombre']);
+    }
+
+    #[Test]
+    public function it_logs_eliminar_action_with_previous_data_and_null_as_new(): void
+    {
+        $anterior = ['nombre' => 'Producto Borrado', 'stock' => 0];
+        $this->auditoria->registrar('productos', 99, 'eliminar', $anterior, null);
+
+        $row = $this->ultimoRegistro();
+        $this->assertSame('eliminar', $row['accion']);
+        $this->assertNotNull($row['datos_anteriores']);
+        $this->assertNull($row['datos_nuevos']);
+    }
+
+    #[Test]
+    public function it_stores_client_ip_in_audit_record(): void
+    {
+        $_SERVER['REMOTE_ADDR'] = '192.168.1.42';
+        $this->auditoria->registrar('categorias', 3, 'crear', null, ['nombre' => 'Test']);
+
+        $row = $this->ultimoRegistro();
+        $this->assertSame('192.168.1.42', $row['ip']);
+    }
+
+    #[Test]
+    public function it_filters_audit_log_by_tabla(): void
+    {
+        $this->auditoria->registrar('productos',  1, 'crear', null, ['n' => 'p']);
+        $this->auditoria->registrar('categorias', 2, 'crear', null, ['n' => 'c']);
+        $this->auditoria->registrar('productos',  3, 'eliminar', ['n' => 'p2'], null);
+
+        $resultados = $this->auditoria->listar(tabla: 'productos');
+
+        $this->assertCount(2, $resultados);
+        foreach ($resultados as $r) {
+            $this->assertSame('productos', $r['tabla']);
+        }
+    }
+
+    #[Test]
+    public function it_filters_audit_log_by_action_type(): void
+    {
+        $this->auditoria->registrar('productos', 1, 'crear',     null,        ['n' => 'p1']);
+        $this->auditoria->registrar('productos', 2, 'actualizar', ['n' => 'old'], ['n' => 'new']);
+        $this->auditoria->registrar('productos', 3, 'eliminar',  ['n' => 'p3'], null);
+
+        $soloCrear = $this->auditoria->listar(accion: 'crear');
+        $this->assertCount(1, $soloCrear);
+        $this->assertSame('crear', $soloCrear[0]['accion']);
+    }
+
+    #[Test]
+    public function it_filters_audit_log_by_date_range(): void
+    {
+        // Insertar registro con fecha pasada directamente en SQLite
+        $this->pdo->exec(
+            "INSERT INTO auditoria (tabla, registro_id, accion, datos_nuevos, fecha)
+             VALUES ('productos', 1, 'crear', '{\"n\":\"old\"}', '2020-01-01 10:00:00')"
+        );
+        $this->auditoria->registrar('productos', 2, 'crear', null, ['n' => 'reciente']);
+
+        $hoy    = date('Y-m-d');
+        $result = $this->auditoria->listar(fechaDesde: $hoy, fechaHasta: $hoy);
+
+        $this->assertCount(1, $result);
+        $this->assertSame('reciente', json_decode($result[0]['datos_nuevos'], true)['n']);
+    }
+
+    #[Test]
+    public function it_returns_correct_count_with_filters(): void
+    {
+        $this->auditoria->registrar('productos',  1, 'crear',    null, ['a' => 1]);
+        $this->auditoria->registrar('categorias', 2, 'crear',    null, ['b' => 2]);
+        $this->auditoria->registrar('productos',  3, 'eliminar', ['a' => 1], null);
+
+        $total          = $this->auditoria->contar();
+        $soloProd       = $this->auditoria->contar(tabla: 'productos');
+        $soloCateg      = $this->auditoria->contar(tabla: 'categorias');
+
+        $this->assertSame(3, $total);
+        $this->assertSame(2, $soloProd);
+        $this->assertSame(1, $soloCateg);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -17,6 +17,8 @@ $_ENV['DB_PASS']  = getenv('DB_PASS')  ?: 'luigi21plus';
 
 require_once __DIR__ . '/../src/includes/AppException.php';
 require_once __DIR__ . '/../src/includes/Database.php';
+require_once __DIR__ . '/../src/includes/Auditoria.php';
+require_once __DIR__ . '/../src/includes/AlertaStock.php';
 require_once __DIR__ . '/../src/includes/Producto.php';
 require_once __DIR__ . '/../src/includes/Movimiento.php';
 require_once __DIR__ . '/../src/includes/Categoria.php';


### PR DESCRIPTION
## Qué se implementa

- **AlertaStock.php**: servicio PHPMailer con guard de duplicados via tabla `alertas_stock`. Transport inyectable (callable) para testabilidad sin servidor SMTP.
- **Alerta automática** tras salida que deje `stock <= stock_minimo` del producto. Episodio reseteado cuando hay una entrada posterior.
- **Auditoria.php**: modelo que registra crear/actualizar/eliminar en `Producto` y `Categoria` con diff JSON (`datos_anteriores` + `datos_nuevos`). IP del cliente incluida.
- **auditoria.php**: página paginada con filtros (tabla, acción, rango de fechas) y display de diff. Sin ningún botón ni ruta de borrado.
- **Tests unitarios** para `AlertaStock` (7 casos) y `Auditoria` (8 casos) usando SQLite en memoria — pasan sin Docker.
- **Sidebar** actualizado en todos los ficheros PHP con enlace a Auditoría.

## Checklist CLAUDE.md

- [x] `composer test` (unit) pasa al 100% — 15/15 sin Docker
- [x] Un commit por archivo o grupo lógico
- [x] `@author Carlitos6712` en todos los archivos nuevos y modificados
- [x] `ALERT_EMAIL` leído de `$_ENV`, nunca hardcodeado
- [x] Auditoría sin opción de borrado en UI
- [x] `database/schema.sql` actualizado con `alertas_stock`, `auditoria` y `ALTER TABLE` para `alertas_email`
- [x] `actualizar()` solo registra auditoría si `rowCount() > 0`
- [x] PHPDoc completo en todas las clases y métodos públicos
- [x] XSS protegido con `htmlspecialchars()` en auditoria.php

## Notas

- Tests de integración (BusquedaTest, ImagenTest, ApiTest) requieren Docker con MySQL — sus 9 fallos son preexistentes y no relacionados con esta fase.
- Cobertura de código requiere Xdebug/PCOV (no disponible localmente); las métricas están disponibles en el entorno Docker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)