### PR TITLE
feat(fase12): full superadmin panel — businesses, employees, messaging, activity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,13 @@ SMTP_PORT=587
 SMTP_USER=noreply@example.com
 SMTP_PASS=secret
 SMTP_FROM_NAME=es21plus Inventario
+
+# --- Email / Panel Superadmin (alias de SMTP_* — puede ser el mismo) ---
+MAIL_HOST=smtp.gmail.com
+MAIL_PORT=587
+MAIL_USERNAME=
+MAIL_PASSWORD=
+MAIL_FROM_NAME=es21plus
+
+# --- Superadmin ---
+SUPERADMIN_EMAIL=superadmin@example.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,12 @@ FROM php:apache
 # Instalar extensiones PDO para MySQL
 RUN docker-php-ext-install pdo_mysql
 
+# Instalar unzip (requerido por Composer para descargar paquetes)
+RUN apt-get update && apt-get install -y --no-install-recommends unzip && rm -rf /var/lib/apt/lists/*
+
+# Instalar Composer
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
 # Habilitar módulos de Apache necesarios
 RUN a2enmod rewrite
 
@@ -16,8 +22,17 @@ COPY apache.conf /etc/apache2/sites-available/000-default.conf
 # Copiar configuración PHP personalizada
 COPY php.ini /usr/local/etc/php/conf.d/custom.ini
 
+# Instalar paquetes sin autoloader (classmap apunta a src/ que aún no existe en /var/www/html/)
+WORKDIR /var/www/html
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --no-autoloader --no-interaction
+
 # Copiar el código fuente
 COPY ./src /var/www/html/
+
+# Generar autoloader ahora que includes/ existe; corregir path del classmap
+RUN sed -i 's|src/includes/|includes/|g' composer.json \
+    && composer dump-autoload --no-dev --optimize --no-interaction
 
 # Permisos correctos para www-data
 RUN chown -R www-data:www-data /var/www/html \

--- a/database/migrations/run_migration.php
+++ b/database/migrations/run_migration.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Runner de migración superadmin_panel.
+ * Ejecutar: php run_migration.php (dentro del contenedor web)
+ * @author Carlos Vico
+ */
+$pdo = new PDO('mysql:host=db;port=3306;dbname=inventario_motos', 'admin', 'luigi21plus');
+$pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+
+$sqls = [];
+
+$sqls[] = "CREATE TABLE IF NOT EXISTS businesses (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(150) NOT NULL,
+    slug VARCHAR(100) NOT NULL UNIQUE,
+    logo_path VARCHAR(255),
+    contact_email VARCHAR(150),
+    phone VARCHAR(30),
+    address TEXT,
+    plan ENUM('free','basic','pro') DEFAULT 'free',
+    plan_expires_at DATE,
+    is_active TINYINT(1) DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+$sqls[] = "CREATE TABLE IF NOT EXISTS employees (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    business_id INT NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    email VARCHAR(150) NOT NULL,
+    password VARCHAR(255) NOT NULL,
+    role ENUM('admin','employee') DEFAULT 'employee',
+    is_active TINYINT(1) DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+$sqls[] = "CREATE TABLE IF NOT EXISTS contact_messages (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    business_id INT,
+    sender_name VARCHAR(100) NOT NULL,
+    sender_email VARCHAR(150) NOT NULL,
+    subject VARCHAR(200),
+    message TEXT NOT NULL,
+    is_read TINYINT(1) DEFAULT 0,
+    replied_at TIMESTAMP NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+$sqls[] = "CREATE TABLE IF NOT EXISTS activity_logs (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    business_id INT,
+    employee_id INT,
+    action VARCHAR(200) NOT NULL,
+    entity VARCHAR(100),
+    entity_id INT,
+    ip_address VARCHAR(45),
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+$sqls[] = "CREATE TABLE IF NOT EXISTS announcements (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    title VARCHAR(200) NOT NULL,
+    body TEXT NOT NULL,
+    is_active TINYINT(1) DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4";
+
+foreach (['productos', 'categorias', 'movimientos', 'alertas_stock'] as $tbl) {
+    $has = $pdo->query("SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+        WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='$tbl' AND COLUMN_NAME='business_id'")->fetchColumn();
+    if (!$has) {
+        $sqls[] = "ALTER TABLE $tbl ADD COLUMN business_id INT NULL AFTER id";
+    }
+}
+
+foreach ($sqls as $sql) {
+    $pdo->exec($sql);
+    echo 'OK: ' . substr($sql, 0, 70) . PHP_EOL;
+}
+
+echo PHP_EOL . 'Tables: ' . implode(', ', $pdo->query('SHOW TABLES')->fetchAll(PDO::FETCH_COLUMN)) . PHP_EOL;

--- a/database/migrations/superadmin_panel.sql
+++ b/database/migrations/superadmin_panel.sql
@@ -1,0 +1,111 @@
+-- =============================================================
+-- Migración: Panel Superadmin
+-- @author   Carlos Vico
+-- @version  1.0.0
+-- Ejecutar: una sola vez sobre la base de datos objetivo.
+-- =============================================================
+
+SET NAMES utf8mb4;
+USE inventario_motos;
+
+-- -------------------------------------------------------------
+-- Tabla: businesses (negocios / talleres clientes)
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS businesses (
+    id              INT           AUTO_INCREMENT PRIMARY KEY,
+    name            VARCHAR(150)  NOT NULL,
+    slug            VARCHAR(100)  NOT NULL UNIQUE,
+    logo_path       VARCHAR(255),
+    contact_email   VARCHAR(150),
+    phone           VARCHAR(30),
+    address         TEXT,
+    plan            ENUM('free','basic','pro') DEFAULT 'free',
+    plan_expires_at DATE,
+    is_active       TINYINT(1)    DEFAULT 1,
+    created_at      TIMESTAMP     DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------------------------------------------
+-- Tabla: employees (empleados por negocio)
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS employees (
+    id            INT           AUTO_INCREMENT PRIMARY KEY,
+    business_id   INT           NOT NULL,
+    name          VARCHAR(100)  NOT NULL,
+    email         VARCHAR(150)  NOT NULL,
+    password      VARCHAR(255)  NOT NULL,
+    role          ENUM('admin','employee') DEFAULT 'employee',
+    is_active     TINYINT(1)    DEFAULT 1,
+    created_at    TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------------------------------------------
+-- Tabla: contact_messages (bandeja de contacto)
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS contact_messages (
+    id            INT           AUTO_INCREMENT PRIMARY KEY,
+    business_id   INT,
+    sender_name   VARCHAR(100)  NOT NULL,
+    sender_email  VARCHAR(150)  NOT NULL,
+    subject       VARCHAR(200),
+    message       TEXT          NOT NULL,
+    is_read       TINYINT(1)    DEFAULT 0,
+    replied_at    TIMESTAMP     NULL,
+    created_at    TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------------------------------------------
+-- Tabla: activity_logs (registro de actividad por negocio)
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS activity_logs (
+    id            INT           AUTO_INCREMENT PRIMARY KEY,
+    business_id   INT,
+    employee_id   INT,
+    action        VARCHAR(200)  NOT NULL,
+    entity        VARCHAR(100),
+    entity_id     INT,
+    ip_address    VARCHAR(45),
+    created_at    TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------------------------------------------
+-- Tabla: announcements (anuncios globales del superadmin)
+-- -------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS announcements (
+    id           INT           AUTO_INCREMENT PRIMARY KEY,
+    title        VARCHAR(200)  NOT NULL,
+    body         TEXT          NOT NULL,
+    is_active    TINYINT(1)    DEFAULT 1,
+    created_at   TIMESTAMP     DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- -------------------------------------------------------------
+-- Añadir business_id a tablas existentes (idempotente vía INFORMATION_SCHEMA)
+-- -------------------------------------------------------------
+
+-- productos
+SET @has = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'productos' AND COLUMN_NAME = 'business_id');
+SET @s = IF(@has = 0, 'ALTER TABLE productos ADD COLUMN business_id INT NULL AFTER id', 'SELECT 1');
+PREPARE _stmt FROM @s; EXECUTE _stmt; DEALLOCATE PREPARE _stmt;
+
+-- categorias
+SET @has = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'categorias' AND COLUMN_NAME = 'business_id');
+SET @s = IF(@has = 0, 'ALTER TABLE categorias ADD COLUMN business_id INT NULL AFTER id', 'SELECT 1');
+PREPARE _stmt FROM @s; EXECUTE _stmt; DEALLOCATE PREPARE _stmt;
+
+-- movimientos
+SET @has = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'movimientos' AND COLUMN_NAME = 'business_id');
+SET @s = IF(@has = 0, 'ALTER TABLE movimientos ADD COLUMN business_id INT NULL AFTER id', 'SELECT 1');
+PREPARE _stmt FROM @s; EXECUTE _stmt; DEALLOCATE PREPARE _stmt;
+
+-- alertas_stock
+SET @has = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'alertas_stock' AND COLUMN_NAME = 'business_id');
+SET @s = IF(@has = 0, 'ALTER TABLE alertas_stock ADD COLUMN business_id INT NULL AFTER id', 'SELECT 1');
+PREPARE _stmt FROM @s; EXECUTE _stmt; DEALLOCATE PREPARE _stmt;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       MYSQL_USER: admin
       MYSQL_PASSWORD: luigi21plus
     ports:
-      - "3307:3306"   # 3306 ocupado por MySQL local → usamos 3307 en el host
+      - "3308:3306"   # 3306 y 3307 ocupados localmente → usamos 3308 en el host
     volumes:
       # Carga inicial de la base de datos
       - ./database/schema.sql:/docker-entrypoint-initdb.d/schema.sql
@@ -25,7 +25,7 @@ services:
     container_name: inventario_motos_web
     restart: unless-stopped
     ports:
-      - "8080:80"
+      - "8090:80"
     # Variables de entorno que PHP leerá via $_ENV
     environment:
       DB_HOST: db
@@ -39,6 +39,8 @@ services:
     volumes:
       # Hot-reload: cambios en src se reflejan sin rebuild
       - ./src:/var/www/html
+      # Preservar vendor del build (el mount de src lo sobreescribiría)
+      - vendor_data:/var/www/html/vendor
     depends_on:
       - db
     networks:
@@ -47,6 +49,7 @@ services:
 # Volúmenes definidos
 volumes:
   db_data:
+  vendor_data:
 
 # Red interna para comunicación entre contenedores
 networks:

--- a/src/api/contact_send.php
+++ b/src/api/contact_send.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Endpoint público: recibir mensaje de contacto.
+ *
+ * POST /api/contact_send.php
+ * Body JSON: { sender_name, sender_email, subject, message }
+ *
+ * @package  Es21Plus\Api
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+header('Content-Type: application/json; charset=utf-8');
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../core/Mailer.php';
+require_once __DIR__ . '/../superadmin/controllers/ContactController.php';
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'data' => null, 'message' => 'Método no permitido.']);
+    exit;
+}
+
+$body = json_decode(file_get_contents('php://input'), true) ?? [];
+$businessId = isset($_SESSION['business_id']) ? (int)$_SESSION['business_id'] : null;
+
+try {
+    $ctrl = new ContactController();
+    $ctrl->recibir($body, $businessId);
+    echo json_encode(['success' => true, 'data' => null, 'message' => 'Mensaje enviado correctamente.']);
+} catch (AppException $e) {
+    http_response_code($e->getCode() ?: 422);
+    echo json_encode(['success' => false, 'data' => null, 'message' => $e->getMessage()]);
+} catch (\Throwable $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'data' => null, 'message' => 'Error interno.']);
+}

--- a/src/core/ActivityLogger.php
+++ b/src/core/ActivityLogger.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Registro de actividad de empleados por negocio.
+ *
+ * Inserta en activity_logs. No lanza excepciones para no interrumpir
+ * el flujo principal si el insert falla.
+ *
+ * @package  Es21Plus\Core
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../includes/Database.php';
+
+class ActivityLogger
+{
+    /**
+     * Registra una acción en activity_logs.
+     *
+     * @param int         $businessId  ID del negocio.
+     * @param int         $employeeId  ID del empleado que realiza la acción.
+     * @param string      $action      Descripción de la acción (e.g. "Creó producto").
+     * @param string|null $entity      Entidad afectada (e.g. "producto").
+     * @param int|null    $entityId    ID de la entidad afectada.
+     * @return void
+     */
+    public static function log(
+        int    $businessId,
+        int    $employeeId,
+        string $action,
+        ?string $entity   = null,
+        ?int    $entityId = null
+    ): void {
+        try {
+            $pdo  = Database::getInstance();
+            $ip   = $_SERVER['REMOTE_ADDR'] ?? null;
+            $stmt = $pdo->prepare(
+                'INSERT INTO activity_logs (business_id, employee_id, action, entity, entity_id, ip_address)
+                 VALUES (?, ?, ?, ?, ?, ?)'
+            );
+            $stmt->execute([$businessId, $employeeId, $action, $entity, $entityId, $ip]);
+        } catch (\Throwable $e) {
+            $logFile = __DIR__ . '/../../logs/activity_errors.log';
+            @file_put_contents(
+                $logFile,
+                '[' . date('Y-m-d H:i:s') . '] ActivityLogger failed: ' . $e->getMessage() . PHP_EOL,
+                FILE_APPEND | LOCK_EX
+            );
+        }
+    }
+}

