### PR TITLE
fix(fase5): add RoleMiddleware and topbar_user to importar_csv.php

### DIFF
--- a/src/importar_csv.php
+++ b/src/importar_csv.php
@@ -12,6 +12,8 @@
  * @version  1.0.0
  */
 require_once __DIR__ . '/includes/auth_check.php';
+require_once __DIR__ . '/middleware/RoleMiddleware.php';
+RoleMiddleware::requireAdmin();
 require_once __DIR__ . '/includes/AppException.php';
 require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Categoria.php';
@@ -315,6 +317,8 @@ $csrfToken = $_SESSION['csrf_token'];
     </style>
 </head>
 <body>
+
+<?php require_once __DIR__ . '/includes/topbar_user.php'; ?>
 
 <div class="csv-page">
 


### PR DESCRIPTION
## Summary
- `importar_csv.php` was added in FASE 5 before FASE 11 introduced `RoleMiddleware` and `topbar_user.php`
- When FASE 5 merged late (after FASE 11), the new page did not inherit the access guard or shared topbar
- Adds `RoleMiddleware::requireAdmin()` to block employee-role users from bulk CSV import
- Adds `topbar_user.php` include so the user menu (profile, logout) is visible on this page

## Test plan
- [ ] Log in as `employee` → visiting `importar_csv.php` should redirect to `index.php` (403/redirect)
- [ ] Log in as `admin` → page loads with user topbar showing name, dropdown, logout link
- [ ] CSV import flow (upload → map columns → import) still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)