--- a/src/core/Mailer.php
+++ b/src/core/Mailer.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Servicio de envío de email centralizado via PHPMailer.
+ *
+ * Lee configuración SMTP desde variables de entorno.
+ * Si el envío falla, registra en logs/mail_errors.log y lanza excepción
+ * controlada — nunca interrumpe el flujo principal si el llamador captura.
+ *
+ * @package  Es21Plus\Core
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception as MailException;
+
+class Mailer
+{
+    /**
+     * Envía un correo HTML al destinatario indicado.
+     *
+     * @param  string $to       Dirección de destino.
+     * @param  string $subject  Asunto del correo.
+     * @param  string $bodyHtml Cuerpo en HTML.
+     * @throws \RuntimeException Si el envío falla (para que el llamador pueda manejarla).
+     * @return bool True si se envió correctamente.
+     */
+    public static function send(string $to, string $subject, string $bodyHtml): bool
+    {
+        $autoload = __DIR__ . '/../../vendor/autoload.php';
+        if (!file_exists($autoload)) {
+            self::logError("vendor/autoload.php no encontrado. Ejecuta: composer install");
+            throw new \RuntimeException('PHPMailer no disponible: vendor no instalado.');
+        }
+        require_once $autoload;
+
+        $host     = getenv('MAIL_HOST')      ?: getenv('SMTP_HOST')      ?: '';
+        $port     = (int)(getenv('MAIL_PORT')     ?: getenv('SMTP_PORT')     ?: 587);
+        $user     = getenv('MAIL_USERNAME')  ?: getenv('SMTP_USER')      ?: '';
+        $pass     = getenv('MAIL_PASSWORD')  ?: getenv('SMTP_PASS')      ?: '';
+        $fromName = getenv('MAIL_FROM_NAME') ?: getenv('SMTP_FROM_NAME') ?: 'es21plus';
+
+        if (!$host || !$user) {
+            self::logError("SMTP no configurado (MAIL_HOST o MAIL_USERNAME vacío).");
+            throw new \RuntimeException('SMTP no configurado.');
+        }
+
+        $mail = new PHPMailer(true);
+        try {
+            $mail->isSMTP();
+            $mail->Host       = $host;
+            $mail->SMTPAuth   = true;
+            $mail->Username   = $user;
+            $mail->Password   = $pass;
+            $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+            $mail->Port       = $port;
+            $mail->CharSet    = 'UTF-8';
+
+            $mail->setFrom($user, $fromName);
+            $mail->addAddress($to);
+            $mail->isHTML(true);
+            $mail->Subject = $subject;
+            $mail->Body    = $bodyHtml;
+            $mail->AltBody = strip_tags($bodyHtml);
+
+            $mail->send();
+            return true;
+        } catch (MailException $e) {
+            $msg = "Error al enviar a {$to}: {$mail->ErrorInfo}";
+            self::logError($msg);
+            throw new \RuntimeException($msg);
+        }
+    }
+
+    /**
+     * Escribe un mensaje en logs/mail_errors.log.
+     *
+     * @param string $message
+     * @return void
+     */
+    private static function logError(string $message): void
+    {
+        $logDir  = __DIR__ . '/../../logs';
+        $logFile = $logDir . '/mail_errors.log';
+        if (!is_dir($logDir)) {
+            @mkdir($logDir, 0755, true);
+        }
+        $line = '[' . date('Y-m-d H:i:s') . '] ' . $message . PHP_EOL;
+        @file_put_contents($logFile, $line, FILE_APPEND | LOCK_EX);
+    }
+}

--- a/src/includes/announcement_banner.php
+++ b/src/includes/announcement_banner.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Banner de anuncio global del superadmin.
+ *
+ * Incluir en el layout del panel principal justo después de <body>.
+ * Usa localStorage para no repetir el mismo anuncio hasta que cambie el ID.
+ *
+ * @package  Es21Plus\Includes
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../superadmin/controllers/AnnouncementController.php';
+
+$_announcementBannerData = AnnouncementController::activo();
+?>
+<?php if ($_announcementBannerData): ?>
+<div id="announcementBanner"
+     data-announcement-id="<?= (int)$_announcementBannerData['id'] ?>"
+     style="display:none;background:linear-gradient(90deg,#4f46e5,#818cf8);color:#fff;
+            padding:.6rem 1.5rem;font-size:.84rem;display:flex;align-items:center;
+            gap:1rem;position:sticky;top:0;z-index:200;">
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="flex-shrink:0;opacity:.85">
+        <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+    </svg>
+    <span style="flex:1;">
+        <strong><?= htmlspecialchars($_announcementBannerData['title'], ENT_QUOTES, 'UTF-8') ?>:</strong>
+        <?= htmlspecialchars($_announcementBannerData['body'], ENT_QUOTES, 'UTF-8') ?>
+    </span>
+    <button onclick="cerrarAnuncio()" style="background:none;border:none;color:#fff;cursor:pointer;opacity:.8;padding:0;line-height:1;" title="Cerrar">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+    </button>
+</div>
+<script>
+(function() {
+    var el  = document.getElementById('announcementBanner');
+    var aid = el ? el.dataset.announcementId : null;
+    if (!aid) return;
+    var dismissed = localStorage.getItem('dismissed_announcement');
+    if (dismissed !== aid) {
+        el.style.display = 'flex';
+    }
+})();
+function cerrarAnuncio() {
+    var el = document.getElementById('announcementBanner');
+    if (el) {
+        localStorage.setItem('dismissed_announcement', el.dataset.announcementId);
+        el.style.display = 'none';
+    }
+}
+</script>
+<?php endif; ?>

--- a/src/middleware/BusinessMiddleware.php
+++ b/src/middleware/BusinessMiddleware.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Middleware de verificación de negocio y plan.
+ *
+ * Aplicar en cada request del panel de negocios.
+ * Verifica: negocio activo, plan vigente, funcionalidades según plan.
+ *
+ * @package  Es21Plus\Middleware
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../includes/Database.php';
+
+class BusinessMiddleware
+{
+    /**
+     * Verifica acceso del negocio. Bloquea si inactivo o plan vencido.
+     *
+     * @param int $businessId
+     * @return array Datos del negocio verificado.
+     */
+    public static function require(int $businessId): array
+    {
+        try {
+            $pdo  = Database::getInstance();
+            $stmt = $pdo->prepare('SELECT * FROM businesses WHERE id = ?');
+            $stmt->execute([$businessId]);
+            $business = $stmt->fetch();
+        } catch (\Throwable) {
+            return [];
+        }
+
+        if (!$business || !$business['is_active']) {
+            self::bloqueado('Tu negocio está desactivado. Contacta con soporte.', $businessId);
+        }
+
+        if ($business['plan_expires_at'] && strtotime($business['plan_expires_at']) < time()) {
+            self::planVencido($business);
+        }
+
+        return $business;
+    }
+
+    /**
+     * Indica si el plan permite una funcionalidad premium.
+     *
+     * @param string $feature 'csv_export' | 'advanced_reports'
+     * @param string $plan    'free' | 'basic' | 'pro'
+     * @return bool
+     */
+    public static function puedeUsar(string $feature, string $plan): bool
+    {
+        $premiumFeatures = ['csv_export', 'advanced_reports', 'pdf_export'];
+        if (!in_array($feature, $premiumFeatures, true)) {
+            return true;
+        }
+        return in_array($plan, ['basic', 'pro'], true);
+    }
+
+    private static function bloqueado(string $mensaje, int $businessId): never
+    {
+        http_response_code(403);
+        include __DIR__ . '/../superadmin/views/plan_blocked.php';
+        exit;
+    }
+
+    private static function planVencido(array $business): never
+    {
+        $planExpiredBusiness = $business;
+        http_response_code(402);
+        include __DIR__ . '/../superadmin/views/plan_expired.php';
+        exit;
+    }
+}

--- a/src/superadmin/announcements.php
+++ b/src/superadmin/announcements.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Gestión de anuncios globales — panel superadmin.
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/csrf.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/controllers/AnnouncementController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl       = new AnnouncementController();
+$action     = $_GET['action'] ?? 'list';
+$id         = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$base       = './';
+$cssBase    = '../';
+$activeMenu = 'announcements';
+
+$pdo = Database::getInstance();
+$mensajesSinLeer = (int)$pdo->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrfToken('sa_announcements', $_POST['csrf_token'] ?? '')) {
+        $_SESSION['flash_error'] = 'Token CSRF inválido.';
+        header('Location: announcements.php');
+        exit;
+    }
+    $postAction = $_POST['_action'] ?? '';
+    try {
+        if ($postAction === 'store') {
+            $ctrl->store($_POST);
+            $_SESSION['flash_success'] = 'Anuncio creado.';
+            header('Location: announcements.php');
+            exit;
+        }
+        if ($postAction === 'toggle') {
+            $nuevo = $ctrl->toggle($id);
+            $_SESSION['flash_success'] = $nuevo ? 'Anuncio activado.' : 'Anuncio desactivado.';
+            header('Location: announcements.php');
+            exit;
+        }
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    }
+}
+
+$csrfToken = generateCsrfToken('sa_announcements');
+
+switch ($action) {
+    case 'create':
+        $pageTitle = 'Nuevo anuncio';
+        ob_start();
+        include __DIR__ . '/views/announcements/create.php';
+        $content = ob_get_clean();
+        break;
+
+    default:
+        $announcements = $ctrl->index();
+        $pageTitle      = 'Anuncios globales';
+        ob_start();
+        include __DIR__ . '/views/announcements/index.php';
+        $content = ob_get_clean();
+}
+
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/businesses.php
+++ b/src/superadmin/businesses.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Gestión de negocios — panel superadmin.
+ *
+ * Acciones GET: list (default), create, show, edit
+ * Acciones POST: store, update, toggle
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/csrf.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/controllers/BusinessController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl       = new BusinessController();
+$action     = $_GET['action'] ?? 'list';
+$id         = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$base       = './';
+$cssBase    = '../';
+$activeMenu = 'businesses';
+
+$mensajesSinLeer = 0;
+try {
+    $pdo = Database::getInstance();
+    $mensajesSinLeer = (int)$pdo->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+} catch (\Throwable) {}
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+// ── POST dispatcher ───────────────────────────────────────────
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $postAction = $_POST['_action'] ?? $action;
+
+    if (!validateCsrfToken('sa_businesses', $_POST['csrf_token'] ?? '')) {
+        $_SESSION['flash_error'] = 'Token CSRF inválido.';
+        header('Location: businesses.php');
+        exit;
+    }
+
+    try {
+        switch ($postAction) {
+            case 'store':
+                $newId = $ctrl->store($_POST);
+                $_SESSION['flash_success'] = 'Negocio creado correctamente.';
+                header("Location: businesses.php?action=show&id={$newId}");
+                exit;
+
+            case 'update':
+                $ctrl->update($id, $_POST);
+                $_SESSION['flash_success'] = 'Negocio actualizado.';
+                header("Location: businesses.php?action=show&id={$id}");
+                exit;
+
+            case 'toggle':
+                $nuevo = $ctrl->toggle($id);
+                $_SESSION['flash_success'] = $nuevo ? 'Negocio activado.' : 'Negocio desactivado.';
+                header('Location: businesses.php');
+                exit;
+        }
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    }
+}
+
+// ── GET views ────────────────────────────────────────────────
+$csrfToken = generateCsrfToken('sa_businesses');
+
+switch ($action) {
+    case 'create':
+        $pageTitle  = 'Nuevo negocio';
+        ob_start();
+        include __DIR__ . '/views/businesses/create.php';
+        $content = ob_get_clean();
+        break;
+
+    case 'show':
+        try {
+            $business  = $ctrl->show($id);
+            $pageTitle = htmlspecialchars($business['name'], ENT_QUOTES, 'UTF-8');
+            ob_start();
+            include __DIR__ . '/views/businesses/show.php';
+            $content = ob_get_clean();
+        } catch (AppException $e) {
+            $flashError = $e->getMessage();
+            header('Location: businesses.php');
+            exit;
+        }
+        break;
+
+    case 'edit':
+        try {
+            $business  = $ctrl->show($id);
+            $pageTitle = 'Editar – ' . htmlspecialchars($business['name'], ENT_QUOTES, 'UTF-8');
+            ob_start();
+            include __DIR__ . '/views/businesses/edit.php';
+            $content = ob_get_clean();
+        } catch (AppException $e) {
+            $flashError = $e->getMessage();
+            header('Location: businesses.php');
+            exit;
+        }
+        break;
+
+    default: // list
+        $page     = max(1, (int)($_GET['page'] ?? 1));
+        $q        = trim($_GET['q'] ?? '');
+        $result   = $ctrl->index($page, $q);
+        $pageTitle = 'Negocios';
+        ob_start();
+        include __DIR__ . '/views/businesses/index.php';
+        $content = ob_get_clean();
+}
+
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/contact.php
+++ b/src/superadmin/contact.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Bandeja de mensajes de contacto — panel superadmin.
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/csrf.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/controllers/ContactController.php';
+require_once __DIR__ . '/../core/Mailer.php';
+
+SuperadminMiddleware::require();
+
+$ctrl       = new ContactController();
+$action     = $_GET['action'] ?? 'list';
+$id         = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$base       = './';
+$cssBase    = '../';
+$activeMenu = 'contact';
+
+$pdo = Database::getInstance();
+$mensajesSinLeer = (int)$pdo->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrfToken('sa_contact', $_POST['csrf_token'] ?? '')) {
+        $_SESSION['flash_error'] = 'Token CSRF inválido.';
+        header('Location: contact.php');
+        exit;
+    }
+    $postAction = $_POST['_action'] ?? '';
+    try {
+        if ($postAction === 'reply') {
+            $ctrl->reply($id, trim($_POST['reply_body'] ?? ''));
+            $_SESSION['flash_success'] = 'Respuesta enviada correctamente.';
+            header("Location: contact.php?action=show&id={$id}");
+            exit;
+        }
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    } catch (\RuntimeException $e) {
+        $flashError = 'Error al enviar correo: ' . $e->getMessage();
+    }
+}
+
+$csrfToken = generateCsrfToken('sa_contact');
+
+switch ($action) {
+    case 'show':
+        try {
+            $message   = $ctrl->show($id);
+            $pageTitle = 'Mensaje de ' . htmlspecialchars($message['sender_name'], ENT_QUOTES, 'UTF-8');
+            ob_start();
+            include __DIR__ . '/views/contact/show.php';
+            $content = ob_get_clean();
+        } catch (AppException $e) {
+            $flashError = $e->getMessage();
+            header('Location: contact.php');
+            exit;
+        }
+        break;
+
+    default:
+        $messages  = $ctrl->index();
+        $pageTitle  = 'Mensajes de contacto';
+        ob_start();
+        include __DIR__ . '/views/contact/index.php';
+        $content = ob_get_clean();
+}
+
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/controllers/AnnouncementController.php
+++ b/src/superadmin/controllers/AnnouncementController.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * Controlador de anuncios globales.
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/AppException.php';
+
+class AnnouncementController
+{
+    private PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    /** @return array Lista completa de anuncios. */
+    public function index(): array
+    {
+        return $this->pdo->query(
+            'SELECT * FROM announcements ORDER BY created_at DESC'
+        )->fetchAll();
+    }
+
+    /**
+     * Crea un anuncio.
+     *
+     * @param array $data title, body.
+     * @throws AppException
+     * @return int
+     */
+    public function store(array $data): int
+    {
+        $title = trim($data['title'] ?? '');
+        $body  = trim($data['body'] ?? '');
+        if (!$title || !$body) {
+            throw new AppException('Título y cuerpo son obligatorios.', 422);
+        }
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO announcements (title, body) VALUES (?, ?)'
+        );
+        $stmt->execute([$title, $body]);
+        return (int)$this->pdo->lastInsertId();
+    }
+
+    /**
+     * Activa o desactiva un anuncio.
+     *
+     * @param int $id
+     * @return bool Nuevo estado.
+     */
+    public function toggle(int $id): bool
+    {
+        $stmt = $this->pdo->prepare('SELECT is_active FROM announcements WHERE id = ?');
+        $stmt->execute([$id]);
+        $current = (int)$stmt->fetchColumn();
+        $nuevo   = $current === 1 ? 0 : 1;
+
+        $this->pdo->prepare('UPDATE announcements SET is_active = ? WHERE id = ?')->execute([$nuevo, $id]);
+        return (bool)$nuevo;
+    }
+
+    /**
+     * Devuelve el anuncio activo más reciente (para banner en panel de negocios).
+     *
+     * @return array|null
+     */
+    public static function activo(): ?array
+    {
+        try {
+            $pdo  = Database::getInstance();
+            $stmt = $pdo->query(
+                'SELECT * FROM announcements WHERE is_active = 1 ORDER BY created_at DESC LIMIT 1'
+            );
+            $row = $stmt->fetch();
+            return $row ?: null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/src/superadmin/controllers/BusinessController.php
+++ b/src/superadmin/controllers/BusinessController.php
@@ -1,0 +1,258 @@
+<?php
+/**
+ * Controlador CRUD de negocios (businesses).
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../core/Mailer.php';
+
+class BusinessController
+{
+    private PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    /**
+     * Listado paginado de negocios con búsqueda por nombre.
+     *
+     * @param int    $page  Página actual (desde 1).
+     * @param string $q     Término de búsqueda.
+     * @return array{items: array, total: int, pages: int, page: int}
+     */
+    public function index(int $page = 1, string $q = ''): array
+    {
+        $perPage = 10;
+        $offset  = ($page - 1) * $perPage;
+        $search  = '%' . $q . '%';
+
+        $total = (int)$this->pdo->prepare(
+            'SELECT COUNT(*) FROM businesses WHERE name LIKE ?'
+        )->execute([$search]) && ($cnt = $this->pdo->prepare(
+            'SELECT COUNT(*) FROM businesses WHERE name LIKE ?'
+        ));
+        $cnt->execute([$search]);
+        $total = (int)$cnt->fetchColumn();
+
+        $stmt = $this->pdo->prepare(
+            "SELECT b.*, COUNT(e.id) AS num_empleados
+             FROM businesses b
+             LEFT JOIN employees e ON e.business_id = b.id
+             WHERE b.name LIKE ?
+             GROUP BY b.id
+             ORDER BY b.created_at DESC
+             LIMIT ? OFFSET ?"
+        );
+        $stmt->execute([$search, $perPage, $offset]);
+
+        return [
+            'items' => $stmt->fetchAll(),
+            'total' => $total,
+            'pages' => (int)ceil($total / $perPage),
+            'page'  => $page,
+        ];
+    }
+
+    /**
+     * Devuelve un negocio por ID con sus empleados y métricas.
+     *
+     * @param int $id
+     * @throws AppException Si no existe.
+     * @return array
+     */
+    public function show(int $id): array
+    {
+        $stmt = $this->pdo->prepare('SELECT * FROM businesses WHERE id = ?');
+        $stmt->execute([$id]);
+        $business = $stmt->fetch();
+        if (!$business) {
+            throw new AppException('Negocio no encontrado.', 404);
+        }
+
+        $stmt = $this->pdo->prepare(
+            'SELECT * FROM employees WHERE business_id = ? ORDER BY created_at DESC'
+        );
+        $stmt->execute([$id]);
+        $business['employees'] = $stmt->fetchAll();
+
+        $stmt = $this->pdo->prepare(
+            "SELECT m.*, p.nombre AS producto
+             FROM movimientos m
+             LEFT JOIN productos p ON p.id = m.producto_id
+             WHERE m.business_id = ?
+             ORDER BY m.fecha DESC LIMIT 10"
+        );
+        $stmt->execute([$id]);
+        $business['movimientos'] = $stmt->fetchAll();
+
+        $business['total_productos'] = (int)$this->pdo->prepare(
+            'SELECT COUNT(*) FROM productos WHERE business_id = ? AND deleted_at IS NULL'
+        )->execute([$id]) ? $this->pdo->prepare(
+            'SELECT COUNT(*) FROM productos WHERE business_id = ? AND deleted_at IS NULL'
+        )->execute([$id]) && 0 : 0;
+
+        $cntProd = $this->pdo->prepare('SELECT COUNT(*) FROM productos WHERE business_id = ? AND deleted_at IS NULL');
+        $cntProd->execute([$id]);
+        $business['total_productos'] = (int)$cntProd->fetchColumn();
+
+        $cntMov = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM movimientos WHERE business_id = ? AND MONTH(fecha) = MONTH(NOW())"
+        );
+        $cntMov->execute([$id]);
+        $business['movimientos_mes'] = (int)$cntMov->fetchColumn();
+
+        return $business;
+    }
+
+    /**
+     * Crea un nuevo negocio y genera su empleado admin inicial.
+     *
+     * @param array $data Campos del formulario.
+     * @throws AppException Si validación falla.
+     * @return int ID del negocio creado.
+     */
+    public function store(array $data): int
+    {
+        $name  = trim($data['name'] ?? '');
+        $email = trim($data['contact_email'] ?? '');
+        if (!$name) {
+            throw new AppException('El nombre del negocio es obligatorio.', 422);
+        }
+
+        $slug = $this->generarSlug($name);
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO businesses (name, slug, contact_email, phone, address, plan, plan_expires_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $name,
+            $slug,
+            $email ?: null,
+            trim($data['phone'] ?? '') ?: null,
+            trim($data['address'] ?? '') ?: null,
+            $data['plan'] ?? 'free',
+            ($data['plan_expires_at'] ?? '') ?: null,
+        ]);
+        $businessId = (int)$this->pdo->lastInsertId();
+
+        $plainPassword = $this->generarPassword();
+        $this->crearEmpleadoAdmin($businessId, $name, $email, $plainPassword);
+
+        if ($email) {
+            $this->enviarBienvenida($email, $name, $email, $plainPassword);
+        }
+
+        return $businessId;
+    }
+
+    /**
+     * Actualiza los datos de un negocio.
+     *
+     * @param int   $id
+     * @param array $data
+     * @throws AppException
+     * @return void
+     */
+    public function update(int $id, array $data): void
+    {
+        $name = trim($data['name'] ?? '');
+        if (!$name) {
+            throw new AppException('El nombre es obligatorio.', 422);
+        }
+
+        $stmt = $this->pdo->prepare(
+            'UPDATE businesses SET name=?, contact_email=?, phone=?, address=?, plan=?, plan_expires_at=?
+             WHERE id=?'
+        );
+        $stmt->execute([
+            $name,
+            trim($data['contact_email'] ?? '') ?: null,
+            trim($data['phone'] ?? '') ?: null,
+            trim($data['address'] ?? '') ?: null,
+            $data['plan'] ?? 'free',
+            ($data['plan_expires_at'] ?? '') ?: null,
+            $id,
+        ]);
+    }
+
+    /**
+     * Activa o desactiva un negocio.
+     *
+     * @param int $id
+     * @return bool Nuevo estado is_active.
+     */
+    public function toggle(int $id): bool
+    {
+        $stmt = $this->pdo->prepare('SELECT is_active FROM businesses WHERE id = ?');
+        $stmt->execute([$id]);
+        $current = (int)$stmt->fetchColumn();
+        $nuevo = $current === 1 ? 0 : 1;
+
+        $this->pdo->prepare('UPDATE businesses SET is_active = ? WHERE id = ?')->execute([$nuevo, $id]);
+        return (bool)$nuevo;
+    }
+
+    private function generarSlug(string $name): string
+    {
+        $slug = strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $name), '-'));
+        $base = $slug;
+        $i    = 1;
+        while ($this->pdo->prepare('SELECT id FROM businesses WHERE slug = ?')->execute([$slug])
+               && $this->pdo->prepare('SELECT id FROM businesses WHERE slug = ?')->execute([$slug])) {
+            $check = $this->pdo->prepare('SELECT COUNT(*) FROM businesses WHERE slug = ?');
+            $check->execute([$slug]);
+            if (!(int)$check->fetchColumn()) break;
+            $slug = $base . '-' . $i++;
+        }
+        return $slug;
+    }
+
+    private function generarPassword(int $len = 12): string
+    {
+        $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$';
+        $pwd   = '';
+        for ($i = 0; $i < $len; $i++) {
+            $pwd .= $chars[random_int(0, strlen($chars) - 1)];
+        }
+        return $pwd;
+    }
+
+    private function crearEmpleadoAdmin(int $businessId, string $businessName, string $email, string $plainPwd): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO employees (business_id, name, email, password, role)
+             VALUES (?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $businessId,
+            'Admin ' . $businessName,
+            $email,
+            password_hash($plainPwd, PASSWORD_BCRYPT, ['cost' => 12]),
+            'admin',
+        ]);
+    }
+
+    private function enviarBienvenida(string $to, string $business, string $username, string $pwd): void
+    {
+        $subject = "Bienvenido a es21plus – Acceso a tu panel";
+        $body    = "<h2>Bienvenido, {$business}</h2>
+                    <p>Tu panel de inventario está listo. Accede con:</p>
+                    <ul><li><strong>Usuario:</strong> {$username}</li>
+                        <li><strong>Contraseña:</strong> {$pwd}</li></ul>
+                    <p>Cambia tu contraseña al primer acceso.</p>
+                    <p><em>es21plus</em></p>";
+        try {
+            Mailer::send($to, $subject, $body);
+        } catch (\Throwable) {
+            // Correo no bloquea el alta del negocio
+        }
+    }
+}

--- a/src/superadmin/controllers/ContactController.php
+++ b/src/superadmin/controllers/ContactController.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Controlador de mensajes de contacto.
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../core/Mailer.php';
+
+class ContactController
+{
+    private PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    /**
+     * Bandeja de entrada: mensajes ordenados por no leídos primero, luego fecha.
+     *
+     * @return array
+     */
+    public function index(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT cm.*, b.name AS negocio
+             FROM contact_messages cm
+             LEFT JOIN businesses b ON b.id = cm.business_id
+             ORDER BY cm.is_read ASC, cm.created_at DESC"
+        );
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Devuelve un mensaje por ID y lo marca como leído.
+     *
+     * @param int $id
+     * @throws AppException
+     * @return array
+     */
+    public function show(int $id): array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT cm.*, b.name AS negocio
+             FROM contact_messages cm
+             LEFT JOIN businesses b ON b.id = cm.business_id
+             WHERE cm.id = ?"
+        );
+        $stmt->execute([$id]);
+        $msg = $stmt->fetch();
+        if (!$msg) {
+            throw new AppException('Mensaje no encontrado.', 404);
+        }
+
+        if (!$msg['is_read']) {
+            $this->pdo->prepare('UPDATE contact_messages SET is_read = 1 WHERE id = ?')->execute([$id]);
+            $msg['is_read'] = 1;
+        }
+
+        return $msg;
+    }
+
+    /**
+     * Envía respuesta al remitente y registra replied_at.
+     *
+     * @param int    $id
+     * @param string $replyBody Texto de la respuesta.
+     * @throws AppException
+     * @return void
+     */
+    public function reply(int $id, string $replyBody): void
+    {
+        $msg = $this->show($id);
+        $body = nl2br(htmlspecialchars($replyBody, ENT_QUOTES, 'UTF-8'));
+        $html = "<p>Hola {$msg['sender_name']},</p><p>{$body}</p><p>— Equipo es21plus</p>";
+
+        Mailer::send($msg['sender_email'], 'Re: ' . ($msg['subject'] ?? 'Consulta'), $html);
+
+        $this->pdo->prepare('UPDATE contact_messages SET replied_at = NOW() WHERE id = ?')->execute([$id]);
+    }
+
+    /**
+     * Recibe un mensaje desde el formulario público y notifica al superadmin.
+     *
+     * @param array $data Campos: sender_name, sender_email, subject, message.
+     * @param int|null $businessId
+     * @throws AppException
+     * @return void
+     */
+    public function recibir(array $data, ?int $businessId = null): void
+    {
+        $name    = trim($data['sender_name'] ?? '');
+        $email   = trim($data['sender_email'] ?? '');
+        $message = trim($data['message'] ?? '');
+
+        if (!$name || !$email || !$message) {
+            throw new AppException('Nombre, email y mensaje son obligatorios.', 422);
+        }
+
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO contact_messages (business_id, sender_name, sender_email, subject, message)
+             VALUES (?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $businessId,
+            $name,
+            $email,
+            trim($data['subject'] ?? '') ?: null,
+            $message,
+        ]);
+
+        $adminEmail = getenv('SUPERADMIN_EMAIL') ?: '';
+        if ($adminEmail) {
+            $subject = 'Nuevo mensaje de contacto – ' . $name;
+            $body    = "<p><strong>De:</strong> {$name} ({$email})</p>
+                        <p><strong>Asunto:</strong> " . htmlspecialchars($data['subject'] ?? '', ENT_QUOTES, 'UTF-8') . "</p>
+                        <p><strong>Mensaje:</strong><br>" . nl2br(htmlspecialchars($message, ENT_QUOTES, 'UTF-8')) . "</p>";
+            try {
+                Mailer::send($adminEmail, $subject, $body);
+            } catch (\Throwable) {
+                // No bloquear flujo si correo falla
+            }
+        }
+    }
+}

--- a/src/superadmin/controllers/DashboardController.php
+++ b/src/superadmin/controllers/DashboardController.php
@@ -1,0 +1,110 @@
+<?php
+/**
+ * Controlador del dashboard global de superadmin.
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+
+class DashboardController
+{
+    private PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    /**
+     * Devuelve todas las métricas para el dashboard.
+     *
+     * @return array{
+     *   totalNegocios: int,
+     *   totalEmpleados: int,
+     *   mensajesSinLeer: int,
+     *   movimientosHoy: int,
+     *   movimientosPorNegocio: array,
+     *   ultimosMensajes: array,
+     *   ultimaActividad: array
+     * }
+     */
+    public function index(): array
+    {
+        return [
+            'totalNegocios'          => $this->contarNegociosActivos(),
+            'totalEmpleados'         => $this->contarEmpleadosActivos(),
+            'mensajesSinLeer'        => $this->contarMensajesSinLeer(),
+            'movimientosHoy'         => $this->contarMovimientosHoy(),
+            'movimientosPorNegocio'  => $this->movimientosUltimos7Dias(),
+            'ultimosMensajes'        => $this->ultimosMensajesSinLeer(),
+            'ultimaActividad'        => $this->ultimaActividad(),
+        ];
+    }
+
+    private function contarNegociosActivos(): int
+    {
+        return (int)$this->pdo->query('SELECT COUNT(*) FROM businesses WHERE is_active = 1')->fetchColumn();
+    }
+
+    private function contarEmpleadosActivos(): int
+    {
+        return (int)$this->pdo->query('SELECT COUNT(*) FROM employees WHERE is_active = 1')->fetchColumn();
+    }
+
+    private function contarMensajesSinLeer(): int
+    {
+        return (int)$this->pdo->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+    }
+
+    private function contarMovimientosHoy(): int
+    {
+        $stmt = $this->pdo->query('SELECT COUNT(*) FROM movimientos WHERE DATE(fecha) = CURDATE()');
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function movimientosUltimos7Dias(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT b.name AS negocio, COUNT(m.id) AS total
+             FROM businesses b
+             LEFT JOIN movimientos m ON m.business_id = b.id
+                 AND m.fecha >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+             WHERE b.is_active = 1
+             GROUP BY b.id, b.name
+             ORDER BY total DESC
+             LIMIT 10"
+        );
+        return $stmt->fetchAll();
+    }
+
+    private function ultimosMensajesSinLeer(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT cm.id, cm.sender_name, cm.sender_email, cm.subject,
+                    cm.created_at, b.name AS negocio
+             FROM contact_messages cm
+             LEFT JOIN businesses b ON b.id = cm.business_id
+             WHERE cm.is_read = 0
+             ORDER BY cm.created_at DESC
+             LIMIT 5"
+        );
+        return $stmt->fetchAll();
+    }
+
+    private function ultimaActividad(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT al.action, al.created_at, al.ip_address,
+                    b.name AS negocio, e.name AS empleado
+             FROM activity_logs al
+             LEFT JOIN businesses b ON b.id = al.business_id
+             LEFT JOIN employees  e ON e.id = al.employee_id
+             ORDER BY al.created_at DESC
+             LIMIT 5"
+        );
+        return $stmt->fetchAll();
+    }
+}

--- a/src/superadmin/controllers/EmployeeController.php
+++ b/src/superadmin/controllers/EmployeeController.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * Controlador CRUD de empleados (employees).
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../core/Mailer.php';
+
+class EmployeeController
+{
+    private PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    /**
+     * Listado global de empleados, filtrable por negocio.
+     *
+     * @param int $businessId 0 = todos.
+     * @return array
+     */
+    public function index(int $businessId = 0): array
+    {
+        if ($businessId > 0) {
+            $stmt = $this->pdo->prepare(
+                'SELECT e.*, b.name AS negocio
+                 FROM employees e
+                 JOIN businesses b ON b.id = e.business_id
+                 WHERE e.business_id = ?
+                 ORDER BY e.created_at DESC'
+            );
+            $stmt->execute([$businessId]);
+        } else {
+            $stmt = $this->pdo->query(
+                'SELECT e.*, b.name AS negocio
+                 FROM employees e
+                 JOIN businesses b ON b.id = e.business_id
+                 ORDER BY b.name, e.name'
+            );
+        }
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Devuelve un empleado por ID.
+     *
+     * @param int $id
+     * @throws AppException
+     * @return array
+     */
+    public function find(int $id): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT e.*, b.name AS negocio
+             FROM employees e
+             JOIN businesses b ON b.id = e.business_id
+             WHERE e.id = ?'
+        );
+        $stmt->execute([$id]);
+        $row = $stmt->fetch();
+        if (!$row) {
+            throw new AppException('Empleado no encontrado.', 404);
+        }
+        return $row;
+    }
+
+    /**
+     * Crea un empleado nuevo.
+     *
+     * @param array $data
+     * @throws AppException
+     * @return int
+     */
+    public function store(array $data): int
+    {
+        $name       = trim($data['name'] ?? '');
+        $email      = trim($data['email'] ?? '');
+        $businessId = (int)($data['business_id'] ?? 0);
+
+        if (!$name || !$email || !$businessId) {
+            throw new AppException('Nombre, email y negocio son obligatorios.', 422);
+        }
+
+        $plain = $this->generarPassword();
+        $stmt  = $this->pdo->prepare(
+            'INSERT INTO employees (business_id, name, email, password, role)
+             VALUES (?, ?, ?, ?, ?)'
+        );
+        $stmt->execute([
+            $businessId,
+            $name,
+            $email,
+            password_hash($plain, PASSWORD_BCRYPT, ['cost' => 12]),
+            $data['role'] ?? 'employee',
+        ]);
+
+        return (int)$this->pdo->lastInsertId();
+    }
+
+    /**
+     * Actualiza datos de un empleado.
+     *
+     * @param int   $id
+     * @param array $data
+     * @throws AppException
+     * @return void
+     */
+    public function update(int $id, array $data): void
+    {
+        $name = trim($data['name'] ?? '');
+        if (!$name) {
+            throw new AppException('El nombre es obligatorio.', 422);
+        }
+
+        $stmt = $this->pdo->prepare(
+            'UPDATE employees SET name=?, email=?, role=?, business_id=? WHERE id=?'
+        );
+        $stmt->execute([
+            $name,
+            trim($data['email'] ?? ''),
+            $data['role'] ?? 'employee',
+            (int)($data['business_id'] ?? 0),
+            $id,
+        ]);
+    }
+
+    /**
+     * Activa o desactiva un empleado.
+     *
+     * @param int $id
+     * @return bool Nuevo estado.
+     */
+    public function toggle(int $id): bool
+    {
+        $stmt = $this->pdo->prepare('SELECT is_active FROM employees WHERE id = ?');
+        $stmt->execute([$id]);
+        $current = (int)$stmt->fetchColumn();
+        $nuevo   = $current === 1 ? 0 : 1;
+
+        $this->pdo->prepare('UPDATE employees SET is_active = ? WHERE id = ?')->execute([$nuevo, $id]);
+        return (bool)$nuevo;
+    }
+
+    /**
+     * Genera nueva contraseña aleatoria, la guarda y envía por correo.
+     * Nunca devuelve la contraseña en texto plano.
+     *
+     * @param int $id
+     * @throws AppException
+     * @return void
+     */
+    public function resetPassword(int $id): void
+    {
+        $emp = $this->find($id);
+        $plain = $this->generarPassword(10);
+
+        $this->pdo->prepare('UPDATE employees SET password = ? WHERE id = ?')
+            ->execute([password_hash($plain, PASSWORD_BCRYPT, ['cost' => 12]), $id]);
+
+        $body = "<h3>Nueva contraseña</h3>
+                 <p>Hola {$emp['name']}, tu contraseña ha sido restablecida.</p>
+                 <p><strong>Nueva contraseña:</strong> {$plain}</p>
+                 <p>Cámbiala al iniciar sesión.</p>";
+        try {
+            Mailer::send($emp['email'], 'Contraseña restablecida – es21plus', $body);
+        } catch (\Throwable) {
+            // No bloquear si el correo falla
+        }
+    }
+
+    /** @return array Lista de negocios activos para selects. */
+    public function negociosActivos(): array
+    {
+        return $this->pdo->query(
+            'SELECT id, name FROM businesses WHERE is_active = 1 ORDER BY name'
+        )->fetchAll();
+    }
+
+    private function generarPassword(int $len = 12): string
+    {
+        $chars = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$';
+        $pwd   = '';
+        for ($i = 0; $i < $len; $i++) {
+            $pwd .= $chars[random_int(0, strlen($chars) - 1)];
+        }
+        return $pwd;
+    }
+}

--- a/src/superadmin/controllers/LogController.php
+++ b/src/superadmin/controllers/LogController.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Controlador de registros de actividad (activity_logs).
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+
+class LogController
+{
+    private PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    /**
+     * Listado paginado con filtros por negocio, empleado y rango de fechas.
+     *
+     * @param array $filters business_id, empleado, fecha_desde, fecha_hasta.
+     * @param int   $page
+     * @return array{items: array, total: int, pages: int, page: int}
+     */
+    public function index(array $filters = [], int $page = 1): array
+    {
+        $perPage = 20;
+        $offset  = ($page - 1) * $perPage;
+        $where   = [];
+        $params  = [];
+
+        if (!empty($filters['business_id'])) {
+            $where[]  = 'al.business_id = ?';
+            $params[] = (int)$filters['business_id'];
+        }
+        if (!empty($filters['empleado'])) {
+            $where[]  = 'e.name LIKE ?';
+            $params[] = '%' . $filters['empleado'] . '%';
+        }
+        if (!empty($filters['fecha_desde'])) {
+            $where[]  = 'al.created_at >= ?';
+            $params[] = $filters['fecha_desde'] . ' 00:00:00';
+        }
+        if (!empty($filters['fecha_hasta'])) {
+            $where[]  = 'al.created_at <= ?';
+            $params[] = $filters['fecha_hasta'] . ' 23:59:59';
+        }
+
+        $whereClause = $where ? 'WHERE ' . implode(' AND ', $where) : '';
+
+        $cntStmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM activity_logs al
+             LEFT JOIN businesses b ON b.id = al.business_id
+             LEFT JOIN employees  e ON e.id = al.employee_id
+             {$whereClause}"
+        );
+        $cntStmt->execute($params);
+        $total = (int)$cntStmt->fetchColumn();
+
+        $stmt = $this->pdo->prepare(
+            "SELECT al.*, b.name AS negocio, e.name AS empleado
+             FROM activity_logs al
+             LEFT JOIN businesses b ON b.id = al.business_id
+             LEFT JOIN employees  e ON e.id = al.employee_id
+             {$whereClause}
+             ORDER BY al.created_at DESC
+             LIMIT ? OFFSET ?"
+        );
+        $stmt->execute(array_merge($params, [$perPage, $offset]));
+
+        return [
+            'items' => $stmt->fetchAll(),
+            'total' => $total,
+            'pages' => (int)ceil($total / $perPage),
+            'page'  => $page,
+        ];
+    }
+
+    /** @return array Lista de negocios para el select de filtro. */
+    public function negocios(): array
+    {
+        return $this->pdo->query(
+            'SELECT id, name FROM businesses ORDER BY name'
+        )->fetchAll();
+    }
+}

--- a/src/superadmin/dashboard.php
+++ b/src/superadmin/dashboard.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Dashboard global del panel de superadmin.
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/controllers/DashboardController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl    = new DashboardController();
+$data    = $ctrl->index();
+$base    = './';
+$cssBase = '../';
+
+$pageTitle = 'Dashboard';
+$activeMenu = 'dashboard';
+$mensajesSinLeer = $data['mensajesSinLeer'];
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+$movLabels = json_encode(array_column($data['movimientosPorNegocio'], 'negocio'));
+$movValues = json_encode(array_column($data['movimientosPorNegocio'], 'total'));
+
+ob_start();
+?>
+<!-- Métricas -->
+<div class="sa-metric-grid">
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Negocios activos</div>
+        <div class="sa-metric-value"><?= $data['totalNegocios'] ?></div>
+    </div>
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Empleados activos</div>
+        <div class="sa-metric-value"><?= $data['totalEmpleados'] ?></div>
+    </div>
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Mensajes sin leer</div>
+        <div class="sa-metric-value" style="<?= $data['mensajesSinLeer'] > 0 ? 'color:#ef4444' : '' ?>"><?= $data['mensajesSinLeer'] ?></div>
+    </div>
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Movimientos hoy</div>
+        <div class="sa-metric-value"><?= $data['movimientosHoy'] ?></div>
+    </div>
+</div>
+
+<!-- Gráfico movimientos por negocio (7 días) -->
+<div class="sa-table-card" style="padding:1.25rem;">
+    <div class="sa-table-header" style="padding:0 0 1rem;">
+        <h3>Movimientos por negocio — últimos 7 días</h3>
+    </div>
+    <canvas id="chartMovimientos" height="80"></canvas>
+</div>
+
+<!-- Últimos mensajes sin leer -->
+<div class="sa-table-card">
+    <div class="sa-table-header">
+        <h3>Mensajes sin leer</h3>
+        <a href="contact.php" style="font-size:.82rem;color:var(--accent);">Ver todos →</a>
+    </div>
+    <?php if (empty($data['ultimosMensajes'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin mensajes pendientes.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th>Remitente</th><th>Negocio</th><th>Asunto</th><th>Fecha</th></tr></thead>
+        <tbody>
+        <?php foreach ($data['ultimosMensajes'] as $m): ?>
+            <tr style="cursor:pointer;" onclick="location.href='contact.php?action=show&id=<?= $m['id'] ?>'">
+                <td><?= htmlspecialchars($m['sender_name'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars($m['negocio'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars($m['subject'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+                <td style="color:var(--text-muted)"><?= date('d/m H:i', strtotime($m['created_at'])) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>
+
+<!-- Última actividad -->
+<div class="sa-table-card">
+    <div class="sa-table-header">
+        <h3>Últimas actividades</h3>
+        <a href="logs.php" style="font-size:.82rem;color:var(--accent);">Ver todas →</a>
+    </div>
+    <?php if (empty($data['ultimaActividad'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin actividad registrada.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th>Negocio</th><th>Empleado</th><th>Acción</th><th>Fecha</th></tr></thead>
+        <tbody>
+        <?php foreach ($data['ultimaActividad'] as $a): ?>
+            <tr>
+                <td><?= htmlspecialchars($a['negocio'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars($a['empleado'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars($a['action'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td style="color:var(--text-muted)"><?= date('d/m H:i', strtotime($a['created_at'])) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<script>
+(function () {
+    const ctx = document.getElementById('chartMovimientos');
+    if (!ctx) return;
+    new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels: <?= $movLabels ?>,
+            datasets: [{
+                label: 'Movimientos',
+                data: <?= $movValues ?>,
+                backgroundColor: 'rgba(99,102,241,0.7)',
+                borderRadius: 6,
+            }]
+        },
+        options: {
+            responsive: true,
+            plugins: { legend: { display: false } },
+            scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } }
+        }
+    });
+})();
+</script>
+<?php
+$content = ob_get_clean();
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/employees.php
+++ b/src/superadmin/employees.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Gestión de empleados — panel superadmin.
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/csrf.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/controllers/EmployeeController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl       = new EmployeeController();
+$action     = $_GET['action'] ?? 'list';
+$id         = isset($_GET['id']) ? (int)$_GET['id'] : 0;
+$businessId = isset($_GET['business_id']) ? (int)$_GET['business_id'] : 0;
+$base       = './';
+$cssBase    = '../';
+$activeMenu = 'employees';
+
+$mensajesSinLeer = 0;
+try {
+    $pdo = Database::getInstance();
+    $mensajesSinLeer = (int)$pdo->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+} catch (\Throwable) {}
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $postAction = $_POST['_action'] ?? $action;
+
+    if (!validateCsrfToken('sa_employees', $_POST['csrf_token'] ?? '')) {
+        $_SESSION['flash_error'] = 'Token CSRF inválido.';
+        header('Location: employees.php');
+        exit;
+    }
+
+    try {
+        switch ($postAction) {
+            case 'store':
+                $ctrl->store($_POST);
+                $_SESSION['flash_success'] = 'Empleado creado.';
+                header('Location: employees.php');
+                exit;
+
+            case 'update':
+                $ctrl->update($id, $_POST);
+                $_SESSION['flash_success'] = 'Empleado actualizado.';
+                header("Location: employees.php");
+                exit;
+
+            case 'toggle':
+                $nuevo = $ctrl->toggle($id);
+                $_SESSION['flash_success'] = $nuevo ? 'Empleado activado.' : 'Empleado desactivado.';
+                header('Location: ' . ($_SERVER['HTTP_REFERER'] ?? 'employees.php'));
+                exit;
+
+            case 'reset-password':
+                $ctrl->resetPassword($id);
+                $_SESSION['flash_success'] = 'Contraseña reseteada y enviada por correo.';
+                header('Location: ' . ($_SERVER['HTTP_REFERER'] ?? 'employees.php'));
+                exit;
+        }
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    }
+}
+
+$csrfToken = generateCsrfToken('sa_employees');
+$negocios  = $ctrl->negociosActivos();
+
+switch ($action) {
+    case 'create':
+        $pageTitle = 'Nuevo empleado';
+        ob_start();
+        include __DIR__ . '/views/employees/create.php';
+        $content = ob_get_clean();
+        break;
+
+    case 'edit':
+        try {
+            $employee  = $ctrl->find($id);
+            $pageTitle = 'Editar – ' . htmlspecialchars($employee['name'], ENT_QUOTES, 'UTF-8');
+            ob_start();
+            include __DIR__ . '/views/employees/edit.php';
+            $content = ob_get_clean();
+        } catch (AppException $e) {
+            $flashError = $e->getMessage();
+            header('Location: employees.php');
+            exit;
+        }
+        break;
+
+    default:
+        $employees = $ctrl->index($businessId);
+        $pageTitle  = 'Empleados';
+        ob_start();
+        include __DIR__ . '/views/employees/index.php';
+        $content = ob_get_clean();
+}
+
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/logs.php
+++ b/src/superadmin/logs.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Registro de actividad global — panel superadmin.
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/controllers/LogController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl       = new LogController();
+$base       = './';
+$cssBase    = '../';
+$activeMenu = 'logs';
+
+$pdo = Database::getInstance();
+$mensajesSinLeer = (int)$pdo->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+$filters = [
+    'business_id' => (int)($_GET['business_id'] ?? 0),
+    'empleado'    => trim($_GET['empleado'] ?? ''),
+    'fecha_desde' => trim($_GET['fecha_desde'] ?? ''),
+    'fecha_hasta' => trim($_GET['fecha_hasta'] ?? ''),
+];
+$page   = max(1, (int)($_GET['page'] ?? 1));
+$result = $ctrl->index($filters, $page);
+$negocios = $ctrl->negocios();
+
+$pageTitle = 'Registro de actividad';
+
+ob_start();
+include __DIR__ . '/views/logs/index.php';
+$content = ob_get_clean();
+
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/middleware/SuperadminMiddleware.php
+++ b/src/superadmin/middleware/SuperadminMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Middleware exclusivo para el panel de superadministración.
+ *
+ * Verifica que la sesión activa corresponde a un usuario con rol superadmin.
+ * Destruye la sesión y redirige al login si el acceso no está autorizado.
+ *
+ * @package  Es21Plus\Superadmin\Middleware
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+class SuperadminMiddleware
+{
+    /**
+     * Garantiza acceso exclusivo al rol superadmin.
+     *
+     * @return void
+     */
+    public static function require(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+
+        if (empty($_SESSION['usuario_id'])) {
+            header('Location: /login.php');
+            exit;
+        }
+
+        if (($_SESSION['rol'] ?? '') !== 'superadmin') {
+            session_unset();
+            session_destroy();
+            header('Location: /login.php?error=acceso_denegado');
+            exit;
+        }
+
+        // Inactividad: 4 horas para superadmin
+        $timeout = 14400;
+        if (isset($_SESSION['last_activity']) && (time() - $_SESSION['last_activity']) > $timeout) {
+            session_unset();
+            session_destroy();
+            header('Location: /login.php?expired=1');
+            exit;
+        }
+
+        $_SESSION['last_activity'] = time();
+    }
+
+    /**
+     * Devuelve el nombre del superadmin en sesión.
+     *
+     * @return string
+     */
+    public static function nombre(): string
+    {
+        return htmlspecialchars($_SESSION['usuario_nombre'] ?? 'Superadmin', ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/src/superadmin/views/announcements/create.php
+++ b/src/superadmin/views/announcements/create.php
@@ -1,0 +1,26 @@
+<div style="max-width:620px;">
+    <div class="sa-form-card">
+        <h2>Nuevo anuncio</h2>
+        <form method="POST" action="announcements.php?action=store">
+            <input type="hidden" name="_action" value="store">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+
+            <div class="form-field" style="margin-bottom:.9rem;">
+                <label class="field-label">Título *</label>
+                <input type="text" name="title" class="field-input" required placeholder="Mantenimiento programado el viernes">
+            </div>
+            <div class="form-field" style="margin-bottom:1.25rem;">
+                <label class="field-label">Mensaje *</label>
+                <textarea name="body" class="field-input" rows="5" required
+                          placeholder="Texto visible en el banner de todos los paneles..."></textarea>
+            </div>
+            <p style="font-size:.78rem;color:var(--text-muted);margin-bottom:1.25rem;">
+                El anuncio se mostrará activo inmediatamente. Solo el más reciente activo aparece como banner.
+            </p>
+            <div style="display:flex;gap:.75rem;justify-content:flex-end;">
+                <a href="announcements.php" class="btn btn-secondary">Cancelar</a>
+                <button type="submit" class="btn btn-primary">Publicar anuncio</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/superadmin/views/announcements/index.php
+++ b/src/superadmin/views/announcements/index.php
@@ -1,0 +1,31 @@
+<div style="display:flex;justify-content:flex-end;margin-bottom:1.25rem;">
+    <a href="announcements.php?action=create" class="btn btn-primary">+ Nuevo anuncio</a>
+</div>
+
+<div class="sa-table-card">
+    <?php if (empty($announcements)): ?>
+        <p style="padding:1.5rem;text-align:center;color:var(--text-muted);">Sin anuncios.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th>Título</th><th>Estado</th><th>Creado</th><th>Acción</th></tr></thead>
+        <tbody>
+        <?php foreach ($announcements as $a): ?>
+        <tr>
+            <td style="font-weight:500;"><?= htmlspecialchars($a['title'], ENT_QUOTES, 'UTF-8') ?></td>
+            <td><?= $a['is_active'] ? '<span class="badge-active">Activo</span>' : '<span class="badge-inactive">Inactivo</span>' ?></td>
+            <td style="color:var(--text-muted)"><?= date('d/m/Y', strtotime($a['created_at'])) ?></td>
+            <td>
+                <form method="POST" action="announcements.php?action=toggle&id=<?= $a['id'] ?>" style="display:inline;">
+                    <input type="hidden" name="_action" value="toggle">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+                    <button type="submit" class="btn btn-secondary" style="font-size:.78rem;padding:.3rem .7rem;">
+                        <?= $a['is_active'] ? 'Desactivar' : 'Activar' ?>
+                    </button>
+                </form>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>

--- a/src/superadmin/views/businesses/create.php
+++ b/src/superadmin/views/businesses/create.php
@@ -1,0 +1,71 @@
+<div style="max-width:720px;">
+    <div class="sa-form-card">
+        <h2>Nuevo negocio</h2>
+        <form method="POST" action="businesses.php?action=store">
+            <input type="hidden" name="_action" value="store">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+
+            <div class="sa-form-grid">
+                <div class="form-field">
+                    <label class="field-label">Nombre *</label>
+                    <input type="text" name="name" class="field-input" required
+                           placeholder="Taller Mecánico García"
+                           oninput="generarSlug(this.value)">
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Slug (URL)</label>
+                    <input type="text" name="slug" id="slugField" class="field-input" readonly
+                           style="background:var(--surface);color:var(--text-muted);">
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Email de contacto</label>
+                    <input type="email" name="contact_email" class="field-input" placeholder="admin@taller.com">
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Teléfono</label>
+                    <input type="text" name="phone" class="field-input" placeholder="+34 600 000 000">
+                </div>
+            </div>
+
+            <div class="form-field" style="margin-top:.9rem;">
+                <label class="field-label">Dirección</label>
+                <textarea name="address" class="field-input" rows="2" placeholder="Calle, ciudad, CP"></textarea>
+            </div>
+
+            <div class="sa-form-grid" style="margin-top:.9rem;">
+                <div class="form-field">
+                    <label class="field-label">Plan</label>
+                    <select name="plan" class="field-input">
+                        <option value="free">Free</option>
+                        <option value="basic">Basic</option>
+                        <option value="pro">Pro</option>
+                    </select>
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Vencimiento del plan</label>
+                    <input type="date" name="plan_expires_at" class="field-input">
+                </div>
+            </div>
+
+            <p style="font-size:.78rem;color:var(--text-muted);margin:.9rem 0 1.25rem;">
+                Se creará automáticamente un empleado con rol admin usando el email de contacto.
+            </p>
+
+            <div style="display:flex;gap:.75rem;justify-content:flex-end;">
+                <a href="businesses.php" class="btn btn-secondary">Cancelar</a>
+                <button type="submit" class="btn btn-primary">Crear negocio</button>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+function generarSlug(nombre) {
+    const slug = nombre.toLowerCase().trim()
+        .normalize('NFD').replace(/[̀-ͯ]/g, '')
+        .replace(/[^a-z0-9\s-]/g, '')
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-');
+    document.getElementById('slugField').value = slug;
+}
+</script>

--- a/src/superadmin/views/businesses/edit.php
+++ b/src/superadmin/views/businesses/edit.php
@@ -1,0 +1,58 @@
+<div style="max-width:720px;">
+    <div class="sa-form-card">
+        <h2>Editar negocio</h2>
+        <form method="POST" action="businesses.php?action=update&id=<?= $business['id'] ?>">
+            <input type="hidden" name="_action" value="update">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+
+            <div class="sa-form-grid">
+                <div class="form-field">
+                    <label class="field-label">Nombre *</label>
+                    <input type="text" name="name" class="field-input" required
+                           value="<?= htmlspecialchars($business['name'], ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Slug</label>
+                    <input type="text" class="field-input" value="<?= htmlspecialchars($business['slug'], ENT_QUOTES, 'UTF-8') ?>"
+                           readonly style="background:var(--surface);color:var(--text-muted);">
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Email de contacto</label>
+                    <input type="email" name="contact_email" class="field-input"
+                           value="<?= htmlspecialchars($business['contact_email'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Teléfono</label>
+                    <input type="text" name="phone" class="field-input"
+                           value="<?= htmlspecialchars($business['phone'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+            </div>
+
+            <div class="form-field" style="margin-top:.9rem;">
+                <label class="field-label">Dirección</label>
+                <textarea name="address" class="field-input" rows="2"><?= htmlspecialchars($business['address'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+            </div>
+
+            <div class="sa-form-grid" style="margin-top:.9rem;">
+                <div class="form-field">
+                    <label class="field-label">Plan</label>
+                    <select name="plan" class="field-input">
+                        <?php foreach (['free','basic','pro'] as $p): ?>
+                            <option value="<?= $p ?>" <?= $business['plan'] === $p ? 'selected' : '' ?>><?= ucfirst($p) ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Vencimiento del plan</label>
+                    <input type="date" name="plan_expires_at" class="field-input"
+                           value="<?= htmlspecialchars($business['plan_expires_at'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+            </div>
+
+            <div style="display:flex;gap:.75rem;justify-content:flex-end;margin-top:1.5rem;">
+                <a href="businesses.php?action=show&id=<?= $business['id'] ?>" class="btn btn-secondary">Cancelar</a>
+                <button type="submit" class="btn btn-primary">Guardar cambios</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/superadmin/views/businesses/index.php
+++ b/src/superadmin/views/businesses/index.php
@@ -1,0 +1,94 @@
+<!-- Toolbar -->
+<div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem;flex-wrap:wrap;">
+    <form method="GET" action="businesses.php" style="display:flex;gap:.5rem;flex:1;max-width:340px;">
+        <input type="hidden" name="action" value="list">
+        <input type="text" name="q" value="<?= htmlspecialchars($q, ENT_QUOTES, 'UTF-8') ?>"
+               placeholder="Buscar negocio..."
+               style="flex:1;padding:.5rem .75rem;border:1px solid var(--border);border-radius:.5rem;font-size:.85rem;">
+        <button type="submit" class="btn btn-secondary" style="padding:.5rem .9rem;">Buscar</button>
+    </form>
+    <a href="businesses.php?action=create" class="btn btn-primary" style="margin-left:auto;">+ Nuevo negocio</a>
+</div>
+
+<div class="sa-table-card">
+    <table class="sa-table">
+        <thead>
+            <tr>
+                <th>Nombre</th>
+                <th>Plan</th>
+                <th>Vence</th>
+                <th>Empleados</th>
+                <th>Estado</th>
+                <th>Creado</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php if (empty($result['items'])): ?>
+            <tr><td colspan="7" style="text-align:center;color:var(--text-muted);padding:2rem;">Sin resultados.</td></tr>
+        <?php else: ?>
+            <?php foreach ($result['items'] as $b): ?>
+            <tr>
+                <td>
+                    <a href="businesses.php?action=show&id=<?= $b['id'] ?>" style="font-weight:600;">
+                        <?= htmlspecialchars($b['name'], ENT_QUOTES, 'UTF-8') ?>
+                    </a>
+                    <div style="font-size:.75rem;color:var(--text-muted);"><?= htmlspecialchars($b['slug'], ENT_QUOTES, 'UTF-8') ?></div>
+                </td>
+                <td><span class="badge-<?= $b['plan'] ?>"><?= strtoupper($b['plan']) ?></span></td>
+                <td style="color:var(--text-muted);">
+                    <?= $b['plan_expires_at'] ? date('d/m/Y', strtotime($b['plan_expires_at'])) : '—' ?>
+                </td>
+                <td><?= $b['num_empleados'] ?></td>
+                <td>
+                    <?php if ($b['is_active']): ?>
+                        <span class="badge-active">Activo</span>
+                    <?php else: ?>
+                        <span class="badge-inactive">Inactivo</span>
+                    <?php endif; ?>
+                </td>
+                <td style="color:var(--text-muted);"><?= date('d/m/Y', strtotime($b['created_at'])) ?></td>
+                <td>
+                    <div style="display:flex;gap:.4rem;align-items:center;">
+                        <a href="businesses.php?action=show&id=<?= $b['id'] ?>" title="Ver" style="color:var(--accent);">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+                        </a>
+                        <a href="businesses.php?action=edit&id=<?= $b['id'] ?>" title="Editar" style="color:var(--text-secondary);">
+                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+                        </a>
+                        <form method="POST" action="businesses.php?action=toggle&id=<?= $b['id'] ?>" style="display:inline;" onsubmit="return confirm('¿Cambiar estado del negocio?')">
+                            <input type="hidden" name="_action" value="toggle">
+                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+                            <button type="submit" title="<?= $b['is_active'] ? 'Desactivar' : 'Activar' ?>"
+                                    style="background:none;border:none;cursor:pointer;color:<?= $b['is_active'] ? '#ef4444' : '#22c55e' ?>;">
+                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                    <?php if ($b['is_active']): ?>
+                                        <circle cx="12" cy="12" r="10"/><line x1="15" y1="9" x2="9" y2="15"/><line x1="9" y1="9" x2="15" y2="15"/>
+                                    <?php else: ?>
+                                        <circle cx="12" cy="12" r="10"/><polyline points="9 12 11 14 15 10"/>
+                                    <?php endif; ?>
+                                </svg>
+                            </button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</div>
+
+<!-- Paginación -->
+<?php if ($result['pages'] > 1): ?>
+<div style="display:flex;gap:.4rem;justify-content:center;margin-top:1rem;">
+    <?php for ($i = 1; $i <= $result['pages']; $i++): ?>
+        <a href="businesses.php?page=<?= $i ?>&q=<?= urlencode($q) ?>"
+           style="padding:.35rem .7rem;border:1px solid var(--border);border-radius:.4rem;font-size:.82rem;
+                  <?= $i === $result['page'] ? 'background:var(--accent);color:#fff;border-color:var(--accent);' : 'color:var(--text-secondary);' ?>
+                  text-decoration:none;">
+            <?= $i ?>
+        </a>
+    <?php endfor; ?>
+</div>
+<?php endif; ?>

--- a/src/superadmin/views/businesses/show.php
+++ b/src/superadmin/views/businesses/show.php
@@ -1,0 +1,116 @@
+<!-- Header del negocio -->
+<div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.5rem;flex-wrap:wrap;">
+    <div style="flex:1;">
+        <div style="display:flex;align-items:center;gap:.75rem;">
+            <h2 style="margin:0;font-size:1.3rem;"><?= htmlspecialchars($business['name'], ENT_QUOTES, 'UTF-8') ?></h2>
+            <?php if ($business['is_active']): ?>
+                <span class="badge-active">Activo</span>
+            <?php else: ?>
+                <span class="badge-inactive">Inactivo</span>
+            <?php endif; ?>
+            <span class="badge-<?= $business['plan'] ?>"><?= strtoupper($business['plan']) ?></span>
+        </div>
+        <p style="margin:.25rem 0 0;font-size:.82rem;color:var(--text-muted);">
+            <?= htmlspecialchars($business['contact_email'] ?? '', ENT_QUOTES, 'UTF-8') ?>
+            <?= $business['phone'] ? ' · ' . htmlspecialchars($business['phone'], ENT_QUOTES, 'UTF-8') : '' ?>
+        </p>
+    </div>
+    <div style="display:flex;gap:.5rem;">
+        <a href="businesses.php?action=edit&id=<?= $business['id'] ?>" class="btn btn-secondary">Editar</a>
+        <form method="POST" action="businesses.php?action=toggle&id=<?= $business['id'] ?>" style="display:inline;" onsubmit="return confirm('¿Cambiar estado?')">
+            <input type="hidden" name="_action" value="toggle">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+            <button type="submit" class="btn <?= $business['is_active'] ? 'btn-danger' : 'btn-primary' ?>">
+                <?= $business['is_active'] ? 'Desactivar' : 'Activar' ?>
+            </button>
+        </form>
+    </div>
+</div>
+
+<!-- Métricas rápidas -->
+<div class="sa-metric-grid" style="margin-bottom:1.5rem;">
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Empleados</div>
+        <div class="sa-metric-value"><?= count($business['employees']) ?></div>
+    </div>
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Productos</div>
+        <div class="sa-metric-value"><?= $business['total_productos'] ?></div>
+    </div>
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Movimientos (mes)</div>
+        <div class="sa-metric-value"><?= $business['movimientos_mes'] ?></div>
+    </div>
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Plan vence</div>
+        <div class="sa-metric-value" style="font-size:1rem;">
+            <?= $business['plan_expires_at'] ? date('d/m/Y', strtotime($business['plan_expires_at'])) : '—' ?>
+        </div>
+    </div>
+</div>
+
+<!-- Empleados del negocio -->
+<div class="sa-table-card" style="margin-bottom:1.5rem;">
+    <div class="sa-table-header">
+        <h3>Empleados</h3>
+        <a href="../employees.php?business_id=<?= $business['id'] ?>&action=create" class="btn btn-primary" style="font-size:.8rem;padding:.35rem .8rem;">+ Empleado</a>
+    </div>
+    <?php if (empty($business['employees'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin empleados.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th>Nombre</th><th>Email</th><th>Rol</th><th>Estado</th><th>Acciones</th></tr></thead>
+        <tbody>
+        <?php foreach ($business['employees'] as $e): ?>
+        <tr>
+            <td><?= htmlspecialchars($e['name'], ENT_QUOTES, 'UTF-8') ?></td>
+            <td style="color:var(--text-muted)"><?= htmlspecialchars($e['email'], ENT_QUOTES, 'UTF-8') ?></td>
+            <td><?= $e['role'] === 'admin' ? '<span class="badge-basic">Admin</span>' : '<span class="badge-free">Empleado</span>' ?></td>
+            <td><?= $e['is_active'] ? '<span class="badge-active">Activo</span>' : '<span class="badge-inactive">Inactivo</span>' ?></td>
+            <td>
+                <a href="../employees.php?action=edit&id=<?= $e['id'] ?>" style="font-size:.8rem;color:var(--accent);">Editar</a>
+                <span style="color:var(--border);margin:0 .25rem;">|</span>
+                <form method="POST" action="../employees.php?action=toggle&id=<?= $e['id'] ?>" style="display:inline;" onsubmit="return confirm('¿Cambiar estado?')">
+                    <input type="hidden" name="_action" value="toggle">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+                    <button type="submit" style="background:none;border:none;cursor:pointer;font-size:.8rem;color:<?= $e['is_active'] ? '#ef4444' : '#22c55e' ?>">
+                        <?= $e['is_active'] ? 'Desactivar' : 'Activar' ?>
+                    </button>
+                </form>
+                <span style="color:var(--border);margin:0 .25rem;">|</span>
+                <form method="POST" action="../employees.php?action=reset-password&id=<?= $e['id'] ?>" style="display:inline;" onsubmit="return confirm('¿Resetear contraseña? Se enviará por correo.')">
+                    <input type="hidden" name="_action" value="reset-password">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+                    <button type="submit" style="background:none;border:none;cursor:pointer;font-size:.8rem;color:var(--text-muted);">Reset pwd</button>
+                </form>
+            </td>
+        </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>
+
+<!-- Últimos 10 movimientos -->
+<div class="sa-table-card">
+    <div class="sa-table-header"><h3>Últimos movimientos</h3></div>
+    <?php if (empty($business['movimientos'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin movimientos.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th>Producto</th><th>Tipo</th><th>Cantidad</th><th>Fecha</th></tr></thead>
+        <tbody>
+        <?php foreach ($business['movimientos'] as $m): ?>
+        <tr>
+            <td><?= htmlspecialchars($m['producto'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+            <td><?= $m['tipo'] === 'entrada'
+                ? '<span class="badge-active">Entrada</span>'
+                : '<span class="badge-inactive">Salida</span>' ?></td>
+            <td><?= $m['cantidad'] ?></td>
+            <td style="color:var(--text-muted)"><?= date('d/m/Y H:i', strtotime($m['fecha'])) ?></td>
+        </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>

--- a/src/superadmin/views/contact/index.php
+++ b/src/superadmin/views/contact/index.php
@@ -1,0 +1,30 @@
+<div class="sa-table-card">
+    <div class="sa-table-header">
+        <h3>Bandeja de entrada <span style="font-weight:400;color:var(--text-muted);font-size:.82rem;">(<?= count($messages) ?> mensajes)</span></h3>
+    </div>
+    <?php if (empty($messages)): ?>
+        <p style="padding:1.5rem;text-align:center;color:var(--text-muted);">Bandeja vacía.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th></th><th>Remitente</th><th>Negocio</th><th>Asunto</th><th>Fecha</th></tr></thead>
+        <tbody>
+        <?php foreach ($messages as $m): ?>
+        <tr style="cursor:pointer;<?= !$m['is_read'] ? 'font-weight:600;' : '' ?>"
+            onclick="location.href='contact.php?action=show&id=<?= $m['id'] ?>'">
+            <td style="width:32px;">
+                <?php if (!$m['is_read']): ?>
+                    <span class="badge-unread">Nuevo</span>
+                <?php endif; ?>
+            </td>
+            <td><?= htmlspecialchars($m['sender_name'], ENT_QUOTES, 'UTF-8') ?>
+                <div style="font-size:.75rem;font-weight:400;color:var(--text-muted)"><?= htmlspecialchars($m['sender_email'], ENT_QUOTES, 'UTF-8') ?></div>
+            </td>
+            <td style="color:var(--text-muted)"><?= htmlspecialchars($m['negocio'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+            <td><?= htmlspecialchars($m['subject'] ?? '(sin asunto)', ENT_QUOTES, 'UTF-8') ?></td>
+            <td style="color:var(--text-muted);white-space:nowrap;"><?= date('d/m/Y H:i', strtotime($m['created_at'])) ?></td>
+        </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>

--- a/src/superadmin/views/contact/show.php
+++ b/src/superadmin/views/contact/show.php
@@ -1,0 +1,43 @@
+<div style="max-width:760px;">
+    <a href="contact.php" style="font-size:.82rem;color:var(--accent);display:inline-flex;align-items:center;gap:.3rem;margin-bottom:1rem;">
+        ← Volver a bandeja
+    </a>
+
+    <div class="sa-form-card" style="margin-bottom:1rem;">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:1rem;margin-bottom:1rem;">
+            <div>
+                <h2 style="margin:0 0 .25rem;"><?= htmlspecialchars($message['subject'] ?? '(sin asunto)', ENT_QUOTES, 'UTF-8') ?></h2>
+                <p style="margin:0;font-size:.83rem;color:var(--text-muted);">
+                    De: <strong><?= htmlspecialchars($message['sender_name'], ENT_QUOTES, 'UTF-8') ?></strong>
+                    &lt;<?= htmlspecialchars($message['sender_email'], ENT_QUOTES, 'UTF-8') ?>&gt;
+                    <?= $message['negocio'] ? ' · ' . htmlspecialchars($message['negocio'], ENT_QUOTES, 'UTF-8') : '' ?>
+                </p>
+                <p style="margin:.25rem 0 0;font-size:.78rem;color:var(--text-muted);">
+                    <?= date('d/m/Y H:i', strtotime($message['created_at'])) ?>
+                    <?= $message['replied_at'] ? ' · Respondido: ' . date('d/m/Y H:i', strtotime($message['replied_at'])) : '' ?>
+                </p>
+            </div>
+            <span class="badge-active" style="flex-shrink:0;">Leído</span>
+        </div>
+
+        <div style="background:var(--surface);border-radius:.5rem;padding:1rem;white-space:pre-wrap;font-size:.9rem;line-height:1.6;color:var(--text-primary);">
+            <?= htmlspecialchars($message['message'], ENT_QUOTES, 'UTF-8') ?>
+        </div>
+    </div>
+
+    <!-- Responder -->
+    <div class="sa-form-card">
+        <h3 style="margin:0 0 1rem;font-size:.9rem;">Responder a <?= htmlspecialchars($message['sender_email'], ENT_QUOTES, 'UTF-8') ?></h3>
+        <form method="POST" action="contact.php?action=reply&id=<?= $message['id'] ?>">
+            <input type="hidden" name="_action" value="reply">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+            <div class="form-field" style="margin-bottom:1rem;">
+                <textarea name="reply_body" class="field-input" rows="5" required
+                          placeholder="Escribe tu respuesta..."></textarea>
+            </div>
+            <div style="display:flex;justify-content:flex-end;">
+                <button type="submit" class="btn btn-primary">Enviar respuesta</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/superadmin/views/employees/create.php
+++ b/src/superadmin/views/employees/create.php
@@ -1,0 +1,43 @@
+<div style="max-width:580px;">
+    <div class="sa-form-card">
+        <h2>Nuevo empleado</h2>
+        <form method="POST" action="employees.php?action=store">
+            <input type="hidden" name="_action" value="store">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+
+            <div class="form-field" style="margin-bottom:.9rem;">
+                <label class="field-label">Negocio *</label>
+                <select name="business_id" class="field-input" required>
+                    <option value="">— Seleccionar —</option>
+                    <?php foreach ($negocios as $n): ?>
+                        <option value="<?= $n['id'] ?>" <?= (int)($businessId ?? 0) === (int)$n['id'] ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($n['name'], ENT_QUOTES, 'UTF-8') ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-field" style="margin-bottom:.9rem;">
+                <label class="field-label">Nombre *</label>
+                <input type="text" name="name" class="field-input" required placeholder="Juan García">
+            </div>
+            <div class="form-field" style="margin-bottom:.9rem;">
+                <label class="field-label">Email *</label>
+                <input type="email" name="email" class="field-input" required placeholder="juan@taller.com">
+            </div>
+            <div class="form-field" style="margin-bottom:1.25rem;">
+                <label class="field-label">Rol</label>
+                <select name="role" class="field-input">
+                    <option value="employee">Empleado</option>
+                    <option value="admin">Admin</option>
+                </select>
+            </div>
+            <p style="font-size:.78rem;color:var(--text-muted);margin-bottom:1.25rem;">
+                Se generará una contraseña aleatoria y se enviará al correo del empleado.
+            </p>
+            <div style="display:flex;gap:.75rem;justify-content:flex-end;">
+                <a href="employees.php" class="btn btn-secondary">Cancelar</a>
+                <button type="submit" class="btn btn-primary">Crear empleado</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/superadmin/views/employees/edit.php
+++ b/src/superadmin/views/employees/edit.php
@@ -1,0 +1,41 @@
+<div style="max-width:580px;">
+    <div class="sa-form-card">
+        <h2>Editar empleado</h2>
+        <form method="POST" action="employees.php?action=update&id=<?= $employee['id'] ?>">
+            <input type="hidden" name="_action" value="update">
+            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+
+            <div class="form-field" style="margin-bottom:.9rem;">
+                <label class="field-label">Negocio *</label>
+                <select name="business_id" class="field-input" required>
+                    <?php foreach ($negocios as $n): ?>
+                        <option value="<?= $n['id'] ?>" <?= (int)$employee['business_id'] === (int)$n['id'] ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($n['name'], ENT_QUOTES, 'UTF-8') ?>
+                        </option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="form-field" style="margin-bottom:.9rem;">
+                <label class="field-label">Nombre *</label>
+                <input type="text" name="name" class="field-input" required
+                       value="<?= htmlspecialchars($employee['name'], ENT_QUOTES, 'UTF-8') ?>">
+            </div>
+            <div class="form-field" style="margin-bottom:.9rem;">
+                <label class="field-label">Email *</label>
+                <input type="email" name="email" class="field-input" required
+                       value="<?= htmlspecialchars($employee['email'], ENT_QUOTES, 'UTF-8') ?>">
+            </div>
+            <div class="form-field" style="margin-bottom:1.25rem;">
+                <label class="field-label">Rol</label>
+                <select name="role" class="field-input">
+                    <option value="employee" <?= $employee['role'] === 'employee' ? 'selected' : '' ?>>Empleado</option>
+                    <option value="admin"    <?= $employee['role'] === 'admin'    ? 'selected' : '' ?>>Admin</option>
+                </select>
+            </div>
+            <div style="display:flex;gap:.75rem;justify-content:flex-end;">
+                <a href="employees.php" class="btn btn-secondary">Cancelar</a>
+                <button type="submit" class="btn btn-primary">Guardar cambios</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/superadmin/views/employees/index.php
+++ b/src/superadmin/views/employees/index.php
@@ -1,0 +1,53 @@
+<div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem;flex-wrap:wrap;">
+    <form method="GET" action="employees.php" style="display:flex;gap:.5rem;">
+        <select name="business_id" class="field-input" style="padding:.5rem .75rem;font-size:.85rem;" onchange="this.form.submit()">
+            <option value="0">Todos los negocios</option>
+            <?php foreach ($negocios as $n): ?>
+                <option value="<?= $n['id'] ?>" <?= $businessId === (int)$n['id'] ? 'selected' : '' ?>>
+                    <?= htmlspecialchars($n['name'], ENT_QUOTES, 'UTF-8') ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+    </form>
+    <a href="employees.php?action=create" class="btn btn-primary" style="margin-left:auto;">+ Nuevo empleado</a>
+</div>
+
+<div class="sa-table-card">
+    <table class="sa-table">
+        <thead>
+            <tr><th>Nombre</th><th>Email</th><th>Negocio</th><th>Rol</th><th>Estado</th><th>Acciones</th></tr>
+        </thead>
+        <tbody>
+        <?php if (empty($employees)): ?>
+            <tr><td colspan="6" style="text-align:center;color:var(--text-muted);padding:2rem;">Sin empleados.</td></tr>
+        <?php else: ?>
+            <?php foreach ($employees as $e): ?>
+            <tr>
+                <td style="font-weight:500;"><?= htmlspecialchars($e['name'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td style="color:var(--text-muted)"><?= htmlspecialchars($e['email'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars($e['negocio'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= $e['role'] === 'admin' ? '<span class="badge-basic">Admin</span>' : '<span class="badge-free">Empleado</span>' ?></td>
+                <td><?= $e['is_active'] ? '<span class="badge-active">Activo</span>' : '<span class="badge-inactive">Inactivo</span>' ?></td>
+                <td>
+                    <div style="display:flex;gap:.5rem;align-items:center;">
+                        <a href="employees.php?action=edit&id=<?= $e['id'] ?>" style="font-size:.8rem;color:var(--accent);">Editar</a>
+                        <form method="POST" action="employees.php?action=toggle&id=<?= $e['id'] ?>" style="display:inline;" onsubmit="return confirm('¿Cambiar estado?')">
+                            <input type="hidden" name="_action" value="toggle">
+                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+                            <button type="submit" style="background:none;border:none;cursor:pointer;font-size:.8rem;color:<?= $e['is_active'] ? '#ef4444' : '#22c55e' ?>">
+                                <?= $e['is_active'] ? 'Desactivar' : 'Activar' ?>
+                            </button>
+                        </form>
+                        <form method="POST" action="employees.php?action=reset-password&id=<?= $e['id'] ?>" style="display:inline;" onsubmit="return confirm('¿Resetear contraseña? Se enviará al correo del empleado.')">
+                            <input type="hidden" name="_action" value="reset-password">
+                            <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8') ?>">
+                            <button type="submit" style="background:none;border:none;cursor:pointer;font-size:.8rem;color:var(--text-muted);">Reset pwd</button>
+                        </form>
+                    </div>
+                </td>
+            </tr>
+            <?php endforeach; ?>
+        <?php endif; ?>
+        </tbody>
+    </table>
+</div>

--- a/src/superadmin/views/layout.php
+++ b/src/superadmin/views/layout.php
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($pageTitle ?? 'Superadmin', ENT_QUOTES, 'UTF-8') ?> — es21plus</title>
+    <link rel="stylesheet" href="<?= $cssBase ?? '../' ?>css/estilos.css">
+    <style>
+        :root {
+            --sa-sidebar-bg:    #0a0f1e;
+            --sa-sidebar-hover: #13182e;
+            --sa-accent:        #818cf8;
+            --sa-accent-dark:   #6366f1;
+        }
+        body { margin: 0; font-family: var(--font-sans); background: var(--body-bg); }
+
+        .sa-wrapper { display: flex; min-height: 100vh; }
+
+        /* ── Sidebar ── */
+        .sa-sidebar {
+            width: 240px;
+            min-width: 240px;
+            background: var(--sa-sidebar-bg);
+            display: flex;
+            flex-direction: column;
+            position: fixed;
+            top: 0; left: 0; bottom: 0;
+            z-index: 100;
+        }
+        .sa-sidebar-brand {
+            padding: 1.25rem 1.25rem 1rem;
+            border-bottom: 1px solid rgba(255,255,255,.06);
+        }
+        .sa-brand-badge {
+            display: inline-block;
+            background: var(--sa-accent-dark);
+            color: #fff;
+            font-size: .65rem;
+            font-weight: 700;
+            padding: .15rem .5rem;
+            border-radius: 20px;
+            letter-spacing: .05em;
+            text-transform: uppercase;
+            margin-bottom: .4rem;
+        }
+        .sa-brand-name { color: #fff; font-weight: 700; font-size: 1.05rem; margin: 0; }
+        .sa-nav { flex: 1; padding: .75rem 0; overflow-y: auto; }
+        .sa-nav-section {
+            padding: .5rem 1.25rem .25rem;
+            font-size: .68rem;
+            font-weight: 600;
+            color: rgba(255,255,255,.3);
+            letter-spacing: .08em;
+            text-transform: uppercase;
+        }
+        .sa-nav a {
+            display: flex;
+            align-items: center;
+            gap: .6rem;
+            padding: .55rem 1.25rem;
+            color: rgba(255,255,255,.6);
+            text-decoration: none;
+            font-size: .84rem;
+            transition: background .15s, color .15s;
+            border-left: 3px solid transparent;
+        }
+        .sa-nav a:hover { background: var(--sa-sidebar-hover); color: #fff; }
+        .sa-nav a.active {
+            background: rgba(99,102,241,.15);
+            color: var(--sa-accent);
+            border-left-color: var(--sa-accent);
+        }
+        .sa-nav a svg { opacity: .7; flex-shrink: 0; }
+        .sa-nav a.active svg { opacity: 1; }
+        .sa-badge-count {
+            margin-left: auto;
+            background: #ef4444;
+            color: #fff;
+            font-size: .65rem;
+            font-weight: 700;
+            padding: .1rem .4rem;
+            border-radius: 20px;
+            min-width: 18px;
+            text-align: center;
+        }
+        .sa-sidebar-footer {
+            padding: 1rem 1.25rem;
+            border-top: 1px solid rgba(255,255,255,.06);
+        }
+        .sa-user-mini {
+            display: flex;
+            align-items: center;
+            gap: .6rem;
+            color: rgba(255,255,255,.7);
+            font-size: .82rem;
+            margin-bottom: .75rem;
+        }
+        .sa-avatar-mini {
+            width: 30px; height: 30px;
+            background: var(--sa-accent-dark);
+            border-radius: 50%;
+            display: flex; align-items: center; justify-content: center;
+            font-size: .7rem;
+            font-weight: 700;
+            color: #fff;
+            flex-shrink: 0;
+        }
+        .sa-logout {
+            display: flex;
+            align-items: center;
+            gap: .5rem;
+            color: #f87171;
+            text-decoration: none;
+            font-size: .82rem;
+            padding: .4rem .5rem;
+            border-radius: .4rem;
+            transition: background .15s;
+        }
+        .sa-logout:hover { background: rgba(239,68,68,.1); }
+
+        /* ── Main area ── */
+        .sa-main { margin-left: 240px; flex: 1; display: flex; flex-direction: column; min-height: 100vh; }
+        .sa-topbar {
+            height: 56px;
+            background: #fff;
+            border-bottom: 1px solid var(--border);
+            display: flex;
+            align-items: center;
+            padding: 0 1.5rem;
+            gap: 1rem;
+            position: sticky;
+            top: 0;
+            z-index: 50;
+        }
+        .sa-topbar-title { font-weight: 600; font-size: .95rem; color: var(--text-primary); flex: 1; }
+        .sa-content { padding: 1.75rem; flex: 1; }
+
+        /* ── Cards métricas ── */
+        .sa-metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
+        .sa-metric-card {
+            background: #fff;
+            border: 1px solid var(--border);
+            border-radius: var(--radius-lg);
+            padding: 1.25rem;
+        }
+        .sa-metric-label { font-size: .78rem; color: var(--text-muted); margin-bottom: .4rem; }
+        .sa-metric-value { font-size: 2rem; font-weight: 700; color: var(--text-primary); line-height: 1; }
+        .sa-metric-icon { float: right; opacity: .15; }
+
+        /* ── Table styles ── */
+        .sa-table-card { background: #fff; border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; margin-bottom: 1.5rem; }
+        .sa-table-header { padding: 1rem 1.25rem; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
+        .sa-table-header h3 { margin: 0; font-size: .9rem; font-weight: 600; }
+        .sa-table { width: 100%; border-collapse: collapse; font-size: .84rem; }
+        .sa-table th { padding: .65rem 1rem; background: var(--surface); color: var(--text-muted); font-weight: 500; font-size: .75rem; text-align: left; border-bottom: 1px solid var(--border); }
+        .sa-table td { padding: .7rem 1rem; border-bottom: 1px solid #f1f5f9; color: var(--text-secondary); vertical-align: middle; }
+        .sa-table tr:last-child td { border-bottom: none; }
+        .sa-table tr:hover td { background: var(--surface); }
+        .sa-table a { color: var(--accent); text-decoration: none; }
+        .sa-table a:hover { text-decoration: underline; }
+
+        /* ── Badge ── */
+        .badge-active   { background: var(--success-light); color: #15803d; padding: .2rem .6rem; border-radius: 20px; font-size: .72rem; font-weight: 600; }
+        .badge-inactive { background: var(--danger-light);  color: #b91c1c; padding: .2rem .6rem; border-radius: 20px; font-size: .72rem; font-weight: 600; }
+        .badge-free     { background: var(--surface); color: var(--text-muted); padding: .2rem .6rem; border-radius: 20px; font-size: .72rem; }
+        .badge-basic    { background: var(--info-light); color: #1d4ed8; padding: .2rem .6rem; border-radius: 20px; font-size: .72rem; font-weight: 600; }
+        .badge-pro      { background: var(--purple-light); color: #7c3aed; padding: .2rem .6rem; border-radius: 20px; font-size: .72rem; font-weight: 600; }
+        .badge-unread   { background: var(--warning-light); color: #92400e; padding: .2rem .6rem; border-radius: 20px; font-size: .72rem; font-weight: 600; }
+
+        /* ── Flash messages ── */
+        .sa-alert { padding: .75rem 1rem; border-radius: .5rem; font-size: .85rem; margin-bottom: 1rem; }
+        .sa-alert-success { background: var(--success-light); color: #15803d; }
+        .sa-alert-error   { background: var(--danger-light);  color: #b91c1c; }
+
+        /* ── Form ── */
+        .sa-form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
+        .sa-form-card { background: #fff; border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 1.5rem; }
+        .sa-form-card h2 { margin: 0 0 1.25rem; font-size: 1rem; font-weight: 600; }
+    </style>
+</head>
+<body>
+<div class="sa-wrapper">
+
+    <!-- Sidebar -->
+    <aside class="sa-sidebar">
+        <div class="sa-sidebar-brand">
+            <span class="sa-brand-badge">Superadmin</span>
+            <p class="sa-brand-name">es21plus</p>
+        </div>
+        <nav class="sa-nav">
+            <div class="sa-nav-section">Panel</div>
+            <a href="<?= $base ?? '../' ?>dashboard.php"
+               class="<?= ($activeMenu ?? '') === 'dashboard' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
+                Dashboard
+            </a>
+
+            <div class="sa-nav-section">Gestión</div>
+            <a href="<?= $base ?? '../' ?>businesses.php"
+               class="<?= ($activeMenu ?? '') === 'businesses' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+                Negocios
+            </a>
+            <a href="<?= $base ?? '../' ?>employees.php"
+               class="<?= ($activeMenu ?? '') === 'employees' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+                Empleados
+            </a>
+
+            <div class="sa-nav-section">Comunicación</div>
+            <a href="<?= $base ?? '../' ?>contact.php"
+               class="<?= ($activeMenu ?? '') === 'contact' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
+                Mensajes
+                <?php if (($mensajesSinLeer ?? 0) > 0): ?>
+                    <span class="sa-badge-count"><?= $mensajesSinLeer ?></span>
+                <?php endif; ?>
+            </a>
+            <a href="<?= $base ?? '../' ?>announcements.php"
+               class="<?= ($activeMenu ?? '') === 'announcements' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 17H2a3 3 0 000 6h20a3 3 0 000-6z"/><path d="M6 17V3a2 2 0 012-2h8a2 2 0 012 2v14"/></svg>
+                Anuncios
+            </a>
+
+            <div class="sa-nav-section">Auditoría</div>
+            <a href="<?= $base ?? '../' ?>logs.php"
+               class="<?= ($activeMenu ?? '') === 'logs' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
+                Actividad
+            </a>
+        </nav>
+
+        <div class="sa-sidebar-footer">
+            <?php
+            $saName = htmlspecialchars($_SESSION['usuario_nombre'] ?? 'Superadmin', ENT_QUOTES, 'UTF-8');
+            $saInit = mb_strtoupper(mb_substr($_SESSION['usuario_nombre'] ?? 'S', 0, 2));
+            ?>
+            <div class="sa-user-mini">
+                <div class="sa-avatar-mini"><?= $saInit ?></div>
+                <div>
+                    <div style="font-weight:600;color:#fff;font-size:.8rem;"><?= $saName ?></div>
+                    <div style="font-size:.72rem;color:rgba(255,255,255,.4);">Superadmin</div>
+                </div>
+            </div>
+            <a href="<?= $base ?? '../' ?>../logout.php" class="sa-logout">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
+                Cerrar sesión
+            </a>
+        </div>
+    </aside>
+
+    <!-- Main -->
+    <main class="sa-main">
+        <div class="sa-topbar">
+            <span class="sa-topbar-title"><?= htmlspecialchars($pageTitle ?? '', ENT_QUOTES, 'UTF-8') ?></span>
+            <?php if (!empty($topbarActions)): ?>
+                <?= $topbarActions ?>
+            <?php endif; ?>
+        </div>
+        <div class="sa-content">
+            <?php if (!empty($flashSuccess)): ?>
+                <div class="sa-alert sa-alert-success"><?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?></div>
+            <?php endif; ?>
+            <?php if (!empty($flashError)): ?>
+                <div class="sa-alert sa-alert-error"><?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?></div>
+            <?php endif; ?>
+
+            <?= $content ?? '' ?>
+        </div>
+    </main>
+</div>
+</body>
+</html>

--- a/src/superadmin/views/logs/index.php
+++ b/src/superadmin/views/logs/index.php
@@ -1,0 +1,73 @@
+<!-- Filtros -->
+<form method="GET" action="logs.php" style="display:flex;flex-wrap:wrap;gap:.75rem;margin-bottom:1.25rem;align-items:flex-end;">
+    <div>
+        <label style="display:block;font-size:.75rem;color:var(--text-muted);margin-bottom:.25rem;">Negocio</label>
+        <select name="business_id" class="field-input" style="padding:.45rem .75rem;font-size:.84rem;">
+            <option value="0">Todos</option>
+            <?php foreach ($negocios as $n): ?>
+                <option value="<?= $n['id'] ?>" <?= (int)$filters['business_id'] === (int)$n['id'] ? 'selected' : '' ?>>
+                    <?= htmlspecialchars($n['name'], ENT_QUOTES, 'UTF-8') ?>
+                </option>
+            <?php endforeach; ?>
+        </select>
+    </div>
+    <div>
+        <label style="display:block;font-size:.75rem;color:var(--text-muted);margin-bottom:.25rem;">Empleado</label>
+        <input type="text" name="empleado" class="field-input" style="padding:.45rem .75rem;font-size:.84rem;"
+               value="<?= htmlspecialchars($filters['empleado'], ENT_QUOTES, 'UTF-8') ?>" placeholder="Nombre...">
+    </div>
+    <div>
+        <label style="display:block;font-size:.75rem;color:var(--text-muted);margin-bottom:.25rem;">Desde</label>
+        <input type="date" name="fecha_desde" class="field-input" style="padding:.45rem .75rem;font-size:.84rem;"
+               value="<?= htmlspecialchars($filters['fecha_desde'], ENT_QUOTES, 'UTF-8') ?>">
+    </div>
+    <div>
+        <label style="display:block;font-size:.75rem;color:var(--text-muted);margin-bottom:.25rem;">Hasta</label>
+        <input type="date" name="fecha_hasta" class="field-input" style="padding:.45rem .75rem;font-size:.84rem;"
+               value="<?= htmlspecialchars($filters['fecha_hasta'], ENT_QUOTES, 'UTF-8') ?>">
+    </div>
+    <button type="submit" class="btn btn-secondary">Filtrar</button>
+    <a href="logs.php" class="btn btn-secondary">Limpiar</a>
+</form>
+
+<div class="sa-table-card">
+    <div class="sa-table-header">
+        <h3>Actividad <span style="font-weight:400;color:var(--text-muted);font-size:.82rem;">(<?= $result['total'] ?> registros)</span></h3>
+    </div>
+    <?php if (empty($result['items'])): ?>
+        <p style="padding:1.5rem;text-align:center;color:var(--text-muted);">Sin registros.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th>Fecha</th><th>Negocio</th><th>Empleado</th><th>Acción</th><th>Entidad</th><th>IP</th></tr></thead>
+        <tbody>
+        <?php foreach ($result['items'] as $l): ?>
+        <tr>
+            <td style="white-space:nowrap;color:var(--text-muted)"><?= date('d/m/Y H:i', strtotime($l['created_at'])) ?></td>
+            <td><?= htmlspecialchars($l['negocio'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+            <td><?= htmlspecialchars($l['empleado'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+            <td><?= htmlspecialchars($l['action'], ENT_QUOTES, 'UTF-8') ?></td>
+            <td style="color:var(--text-muted)"><?= $l['entity'] ? htmlspecialchars($l['entity'], ENT_QUOTES, 'UTF-8') . ($l['entity_id'] ? " #{$l['entity_id']}" : '') : '—' ?></td>
+            <td style="font-size:.78rem;color:var(--text-muted)"><?= htmlspecialchars($l['ip_address'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+        </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>
+
+<!-- Paginación -->
+<?php if ($result['pages'] > 1): ?>
+<div style="display:flex;gap:.4rem;justify-content:center;margin-top:1rem;flex-wrap:wrap;">
+    <?php
+    $qStr = http_build_query(array_filter($filters));
+    for ($i = 1; $i <= $result['pages']; $i++):
+    ?>
+        <a href="logs.php?<?= $qStr ?>&page=<?= $i ?>"
+           style="padding:.35rem .7rem;border:1px solid var(--border);border-radius:.4rem;font-size:.82rem;
+                  <?= $i === $result['page'] ? 'background:var(--accent);color:#fff;border-color:var(--accent);' : 'color:var(--text-secondary);' ?>
+                  text-decoration:none;">
+            <?= $i ?>
+        </a>
+    <?php endfor; ?>
+</div>
+<?php endif; ?>

--- a/src/superadmin/views/plan_expired.php
+++ b/src/superadmin/views/plan_expired.php
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Plan vencido – es21plus</title>
+    <link rel="stylesheet" href="/css/estilos.css">
+</head>
+<body class="login-page">
+<div style="text-align:center;max-width:460px;margin:auto;padding:3rem 1.5rem;">
+    <svg width="52" height="52" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="1.5" style="margin:auto;display:block;margin-bottom:1.5rem;">
+        <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+    </svg>
+    <h1 style="color:#fff;font-size:1.5rem;margin-bottom:.5rem;">Plan vencido</h1>
+    <p style="color:#94a3b8;margin-bottom:2rem;">
+        El plan de <strong style="color:#fff;"><?= htmlspecialchars($planExpiredBusiness['name'] ?? 'tu negocio', ENT_QUOTES, 'UTF-8') ?></strong>
+        venció el <?= date('d/m/Y', strtotime($planExpiredBusiness['plan_expires_at'] ?? 'now')) ?>.
+        Contacta con soporte para renovarlo.
+    </p>
+    <a href="/api/contact_send.php" class="btn btn-primary" style="display:inline-block;padding:.75rem 1.5rem;">
+        Contactar soporte
+    </a>
+    <br><br>
+    <a href="/logout.php" style="color:#475569;font-size:.82rem;">Cerrar sesión</a>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Panel superadmin completo** en `src/superadmin/` con sidebar oscuro diferenciado
- **CRUD Negocios**: listado paginado, crear (auto-genera empleado admin), editar, toggle activo/inactivo, detalle con métricas
- **CRUD Empleados**: filtro por negocio, toggle, reset-password con notificación por correo
- **Bandeja mensajes**: inbox con no-leídos primero, vista individual, responder por email, endpoint público `POST /api/contact_send.php`
- **Anuncios globales**: CRUD con banner sticky en panel de negocios (dismiss via localStorage)
- **Registro actividad**: tabla paginada con filtros por negocio, empleado, rango de fechas
- **Mailer centralizado** (`core/Mailer.php`): PHPMailer SMTP, lee `MAIL_*`/`SMTP_*`, log errores, no interrumpe flujo
- **ActivityLogger** (`core/ActivityLogger.php`): inserta en `activity_logs`, swallows exceptions
- **BusinessMiddleware**: verifica `is_active` y plan no vencido por request; pantalla plan vencido
- **Infraestructura**: Dockerfile con Composer en build, vendor preservado con named volume, puertos fijos (DB→3308, web→8090)
- **Migración**: `database/migrations/superadmin_panel.sql` + runner idempotente

## Test plan

- [ ] Login `superadmin` → llega a `dashboard.php` con métricas (0s por DB vacía)
- [ ] Crear negocio → empleado admin generado automáticamente en `employees`
- [ ] Desactivar negocio → empleados no pueden acceder al panel (BusinessMiddleware)
- [ ] Crear anuncio activo → aparece banner en panel de negocios
- [ ] Enviar contacto desde formulario público → aparece en bandeja superadmin como no leído
- [ ] Abrir mensaje → marcado como leído, puede responder
- [ ] Reset password empleado → correo enviado (o error gracioso si SMTP no configurado)
- [ ] Negocio con `plan_expires_at` pasado → pantalla bloqueo en lugar de panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)