### PR TITLE
feat(superadmin): security hardening, dashboard, notifications and global settings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,3 +41,7 @@ MAIL_FROM_NAME=es21plus
 
 # --- Superadmin ---
 SUPERADMIN_EMAIL=superadmin@example.com
+
+# --- Seguridad (cifrado contraseña SMTP) ---
+# Genera una clave aleatoria: openssl rand -base64 32
+APP_KEY=

--- a/database/migrations/notifications.sql
+++ b/database/migrations/notifications.sql
@@ -1,0 +1,16 @@
+-- ============================================================
+-- Migración: Notificaciones internas del superadmin
+-- @author Carlos Vico
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS superadmin_notifications (
+    id         INT AUTO_INCREMENT PRIMARY KEY,
+    type       VARCHAR(100)  NOT NULL,
+    title      VARCHAR(200)  NOT NULL,
+    body       TEXT,
+    link       VARCHAR(255),
+    is_read    TINYINT(1)    DEFAULT 0,
+    created_at TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_read (is_read),
+    INDEX idx_created (created_at)
+);

--- a/database/migrations/security.sql
+++ b/database/migrations/security.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- Migración: Seguridad — fuerza bruta, sesiones, auditoría crítica
+-- @author Carlos Vico
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS login_attempts (
+    id           INT AUTO_INCREMENT PRIMARY KEY,
+    ip_address   VARCHAR(45)  NOT NULL,
+    email        VARCHAR(150),
+    attempted_at TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_ip   (ip_address),
+    INDEX idx_time (attempted_at)
+);
+
+CREATE TABLE IF NOT EXISTS session_logs (
+    id           INT AUTO_INCREMENT PRIMARY KEY,
+    user_type    ENUM('superadmin','employee') NOT NULL,
+    user_id      INT          NOT NULL,
+    business_id  INT          NULL,
+    ip_address   VARCHAR(45)  NULL,
+    user_agent   VARCHAR(500) NULL,
+    action       ENUM('login','logout','expired') NOT NULL,
+    created_at   TIMESTAMP    DEFAULT CURRENT_TIMESTAMP
+);
+
+ALTER TABLE activity_logs
+    ADD COLUMN IF NOT EXISTS metadata    JSON             NULL    AFTER ip_address,
+    ADD COLUMN IF NOT EXISTS is_critical TINYINT(1)       DEFAULT 0 AFTER metadata;

--- a/database/migrations/settings.sql
+++ b/database/migrations/settings.sql
@@ -1,0 +1,29 @@
+-- ============================================================
+-- Migración: Configuración global del sistema
+-- @author Carlos Vico
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS system_settings (
+    id          INT AUTO_INCREMENT PRIMARY KEY,
+    setting_key VARCHAR(100)  NOT NULL UNIQUE,
+    value       TEXT,
+    type        ENUM('string','integer','boolean','json') DEFAULT 'string',
+    description VARCHAR(255),
+    updated_at  TIMESTAMP     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+INSERT INTO system_settings (setting_key, value, type, description) VALUES
+('app_name',           'es21plus', 'string',  'Nombre de la aplicación'),
+('registration_open',  '1',        'boolean', 'Permitir registro público'),
+('maintenance_mode',   '0',        'boolean', 'Modo mantenimiento'),
+('maintenance_message','',         'string',  'Mensaje de mantenimiento'),
+('default_plan',       'free',     'string',  'Plan por defecto en registro'),
+('trial_days',         '14',       'integer', 'Días de prueba al registrarse'),
+('max_file_upload_mb', '5',        'integer', 'Tamaño máximo de subida en MB'),
+('superadmin_email',   '',         'string',  'Email de notificaciones'),
+('smtp_host',          '',         'string',  'Servidor SMTP'),
+('smtp_port',          '587',      'integer', 'Puerto SMTP'),
+('smtp_user',          '',         'string',  'Usuario SMTP'),
+('smtp_password',      '',         'string',  'Contraseña SMTP cifrada'),
+('smtp_from_name',     'es21plus', 'string',  'Nombre remitente de correos')
+ON DUPLICATE KEY UPDATE setting_key = setting_key;

--- a/src/core/ActivityLogger.php
+++ b/src/core/ActivityLogger.php
@@ -7,7 +7,7 @@
  *
  * @package  Es21Plus\Core
  * @author   Carlos Vico
- * @version  1.0.0
+ * @version  1.1.0
  */
 
 require_once __DIR__ . '/../includes/Database.php';
@@ -17,28 +17,44 @@ class ActivityLogger
     /**
      * Registra una acción en activity_logs.
      *
-     * @param int         $businessId  ID del negocio.
+     * @param int         $businessId  ID del negocio (0 para acciones de superadmin global).
      * @param int         $employeeId  ID del empleado que realiza la acción.
      * @param string      $action      Descripción de la acción (e.g. "Creó producto").
      * @param string|null $entity      Entidad afectada (e.g. "producto").
      * @param int|null    $entityId    ID de la entidad afectada.
+     * @param array       $metadata    Datos adicionales antes/después para auditoría.
+     * @param bool        $isCritical  Si true, la acción se marca como crítica.
      * @return void
      */
     public static function log(
-        int    $businessId,
-        int    $employeeId,
-        string $action,
-        ?string $entity   = null,
-        ?int    $entityId = null
+        int     $businessId,
+        int     $employeeId,
+        string  $action,
+        ?string $entity     = null,
+        ?int    $entityId   = null,
+        array   $metadata   = [],
+        bool    $isCritical = false
     ): void {
         try {
-            $pdo  = Database::getInstance();
-            $ip   = $_SERVER['REMOTE_ADDR'] ?? null;
+            $pdo          = Database::getInstance();
+            $ip           = $_SERVER['REMOTE_ADDR'] ?? null;
+            $metadataJson = !empty($metadata) ? json_encode($metadata, JSON_UNESCAPED_UNICODE) : null;
+
             $stmt = $pdo->prepare(
-                'INSERT INTO activity_logs (business_id, employee_id, action, entity, entity_id, ip_address)
-                 VALUES (?, ?, ?, ?, ?, ?)'
+                'INSERT INTO activity_logs
+                    (business_id, employee_id, action, entity, entity_id, ip_address, metadata, is_critical)
+                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
             );
-            $stmt->execute([$businessId, $employeeId, $action, $entity, $entityId, $ip]);
+            $stmt->execute([
+                $businessId ?: null,
+                $employeeId ?: null,
+                $action,
+                $entity,
+                $entityId,
+                $ip,
+                $metadataJson,
+                $isCritical ? 1 : 0,
+            ]);
         } catch (\Throwable $e) {
             $logFile = __DIR__ . '/../../logs/activity_errors.log';
             @file_put_contents(

--- a/src/core/AuthController.php
+++ b/src/core/AuthController.php
@@ -3,16 +3,18 @@
  * Controlador de autenticación para empleados de empresa (multi-tenant).
  *
  * Gestiona el login con empresa + email + contraseña usando la tabla employees.
- * El login de superadmin usa /superadmin/login de forma independiente.
+ * El login de superadmin usa /login.php con la tabla usuarios de forma independiente.
+ * Incluye protección contra fuerza bruta vía SecurityService.
  *
  * @package  Es21Plus\Core
  * @author   Carlos Vico
- * @version  1.0.0
+ * @version  1.1.0
  */
 
 require_once __DIR__ . '/../includes/Database.php';
 require_once __DIR__ . '/../includes/AppException.php';
 require_once __DIR__ . '/Session.php';
+require_once __DIR__ . '/SecurityService.php';
 
 class AuthController
 {
@@ -24,55 +26,84 @@ class AuthController
     }
 
     /**
-     * Autentica un empleado de empresa.
+     * Autentica un empleado de empresa con protección contra fuerza bruta.
      *
      * @param string $business  Nombre o slug del negocio.
      * @param string $email     Email del empleado.
      * @param string $password  Contraseña en texto plano.
-     * @throws AppException En caso de credenciales incorrectas o empresa inactiva.
+     * @throws AppException En caso de bloqueo, credenciales incorrectas o empresa inactiva.
      * @return void — redirige a /index.php en éxito.
      */
     public function login(string $business, string $email, string $password): void
     {
         $business = trim($business);
         $email    = trim($email);
+        $ip       = $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0';
 
         if ($business === '' || $email === '' || $password === '') {
             throw new AppException('Empresa, email y contraseña son obligatorios.', 400);
         }
 
-        // 1. Buscar empresa activa
+        // 1. Verificar bloqueo por fuerza bruta
+        if (SecurityService::isIpBlocked($ip)) {
+            throw new AppException('Demasiados intentos. Espera 15 minutos.', 429);
+        }
+
+        // 2. Buscar empresa activa
         $stmt = $this->pdo->prepare(
             "SELECT * FROM businesses WHERE (name = ? OR slug = ?) AND is_active = 1 LIMIT 1"
         );
         $stmt->execute([$business, $business]);
         $biz = $stmt->fetch();
         if (!$biz) {
+            SecurityService::registerFailedAttempt($ip, $email);
             throw new AppException('Empresa no encontrada o inactiva.', 401);
         }
 
-        // 2. Buscar empleado activo en esa empresa
+        // 3. Buscar empleado activo en esa empresa
         $stmt = $this->pdo->prepare(
             "SELECT * FROM employees WHERE email = ? AND business_id = ? AND is_active = 1 LIMIT 1"
         );
         $stmt->execute([$email, $biz['id']]);
         $employee = $stmt->fetch();
         if (!$employee) {
+            SecurityService::registerFailedAttempt($ip, $email);
             throw new AppException('Credenciales incorrectas.', 401);
         }
 
-        // 3. Verificar contraseña
+        // 4. Verificar contraseña
         if (!password_verify($password, $employee['password'])) {
+            SecurityService::registerFailedAttempt($ip, $email);
             throw new AppException('Credenciales incorrectas.', 401);
         }
 
-        // 4. Crear sesión multi-tenant
+        // 5. Login correcto: limpiar intentos y crear sesión
+        SecurityService::clearAttempts($ip);
         Session::setBusinessUser($employee, $biz);
+        SecurityService::logSession('employee', (int)$employee['id'], (int)$biz['id'], 'login');
 
         // Registrar último login
         $this->pdo->prepare(
             "UPDATE employees SET last_login = NOW() WHERE id = ?"
         )->execute([$employee['id']]);
+    }
+
+    /**
+     * Registra el cierre de sesión de un empleado en session_logs.
+     *
+     * @return void
+     */
+    public static function logout(): void
+    {
+        if (session_status() === PHP_SESSION_NONE) {
+            session_start();
+        }
+        $userId     = (int)($_SESSION['user_id']    ?? 0);
+        $businessId = (int)($_SESSION['business_id'] ?? 0);
+
+        if ($userId > 0) {
+            SecurityService::logSession('employee', $userId, $businessId ?: null, 'logout');
+        }
     }
 
     /**

--- a/src/core/Mailer.php
+++ b/src/core/Mailer.php
@@ -2,13 +2,15 @@
 /**
  * Servicio de envío de email centralizado via PHPMailer.
  *
- * Lee configuración SMTP desde variables de entorno.
- * Si el envío falla, registra en logs/mail_errors.log y lanza excepción
- * controlada — nunca interrumpe el flujo principal si el llamador captura.
+ * Prioridad de configuración SMTP:
+ *   1. Tabla system_settings (Settings::get)
+ *   2. Variables de entorno MAIL_* / SMTP_*
+ *
+ * La contraseña SMTP se guarda cifrada en BD (AES-256-CBC con APP_KEY).
  *
  * @package  Es21Plus\Core
  * @author   Carlos Vico
- * @version  1.0.0
+ * @version  1.1.0
  */
 
 use PHPMailer\PHPMailer\PHPMailer;
@@ -22,7 +24,7 @@ class Mailer
      * @param  string $to       Dirección de destino.
      * @param  string $subject  Asunto del correo.
      * @param  string $bodyHtml Cuerpo en HTML.
-     * @throws \RuntimeException Si el envío falla (para que el llamador pueda manejarla).
+     * @throws \RuntimeException Si el envío falla.
      * @return bool True si se envió correctamente.
      */
     public static function send(string $to, string $subject, string $bodyHtml): bool
@@ -34,14 +36,26 @@ class Mailer
         }
         require_once $autoload;
 
-        $host     = getenv('MAIL_HOST')      ?: getenv('SMTP_HOST')      ?: '';
-        $port     = (int)(getenv('MAIL_PORT')     ?: getenv('SMTP_PORT')     ?: 587);
-        $user     = getenv('MAIL_USERNAME')  ?: getenv('SMTP_USER')      ?: '';
-        $pass     = getenv('MAIL_PASSWORD')  ?: getenv('SMTP_PASS')      ?: '';
-        $fromName = getenv('MAIL_FROM_NAME') ?: getenv('SMTP_FROM_NAME') ?: 'es21plus';
+        // Cargar Settings solo si está disponible (evitar error si DB no levantó aún)
+        $settingsHost = $settingsUser = $settingsPass = $settingsPort = $settingsFromName = '';
+        if (class_exists('Settings')) {
+            $settingsHost     = Settings::get('smtp_host',      '');
+            $settingsUser     = Settings::get('smtp_user',      '');
+            $settingsPass     = Settings::get('smtp_password',  '');
+            $settingsPort     = Settings::get('smtp_port',      '');
+            $settingsFromName = Settings::get('smtp_from_name', '');
+        }
+
+        $host     = $settingsHost     ?: (getenv('MAIL_HOST')      ?: getenv('SMTP_HOST')      ?: '');
+        $port     = (int)(($settingsPort ?: (getenv('MAIL_PORT')   ?: getenv('SMTP_PORT')      ?: 587)));
+        $user     = $settingsUser     ?: (getenv('MAIL_USERNAME')  ?: getenv('SMTP_USER')      ?: '');
+        $pass     = $settingsPass
+            ? self::decryptSmtpPassword($settingsPass)
+            : (getenv('MAIL_PASSWORD') ?: getenv('SMTP_PASS') ?: '');
+        $fromName = $settingsFromName ?: (getenv('MAIL_FROM_NAME') ?: getenv('SMTP_FROM_NAME') ?: 'es21plus');
 
         if (!$host || !$user) {
-            self::logError("SMTP no configurado (MAIL_HOST o MAIL_USERNAME vacío).");
+            self::logError("SMTP no configurado (host o usuario vacío).");
             throw new \RuntimeException('SMTP no configurado.');
         }
 
@@ -73,11 +87,52 @@ class Mailer
     }
 
     /**
-     * Escribe un mensaje en logs/mail_errors.log.
+     * Cifra una contraseña SMTP con AES-256-CBC usando APP_KEY del entorno.
      *
-     * @param string $message
-     * @return void
+     * @param string $password Contraseña en texto plano.
+     * @return string Contraseña cifrada en base64, o el valor original si no hay APP_KEY.
      */
+    public static function encryptSmtpPassword(string $password): string
+    {
+        $appKey = getenv('APP_KEY');
+        if (!$appKey || $password === '') {
+            return $password;
+        }
+        try {
+            $iv  = random_bytes(16);
+            $enc = openssl_encrypt($password, 'AES-256-CBC', $appKey, OPENSSL_RAW_DATA, $iv);
+            return base64_encode($iv . $enc);
+        } catch (\Throwable) {
+            return $password;
+        }
+    }
+
+    /**
+     * Descifra una contraseña SMTP cifrada con encryptSmtpPassword.
+     *
+     * @param string $encrypted
+     * @return string Contraseña descifrada, o el valor original si no se puede descifrar.
+     */
+    private static function decryptSmtpPassword(string $encrypted): string
+    {
+        $appKey = getenv('APP_KEY');
+        if (!$appKey || $encrypted === '') {
+            return $encrypted;
+        }
+        try {
+            $data = base64_decode($encrypted, true);
+            if ($data === false || strlen($data) <= 16) {
+                return $encrypted;
+            }
+            $iv  = substr($data, 0, 16);
+            $enc = substr($data, 16);
+            $dec = openssl_decrypt($enc, 'AES-256-CBC', $appKey, OPENSSL_RAW_DATA, $iv);
+            return ($dec !== false) ? $dec : $encrypted;
+        } catch (\Throwable) {
+            return $encrypted;
+        }
+    }
+
     private static function logError(string $message): void
     {
         $logDir  = __DIR__ . '/../../logs';
@@ -85,7 +140,6 @@ class Mailer
         if (!is_dir($logDir)) {
             @mkdir($logDir, 0755, true);
         }
-        $line = '[' . date('Y-m-d H:i:s') . '] ' . $message . PHP_EOL;
-        @file_put_contents($logFile, $line, FILE_APPEND | LOCK_EX);
+        @file_put_contents($logFile, '[' . date('Y-m-d H:i:s') . '] ' . $message . PHP_EOL, FILE_APPEND | LOCK_EX);
     }
 }

--- a/src/core/NotificationService.php
+++ b/src/core/NotificationService.php
@@ -1,0 +1,141 @@
+<?php
+/**
+ * Servicio de notificaciones internas para el superadmin.
+ *
+ * Todas las inserciones y consultas son tolerantes a fallos;
+ * nunca interrumpen el flujo principal si la BD no está disponible.
+ *
+ * @package  Es21Plus\Core
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../includes/Database.php';
+
+class NotificationService
+{
+    /**
+     * Crea una notificación para el superadmin.
+     *
+     * @param string      $type  'new_business'|'plan_expiring'|'critical_ticket'|'new_message'|'business_deactivated'
+     * @param string      $title Título breve.
+     * @param string      $body  Cuerpo descriptivo.
+     * @param string|null $link  URL relativa de acción directa.
+     * @return void
+     */
+    public static function notify(
+        string  $type,
+        string  $title,
+        string  $body,
+        ?string $link = null
+    ): void {
+        try {
+            $pdo = Database::getInstance();
+            $pdo->prepare(
+                'INSERT INTO superadmin_notifications (type, title, body, link)
+                 VALUES (?, ?, ?, ?)'
+            )->execute([$type, $title, $body, $link]);
+        } catch (\Throwable) {
+            // No interrumpir flujo principal
+        }
+    }
+
+    /**
+     * Devuelve el conteo de notificaciones no leídas.
+     *
+     * @return int
+     */
+    public static function unreadCount(): int
+    {
+        try {
+            $pdo = Database::getInstance();
+            return (int)$pdo->query(
+                'SELECT COUNT(*) FROM superadmin_notifications WHERE is_read = 0'
+            )->fetchColumn();
+        } catch (\Throwable) {
+            return 0;
+        }
+    }
+
+    /**
+     * Devuelve las últimas N notificaciones no leídas, más recientes primero.
+     *
+     * @param int $limit
+     * @return array
+     */
+    public static function getUnread(int $limit = 10): array
+    {
+        try {
+            $pdo  = Database::getInstance();
+            $stmt = $pdo->prepare(
+                'SELECT * FROM superadmin_notifications
+                 WHERE is_read = 0
+                 ORDER BY created_at DESC
+                 LIMIT ?'
+            );
+            $stmt->execute([$limit]);
+            return $stmt->fetchAll();
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * Marca todas las notificaciones no leídas como leídas.
+     *
+     * @return void
+     */
+    public static function markAllRead(): void
+    {
+        try {
+            $pdo = Database::getInstance();
+            $pdo->exec('UPDATE superadmin_notifications SET is_read = 1 WHERE is_read = 0');
+        } catch (\Throwable) {
+            // No interrumpir flujo principal
+        }
+    }
+
+    /**
+     * Verifica empresas con plan a punto de vencer (< 7 días) y crea
+     * notificaciones de tipo 'plan_expiring' si no se creó ya una hoy.
+     *
+     * @return void
+     */
+    public static function checkExpiringPlans(): void
+    {
+        try {
+            $pdo  = Database::getInstance();
+            $stmt = $pdo->query(
+                "SELECT id, name, plan_expires_at
+                 FROM businesses
+                 WHERE is_active = 1
+                   AND plan_expires_at IS NOT NULL
+                   AND plan_expires_at > NOW()
+                   AND plan_expires_at <= DATE_ADD(NOW(), INTERVAL 7 DAY)"
+            );
+            foreach ($stmt->fetchAll() as $biz) {
+                $linkPattern = '%id=' . $biz['id'];
+                $exists = $pdo->prepare(
+                    "SELECT COUNT(*) FROM superadmin_notifications
+                     WHERE type = 'plan_expiring'
+                       AND link LIKE ?
+                       AND created_at >= CURDATE()"
+                );
+                $exists->execute([$linkPattern]);
+                if ((int)$exists->fetchColumn() > 0) {
+                    continue;
+                }
+
+                $dias = (int)ceil((strtotime($biz['plan_expires_at']) - time()) / 86400);
+                self::notify(
+                    'plan_expiring',
+                    'Plan próximo a vencer: ' . $biz['name'],
+                    "El plan de {$biz['name']} vence en {$dias} día(s) ({$biz['plan_expires_at']}).",
+                    '/superadmin/businesses.php?action=edit&id=' . $biz['id']
+                );
+            }
+        } catch (\Throwable) {
+            // No interrumpir flujo principal
+        }
+    }
+}

--- a/src/core/SecurityService.php
+++ b/src/core/SecurityService.php
@@ -1,0 +1,172 @@
+<?php
+/**
+ * Servicio de seguridad: protección fuerza bruta y registro de sesiones.
+ *
+ * Métodos estáticos sin dependencias de constructor para usarse
+ * en cualquier punto del flujo de autenticación.
+ *
+ * @package  Es21Plus\Core
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../includes/Database.php';
+
+class SecurityService
+{
+    private const MAX_ATTEMPTS    = 5;
+    private const WINDOW_MINUTES  = 15;
+
+    /**
+     * Verifica si una IP está bloqueada por exceso de intentos fallidos.
+     *
+     * @param string $ip
+     * @return bool
+     */
+    public static function isIpBlocked(string $ip): bool
+    {
+        try {
+            $pdo  = Database::getInstance();
+            $stmt = $pdo->prepare(
+                "SELECT COUNT(*) FROM login_attempts
+                 WHERE ip_address = ?
+                   AND attempted_at > DATE_SUB(NOW(), INTERVAL ? MINUTE)"
+            );
+            $stmt->execute([$ip, self::WINDOW_MINUTES]);
+            return (int)$stmt->fetchColumn() >= self::MAX_ATTEMPTS;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * Registra un intento de login fallido para la IP dada.
+     *
+     * @param string $ip
+     * @param string $email
+     * @return void
+     */
+    public static function registerFailedAttempt(string $ip, string $email): void
+    {
+        try {
+            $pdo = Database::getInstance();
+            $pdo->prepare(
+                'INSERT INTO login_attempts (ip_address, email) VALUES (?, ?)'
+            )->execute([$ip, $email]);
+        } catch (\Throwable) {
+            // No interrumpir flujo principal
+        }
+    }
+
+    /**
+     * Elimina todos los intentos de login registrados para una IP.
+     *
+     * @param string $ip
+     * @return void
+     */
+    public static function clearAttempts(string $ip): void
+    {
+        try {
+            $pdo = Database::getInstance();
+            $pdo->prepare('DELETE FROM login_attempts WHERE ip_address = ?')->execute([$ip]);
+        } catch (\Throwable) {
+            // No interrumpir flujo principal
+        }
+    }
+
+    /**
+     * Registra un evento de sesión (login / logout / expired).
+     *
+     * @param string   $userType   'superadmin' | 'employee'
+     * @param int      $userId     ID del usuario o empleado.
+     * @param int|null $businessId ID del negocio (null para superadmin).
+     * @param string   $action     'login' | 'logout' | 'expired'
+     * @return void
+     */
+    public static function logSession(
+        string $userType,
+        int    $userId,
+        ?int   $businessId,
+        string $action
+    ): void {
+        try {
+            $pdo = Database::getInstance();
+            $ip  = $_SERVER['REMOTE_ADDR'] ?? null;
+            $ua  = isset($_SERVER['HTTP_USER_AGENT'])
+                ? substr($_SERVER['HTTP_USER_AGENT'], 0, 500)
+                : null;
+            $pdo->prepare(
+                'INSERT INTO session_logs
+                    (user_type, user_id, business_id, ip_address, user_agent, action)
+                 VALUES (?, ?, ?, ?, ?, ?)'
+            )->execute([$userType, $userId, $businessId, $ip, $ua, $action]);
+        } catch (\Throwable) {
+            // No interrumpir flujo principal
+        }
+    }
+
+    /**
+     * Devuelve las IPs bloqueadas actualmente con su conteo de intentos.
+     *
+     * @return array
+     */
+    public static function getBlockedIps(): array
+    {
+        try {
+            $pdo  = Database::getInstance();
+            $stmt = $pdo->prepare(
+                "SELECT ip_address, COUNT(*) AS intentos,
+                        MIN(attempted_at) AS primer_intento,
+                        MAX(attempted_at) AS ultimo_intento
+                 FROM login_attempts
+                 WHERE attempted_at > DATE_SUB(NOW(), INTERVAL ? MINUTE)
+                 GROUP BY ip_address
+                 HAVING COUNT(*) >= ?
+                 ORDER BY intentos DESC"
+            );
+            $stmt->execute([self::WINDOW_MINUTES, self::MAX_ATTEMPTS]);
+            return $stmt->fetchAll();
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+
+    /**
+     * Devuelve las últimas N sesiones registradas con filtros opcionales.
+     *
+     * @param int         $limit
+     * @param string|null $userType
+     * @param string|null $fechaDesde  'Y-m-d'
+     * @return array
+     */
+    public static function getSessionLogs(
+        int     $limit    = 50,
+        ?string $userType = null,
+        ?string $fechaDesde = null
+    ): array {
+        try {
+            $pdo    = Database::getInstance();
+            $where  = ['1=1'];
+            $params = [];
+
+            if ($userType) {
+                $where[]  = 'user_type = ?';
+                $params[] = $userType;
+            }
+            if ($fechaDesde) {
+                $where[]  = 'created_at >= ?';
+                $params[] = $fechaDesde . ' 00:00:00';
+            }
+
+            $params[] = $limit;
+            $stmt = $pdo->prepare(
+                'SELECT * FROM session_logs WHERE ' . implode(' AND ', $where)
+                . ' ORDER BY created_at DESC LIMIT ?'
+            );
+            $stmt->execute($params);
+            return $stmt->fetchAll();
+        } catch (\Throwable) {
+            return [];
+        }
+    }
+}

--- a/src/core/Settings.php
+++ b/src/core/Settings.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Acceso centralizado a la configuración del sistema almacenada en BD.
+ *
+ * Usa caché estática para evitar consultas repetidas en la misma petición.
+ * Los valores de la tabla system_settings tienen prioridad sobre los .env
+ * cuando están rellenados.
+ *
+ * @package  Es21Plus\Core
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../includes/Database.php';
+
+class Settings
+{
+    /** @var array<string,string>|null Caché estática; null = sin cargar */
+    private static ?array $cache = null;
+
+    /**
+     * Obtiene el valor de una clave de configuración.
+     *
+     * @param string $key
+     * @param mixed  $default Valor por defecto si la clave no existe o está vacía.
+     * @return mixed
+     */
+    public static function get(string $key, mixed $default = null): mixed
+    {
+        self::loadAll();
+        $val = self::$cache[$key] ?? null;
+        return ($val !== null && $val !== '') ? $val : $default;
+    }
+
+    /**
+     * Actualiza el valor de una clave e invalida la caché estática.
+     *
+     * @param string $key
+     * @param string $value
+     * @return void
+     */
+    public static function set(string $key, string $value): void
+    {
+        try {
+            $pdo = Database::getInstance();
+            $pdo->prepare(
+                'UPDATE system_settings SET value = ? WHERE setting_key = ?'
+            )->execute([$value, $key]);
+            self::$cache = null;
+        } catch (\Throwable) {
+            // No interrumpir flujo principal
+        }
+    }
+
+    /**
+     * Devuelve todas las configuraciones como array asociativo clave → valor.
+     *
+     * @return array<string,string>
+     */
+    public static function all(): array
+    {
+        self::loadAll();
+        return self::$cache ?? [];
+    }
+
+    /**
+     * Invalida la caché; fuerza recarga en el próximo get/all.
+     *
+     * @return void
+     */
+    public static function flush(): void
+    {
+        self::$cache = null;
+    }
+
+    private static function loadAll(): void
+    {
+        if (self::$cache !== null) {
+            return;
+        }
+        try {
+            $pdo        = Database::getInstance();
+            $rows       = $pdo->query('SELECT setting_key, value FROM system_settings')->fetchAll();
+            self::$cache = array_column($rows, 'value', 'setting_key');
+        } catch (\Throwable) {
+            self::$cache = [];
+        }
+    }
+}

--- a/src/logout.php
+++ b/src/logout.php
@@ -2,13 +2,32 @@
 /**
  * Cierre de sesión del sistema.
  *
+ * Registra el logout en session_logs si es un empleado de empresa,
+ * luego destruye la sesión completamente.
+ *
  * @package  Es21Plus
  * @author   Carlitos6712
  * @author   miguelrechefdez
- * @version  1.0.0
+ * @version  1.1.0
  */
 if (session_status() === PHP_SESSION_NONE) {
     session_start();
+}
+
+// Registrar logout de empleado de empresa
+if (isset($_SESSION['user_id'], $_SESSION['business_id'])) {
+    try {
+        require_once __DIR__ . '/includes/Database.php';
+        require_once __DIR__ . '/core/SecurityService.php';
+        SecurityService::logSession(
+            'employee',
+            (int)$_SESSION['user_id'],
+            (int)$_SESSION['business_id'],
+            'logout'
+        );
+    } catch (\Throwable) {
+        // No interrumpir el logout
+    }
 }
 
 session_unset();

--- a/src/middleware/BusinessMiddleware.php
+++ b/src/middleware/BusinessMiddleware.php
@@ -7,10 +7,11 @@
  *   2. Negocio activo en BD
  *   3. Plan no vencido
  *   4. Rol válido (admin | employee, nunca superadmin)
+ *   5. Modo mantenimiento (Settings::get) — bloquea a empleados, no al superadmin
  *
  * @package  Es21Plus\Middleware
  * @author   Carlos Vico
- * @version  2.0.0
+ * @version  2.1.0
  */
 
 require_once __DIR__ . '/../includes/Database.php';
@@ -21,9 +22,7 @@ class BusinessMiddleware
     /**
      * Aplica todas las verificaciones de acceso al panel de empresa.
      *
-     * Llama exit si el acceso no está permitido.
-     *
-     * @return array Datos del negocio verificado (para uso en la vista).
+     * @return array Datos del negocio verificado.
      */
     public static function require(): array
     {
@@ -81,6 +80,23 @@ class BusinessMiddleware
             http_response_code(402);
             include __DIR__ . '/../superadmin/views/plan_expired.php';
             exit;
+        }
+
+        // 6. Modo mantenimiento — bloquea a empleados; superadmin pasa siempre
+        if (!Session::isSuperadmin()) {
+            try {
+                if (!class_exists('Settings')) {
+                    require_once __DIR__ . '/../core/Settings.php';
+                }
+                if (Settings::get('maintenance_mode') === '1') {
+                    $maintenanceMessage = Settings::get('maintenance_message', '');
+                    http_response_code(503);
+                    include __DIR__ . '/../views/maintenance.php';
+                    exit;
+                }
+            } catch (\Throwable) {
+                // Si Settings no está disponible, no bloqueamos
+            }
         }
 
         return $business;

--- a/src/superadmin/activity/recent.php
+++ b/src/superadmin/activity/recent.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Endpoint JSON: últimas 15 actividades para el feed del dashboard.
+ *
+ * GET /superadmin/activity/recent.php
+ *
+ * @package  Es21Plus\Superadmin\Activity
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../controllers/DashboardController.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+
+SuperadminMiddleware::require();
+
+$ctrl  = new DashboardController();
+$items = $ctrl->actividadReciente();
+
+// Añadir tiempo relativo
+$now = time();
+foreach ($items as &$item) {
+    $diff = $now - strtotime($item['created_at']);
+    if ($diff < 60) {
+        $item['tiempo_relativo'] = 'hace un momento';
+    } elseif ($diff < 3600) {
+        $item['tiempo_relativo'] = 'hace ' . floor($diff / 60) . ' minuto(s)';
+    } elseif ($diff < 86400) {
+        $item['tiempo_relativo'] = 'hace ' . floor($diff / 3600) . ' hora(s)';
+    } else {
+        $item['tiempo_relativo'] = 'hace ' . floor($diff / 86400) . ' día(s)';
+    }
+}
+unset($item);
+
+echo json_encode(['success' => true, 'data' => $items]);

--- a/src/superadmin/controllers/BusinessController.php
+++ b/src/superadmin/controllers/BusinessController.php
@@ -4,7 +4,7 @@
  *
  * @package  Es21Plus\Superadmin\Controllers
  * @author   Carlos Vico
- * @version  1.0.0
+ * @version  1.1.0
  */
 
 require_once __DIR__ . '/../../includes/Database.php';
@@ -12,6 +12,8 @@ require_once __DIR__ . '/../../includes/AppException.php';
 require_once __DIR__ . '/../../core/Mailer.php';
 require_once __DIR__ . '/../../core/Session.php';
 require_once __DIR__ . '/../../core/BusinessSeeder.php';
+require_once __DIR__ . '/../../core/ActivityLogger.php';
+require_once __DIR__ . '/../../core/NotificationService.php';
 
 class BusinessController
 {
@@ -35,11 +37,7 @@ class BusinessController
         $offset  = ($page - 1) * $perPage;
         $search  = '%' . $q . '%';
 
-        $total = (int)$this->pdo->prepare(
-            'SELECT COUNT(*) FROM businesses WHERE name LIKE ?'
-        )->execute([$search]) && ($cnt = $this->pdo->prepare(
-            'SELECT COUNT(*) FROM businesses WHERE name LIKE ?'
-        ));
+        $cnt = $this->pdo->prepare('SELECT COUNT(*) FROM businesses WHERE name LIKE ?');
         $cnt->execute([$search]);
         $total = (int)$cnt->fetchColumn();
 
@@ -94,12 +92,6 @@ class BusinessController
         $stmt->execute([$id]);
         $business['movimientos'] = $stmt->fetchAll();
 
-        $business['total_productos'] = (int)$this->pdo->prepare(
-            'SELECT COUNT(*) FROM productos WHERE business_id = ? AND deleted_at IS NULL'
-        )->execute([$id]) ? $this->pdo->prepare(
-            'SELECT COUNT(*) FROM productos WHERE business_id = ? AND deleted_at IS NULL'
-        )->execute([$id]) && 0 : 0;
-
         $cntProd = $this->pdo->prepare('SELECT COUNT(*) FROM productos WHERE business_id = ? AND deleted_at IS NULL');
         $cntProd->execute([$id]);
         $business['total_productos'] = (int)$cntProd->fetchColumn();
@@ -148,18 +140,26 @@ class BusinessController
         $plainPassword = $this->generarPassword();
         $this->crearEmpleadoAdmin($businessId, $name, $email, $plainPassword);
 
-        // Datos de demostración para que el panel no arranque vacío
         BusinessSeeder::seed($businessId);
 
         if ($email) {
             $this->enviarBienvenida($email, $name, $email, $plainPassword);
         }
 
+        // Notificar nuevo negocio al superadmin
+        NotificationService::notify(
+            'new_business',
+            'Nuevo negocio registrado: ' . $name,
+            "Se ha creado el negocio \"{$name}\" con plan " . ($data['plan'] ?? 'free') . '.',
+            '/superadmin/businesses.php?action=show&id=' . $businessId
+        );
+
         return $businessId;
     }
 
     /**
      * Actualiza los datos de un negocio.
+     * Si cambia el plan, registra acción crítica en activity_logs.
      *
      * @param int   $id
      * @param array $data
@@ -172,6 +172,11 @@ class BusinessController
         if (!$name) {
             throw new AppException('El nombre es obligatorio.', 422);
         }
+
+        // Capturar estado anterior para auditoría
+        $antes = $this->pdo->prepare('SELECT name, plan, plan_expires_at FROM businesses WHERE id = ?');
+        $antes->execute([$id]);
+        $anterior = $antes->fetch();
 
         $stmt = $this->pdo->prepare(
             'UPDATE businesses SET name=?, contact_email=?, phone=?, address=?, plan=?, plan_expires_at=?
@@ -186,40 +191,67 @@ class BusinessController
             ($data['plan_expires_at'] ?? '') ?: null,
             $id,
         ]);
+
+        // Log crítico si cambia el plan
+        if ($anterior && $anterior['plan'] !== ($data['plan'] ?? 'free')) {
+            $saId = (int)($_SESSION['usuario_id'] ?? 0);
+            ActivityLogger::log(
+                $id,
+                $saId,
+                'Cambió el plan de ' . $anterior['plan'] . ' a ' . ($data['plan'] ?? 'free'),
+                'business',
+                $id,
+                [
+                    'antes'   => ['plan' => $anterior['plan'], 'plan_expires_at' => $anterior['plan_expires_at']],
+                    'despues' => ['plan' => $data['plan'] ?? 'free', 'plan_expires_at' => $data['plan_expires_at'] ?? null],
+                ],
+                true
+            );
+        }
     }
 
     /**
      * Activa o desactiva un negocio.
+     * Desactivar registra acción crítica y crea notificación.
      *
      * @param int $id
      * @return bool Nuevo estado is_active.
      */
     public function toggle(int $id): bool
     {
-        $stmt = $this->pdo->prepare('SELECT is_active FROM businesses WHERE id = ?');
+        $stmt = $this->pdo->prepare('SELECT is_active, name FROM businesses WHERE id = ?');
         $stmt->execute([$id]);
-        $current = (int)$stmt->fetchColumn();
-        $nuevo = $current === 1 ? 0 : 1;
+        $row     = $stmt->fetch();
+        $current = (int)($row['is_active'] ?? 1);
+        $nuevo   = $current === 1 ? 0 : 1;
 
         $this->pdo->prepare('UPDATE businesses SET is_active = ? WHERE id = ?')->execute([$nuevo, $id]);
+
+        if ($nuevo === 0) {
+            $saId = (int)($_SESSION['usuario_id'] ?? 0);
+            ActivityLogger::log(
+                $id,
+                $saId,
+                'Desactivó el negocio "' . ($row['name'] ?? '') . '"',
+                'business',
+                $id,
+                ['antes' => ['is_active' => 1], 'despues' => ['is_active' => 0]],
+                true
+            );
+            NotificationService::notify(
+                'business_deactivated',
+                'Negocio desactivado: ' . ($row['name'] ?? ''),
+                'El negocio "' . ($row['name'] ?? '') . '" ha sido desactivado por el superadmin.',
+                '/superadmin/businesses.php?action=show&id=' . $id
+            );
+        }
+
         return (bool)$nuevo;
     }
 
     /**
      * Inicia una sesión impersonada como administrador de la empresa.
-     *
-     * Guarda los datos del superadmin en sesión para poder volver.
-     * El superadmin accede al panel de empresa como si fuera su admin.
-     *
-     * @param int $id ID del negocio.
-     * @throws AppException Si el negocio no existe o no tiene empleado admin.
-     * @return void — redirige a /index.php
-     */
-    /**
-     * Inicia una sesión impersonada como administrador de la empresa.
-     *
-     * El superadmin accede al panel de empresa como si fuera su admin.
-     * Guarda las claves de retorno en sesión para poder volver.
+     * Registra acción crítica en activity_logs.
      *
      * @param int $id ID del negocio.
      * @throws AppException Si el negocio no existe o no tiene empleado admin.
@@ -244,7 +276,17 @@ class BusinessController
             throw new AppException('Este negocio no tiene empleados admin activos.', 409);
         }
 
-        // Capturar datos del superadmin antes de sobreescribir la sesión
+        $saId = (int)($_SESSION['usuario_id'] ?? 0);
+        ActivityLogger::log(
+            $id,
+            $saId,
+            'Acceso impersonado al negocio "' . $business['name'] . '"',
+            'business',
+            $id,
+            ['superadmin_id' => $saId, 'employee_id' => (int)$employee['id']],
+            true
+        );
+
         $saReturn = [
             'usuario_id'       => $_SESSION['usuario_id']       ?? null,
             'usuario_nombre'   => $_SESSION['usuario_nombre']   ?? '',
@@ -252,10 +294,8 @@ class BusinessController
             'rol'              => $_SESSION['rol']              ?? 'superadmin',
         ];
 
-        // Establecer sesión de empresa (setBusinessUser no hace session_unset)
         Session::setBusinessUser($employee, $business);
 
-        // Añadir marcadores de impersonación + datos de retorno
         $_SESSION['superadmin_impersonating']   = true;
         $_SESSION['superadmin_return_uid']      = $saReturn['usuario_id'];
         $_SESSION['superadmin_return_nombre']   = $saReturn['usuario_nombre'];
@@ -270,8 +310,7 @@ class BusinessController
         $slug = strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $name), '-'));
         $base = $slug;
         $i    = 1;
-        while ($this->pdo->prepare('SELECT id FROM businesses WHERE slug = ?')->execute([$slug])
-               && $this->pdo->prepare('SELECT id FROM businesses WHERE slug = ?')->execute([$slug])) {
+        while (true) {
             $check = $this->pdo->prepare('SELECT COUNT(*) FROM businesses WHERE slug = ?');
             $check->execute([$slug]);
             if (!(int)$check->fetchColumn()) break;

--- a/src/superadmin/controllers/DashboardController.php
+++ b/src/superadmin/controllers/DashboardController.php
@@ -2,9 +2,11 @@
 /**
  * Controlador del dashboard global de superadmin.
  *
+ * Incluye KPIs con variación mensual y datos para gráficos Chart.js.
+ *
  * @package  Es21Plus\Superadmin\Controllers
  * @author   Carlos Vico
- * @version  1.0.0
+ * @version  1.1.0
  */
 
 require_once __DIR__ . '/../../includes/Database.php';
@@ -19,30 +21,98 @@ class DashboardController
     }
 
     /**
-     * Devuelve todas las métricas para el dashboard.
+     * Devuelve todas las métricas y datos para el dashboard.
      *
-     * @return array{
-     *   totalNegocios: int,
-     *   totalEmpleados: int,
-     *   mensajesSinLeer: int,
-     *   movimientosHoy: int,
-     *   movimientosPorNegocio: array,
-     *   ultimosMensajes: array,
-     *   ultimaActividad: array
-     * }
+     * @return array
      */
     public function index(): array
     {
         return [
-            'totalNegocios'          => $this->contarNegociosActivos(),
-            'totalEmpleados'         => $this->contarEmpleadosActivos(),
-            'mensajesSinLeer'        => $this->contarMensajesSinLeer(),
-            'movimientosHoy'         => $this->contarMovimientosHoy(),
-            'movimientosPorNegocio'  => $this->movimientosUltimos7Dias(),
-            'ultimosMensajes'        => $this->ultimosMensajesSinLeer(),
-            'ultimaActividad'        => $this->ultimaActividad(),
+            'kpis'              => $this->buildKpis(),
+            'negociosPorMes'    => $this->negociosPorMes12(),
+            'topMovimientos'    => $this->topMovimientos30Dias(),
+            'planesDistrib'     => $this->distribucionPlanes(),
+            'mensajesPorSemana' => $this->mensajesPorSemana8(),
+            'resumenNegocios'   => $this->resumenNegocios(),
+            'ultimosMensajes'   => $this->ultimosMensajesSinLeer(),
+            'ultimaActividad'   => $this->ultimaActividad(),
+            // backward compat para sidebar badge
+            'mensajesSinLeer'   => $this->contarMensajesSinLeer(),
         ];
     }
+
+    /**
+     * Devuelve los últimos 15 eventos de actividad como array listo para JSON.
+     *
+     * @return array
+     */
+    public function actividadReciente(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT al.id, al.action, al.created_at, al.entity, al.is_critical,
+                    b.name AS negocio, e.name AS empleado
+             FROM activity_logs al
+             LEFT JOIN businesses b ON b.id = al.business_id
+             LEFT JOIN employees  e ON e.id = al.employee_id
+             ORDER BY al.created_at DESC
+             LIMIT 15"
+        );
+        return $stmt->fetchAll();
+    }
+
+    // ── KPIs con variación ────────────────────────────────────────────────────
+
+    private function buildKpis(): array
+    {
+        $negActual  = $this->contarNegociosRegistradosMes(0);
+        $negPrev    = $this->contarNegociosRegistradosMes(1);
+        $empActual  = $this->contarEmpleadosCreadosMes(0);
+        $empPrev    = $this->contarEmpleadosCreadosMes(1);
+        $movActual  = $this->contarMovimientosMes(0);
+        $movPrev    = $this->contarMovimientosMes(1);
+        $msgActual  = $this->contarMensajesMes(0);
+        $msgPrev    = $this->contarMensajesMes(1);
+
+        return [
+            'negocios' => [
+                'value'     => $this->contarNegociosActivos(),
+                'mes'       => $negActual,
+                'variation' => $this->variacion($negActual, $negPrev),
+            ],
+            'empleados' => [
+                'value'     => $this->contarEmpleadosActivos(),
+                'mes'       => $empActual,
+                'variation' => $this->variacion($empActual, $empPrev),
+            ],
+            'movimientos' => [
+                'value'     => $movActual,
+                'variation' => $this->variacion($movActual, $movPrev),
+            ],
+            'mensajes' => [
+                'value'     => $this->contarMensajesSinLeer(),
+                'mes'       => $msgActual,
+                'variation' => $this->variacion($msgActual, $msgPrev),
+            ],
+        ];
+    }
+
+    /**
+     * Calcula la variación porcentual entre el valor actual y el anterior.
+     * Devuelve ['pct' => float, 'dir' => 'up'|'down'|'same'].
+     */
+    private function variacion(int $actual, int $anterior): array
+    {
+        if ($anterior === 0) {
+            return ['pct' => $actual > 0 ? 100.0 : 0.0, 'dir' => $actual > 0 ? 'up' : 'same'];
+        }
+        $pct = round((($actual - $anterior) / $anterior) * 100, 1);
+        return [
+            'pct' => abs($pct),
+            'dir' => $pct > 0 ? 'up' : ($pct < 0 ? 'down' : 'same'),
+        ];
+    }
+
+    // ── Contadores simples ────────────────────────────────────────────────────
 
     private function contarNegociosActivos(): int
     {
@@ -59,26 +129,142 @@ class DashboardController
         return (int)$this->pdo->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
     }
 
-    private function contarMovimientosHoy(): int
+    /**
+     * Negocios registrados en el mes N meses atrás (0 = este mes, 1 = mes anterior).
+     */
+    private function contarNegociosRegistradosMes(int $mesesAtras): int
     {
-        $stmt = $this->pdo->query('SELECT COUNT(*) FROM movimientos WHERE DATE(fecha) = CURDATE()');
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM businesses
+             WHERE YEAR(created_at)  = YEAR(DATE_SUB(NOW(),  INTERVAL ? MONTH))
+               AND MONTH(created_at) = MONTH(DATE_SUB(NOW(), INTERVAL ? MONTH))"
+        );
+        $stmt->execute([$mesesAtras, $mesesAtras]);
         return (int)$stmt->fetchColumn();
     }
 
-    private function movimientosUltimos7Dias(): array
+    private function contarEmpleadosCreadosMes(int $mesesAtras): int
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM employees
+             WHERE YEAR(created_at)  = YEAR(DATE_SUB(NOW(),  INTERVAL ? MONTH))
+               AND MONTH(created_at) = MONTH(DATE_SUB(NOW(), INTERVAL ? MONTH))"
+        );
+        $stmt->execute([$mesesAtras, $mesesAtras]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function contarMovimientosMes(int $mesesAtras): int
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM movimientos
+             WHERE YEAR(fecha)  = YEAR(DATE_SUB(NOW(),  INTERVAL ? MONTH))
+               AND MONTH(fecha) = MONTH(DATE_SUB(NOW(), INTERVAL ? MONTH))"
+        );
+        $stmt->execute([$mesesAtras, $mesesAtras]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    private function contarMensajesMes(int $mesesAtras): int
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM contact_messages
+             WHERE YEAR(created_at)  = YEAR(DATE_SUB(NOW(),  INTERVAL ? MONTH))
+               AND MONTH(created_at) = MONTH(DATE_SUB(NOW(), INTERVAL ? MONTH))"
+        );
+        $stmt->execute([$mesesAtras, $mesesAtras]);
+        return (int)$stmt->fetchColumn();
+    }
+
+    // ── Datos para gráficos ───────────────────────────────────────────────────
+
+    /**
+     * Negocios registrados por mes en los últimos 12 meses.
+     */
+    private function negociosPorMes12(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT DATE_FORMAT(created_at, '%Y-%m') AS mes, COUNT(*) AS total
+             FROM businesses
+             WHERE created_at >= DATE_SUB(NOW(), INTERVAL 12 MONTH)
+             GROUP BY DATE_FORMAT(created_at, '%Y-%m')
+             ORDER BY mes ASC"
+        );
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Top 5 empresas por movimientos en los últimos 30 días.
+     */
+    private function topMovimientos30Dias(): array
     {
         $stmt = $this->pdo->query(
             "SELECT b.name AS negocio, COUNT(m.id) AS total
              FROM businesses b
              LEFT JOIN movimientos m ON m.business_id = b.id
-                 AND m.fecha >= DATE_SUB(NOW(), INTERVAL 7 DAY)
+                 AND m.fecha >= DATE_SUB(NOW(), INTERVAL 30 DAY)
              WHERE b.is_active = 1
              GROUP BY b.id, b.name
              ORDER BY total DESC
-             LIMIT 10"
+             LIMIT 5"
         );
         return $stmt->fetchAll();
     }
+
+    /**
+     * Distribución de planes en negocios activos.
+     */
+    private function distribucionPlanes(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT plan, COUNT(*) AS total
+             FROM businesses
+             WHERE is_active = 1
+             GROUP BY plan"
+        );
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Mensajes de contacto recibidos por semana en las últimas 8 semanas.
+     */
+    private function mensajesPorSemana8(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT DATE_FORMAT(MIN(created_at), '%d/%m') AS semana_label,
+                    YEARWEEK(created_at, 1) AS semana_key,
+                    COUNT(*) AS total
+             FROM contact_messages
+             WHERE created_at >= DATE_SUB(NOW(), INTERVAL 8 WEEK)
+             GROUP BY YEARWEEK(created_at, 1)
+             ORDER BY semana_key ASC"
+        );
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Resumen de negocios con días hasta vencimiento y movimientos del mes.
+     */
+    private function resumenNegocios(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT b.id, b.name, b.plan, b.is_active, b.plan_expires_at,
+                    DATEDIFF(b.plan_expires_at, NOW()) AS dias_vencimiento,
+                    COUNT(DISTINCT e.id)  AS empleados_activos,
+                    COUNT(DISTINCT CASE
+                        WHEN m.fecha >= DATE_FORMAT(NOW(), '%Y-%m-01') THEN m.id
+                    END) AS movimientos_mes
+             FROM businesses b
+             LEFT JOIN employees e  ON e.business_id = b.id AND e.is_active = 1
+             LEFT JOIN movimientos m ON m.business_id = b.id
+             GROUP BY b.id
+             ORDER BY b.created_at DESC
+             LIMIT 15"
+        );
+        return $stmt->fetchAll();
+    }
+
+    // ── Listados para tablas del dashboard ───────────────────────────────────
 
     private function ultimosMensajesSinLeer(): array
     {
@@ -97,13 +283,13 @@ class DashboardController
     private function ultimaActividad(): array
     {
         $stmt = $this->pdo->query(
-            "SELECT al.action, al.created_at, al.ip_address,
+            "SELECT al.action, al.created_at, al.ip_address, al.is_critical,
                     b.name AS negocio, e.name AS empleado
              FROM activity_logs al
              LEFT JOIN businesses b ON b.id = al.business_id
              LEFT JOIN employees  e ON e.id = al.employee_id
              ORDER BY al.created_at DESC
-             LIMIT 5"
+             LIMIT 15"
         );
         return $stmt->fetchAll();
     }

--- a/src/superadmin/controllers/EmployeeController.php
+++ b/src/superadmin/controllers/EmployeeController.php
@@ -4,12 +4,13 @@
  *
  * @package  Es21Plus\Superadmin\Controllers
  * @author   Carlos Vico
- * @version  1.0.0
+ * @version  1.1.0
  */
 
 require_once __DIR__ . '/../../includes/Database.php';
 require_once __DIR__ . '/../../includes/AppException.php';
 require_once __DIR__ . '/../../core/Mailer.php';
+require_once __DIR__ . '/../../core/ActivityLogger.php';
 
 class EmployeeController
 {
@@ -150,7 +151,7 @@ class EmployeeController
 
     /**
      * Genera nueva contraseña aleatoria, la guarda y envía por correo.
-     * Nunca devuelve la contraseña en texto plano.
+     * Registra acción crítica en activity_logs.
      *
      * @param int $id
      * @throws AppException
@@ -158,11 +159,22 @@ class EmployeeController
      */
     public function resetPassword(int $id): void
     {
-        $emp = $this->find($id);
+        $emp   = $this->find($id);
         $plain = $this->generarPassword(10);
 
         $this->pdo->prepare('UPDATE employees SET password = ? WHERE id = ?')
             ->execute([password_hash($plain, PASSWORD_BCRYPT, ['cost' => 12]), $id]);
+
+        $saId = (int)($_SESSION['usuario_id'] ?? 0);
+        ActivityLogger::log(
+            (int)$emp['business_id'],
+            $saId,
+            'Reseteó contraseña del empleado "' . $emp['name'] . '"',
+            'employee',
+            $id,
+            ['employee_email' => $emp['email'], 'superadmin_id' => $saId],
+            true
+        );
 
         $body = "<h3>Nueva contraseña</h3>
                  <p>Hola {$emp['name']}, tu contraseña ha sido restablecida.</p>

--- a/src/superadmin/controllers/NotificationController.php
+++ b/src/superadmin/controllers/NotificationController.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Controlador de notificaciones internas del superadmin.
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../core/NotificationService.php';
+
+class NotificationController
+{
+    /**
+     * Devuelve el conteo de notificaciones no leídas en formato JSON.
+     *
+     * @return array
+     */
+    public function unreadCount(): array
+    {
+        return ['count' => NotificationService::unreadCount()];
+    }
+
+    /**
+     * Devuelve las últimas 10 notificaciones no leídas en formato JSON.
+     *
+     * @return array
+     */
+    public function unreadList(): array
+    {
+        return NotificationService::getUnread(10);
+    }
+
+    /**
+     * Marca todas las notificaciones como leídas.
+     *
+     * @return void
+     */
+    public function markAllRead(): void
+    {
+        NotificationService::markAllRead();
+    }
+}

--- a/src/superadmin/controllers/SecurityController.php
+++ b/src/superadmin/controllers/SecurityController.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Controlador de seguridad para el panel de superadmin.
+ *
+ * Gestiona IPs bloqueadas, logs de sesión y acciones críticas.
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../core/SecurityService.php';
+
+class SecurityController
+{
+    private PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    /**
+     * Devuelve datos para la vista de seguridad.
+     *
+     * @param string|null $userTypeFilter  Filtro tipo de usuario para session_logs.
+     * @param string|null $fechaDesde      Filtro fecha inicio para session_logs.
+     * @return array
+     */
+    public function index(?string $userTypeFilter = null, ?string $fechaDesde = null): array
+    {
+        return [
+            'blockedIps'      => SecurityService::getBlockedIps(),
+            'sessionLogs'     => SecurityService::getSessionLogs(50, $userTypeFilter, $fechaDesde),
+            'criticalActions' => $this->getCriticalActions(),
+        ];
+    }
+
+    /**
+     * Desbloquea una IP eliminando sus intentos de login.
+     *
+     * @param string $ip
+     * @return void
+     */
+    public function unblockIp(string $ip): void
+    {
+        SecurityService::clearAttempts($ip);
+    }
+
+    /**
+     * Devuelve las últimas 50 acciones críticas de activity_logs.
+     *
+     * @return array
+     */
+    private function getCriticalActions(): array
+    {
+        $stmt = $this->pdo->query(
+            "SELECT al.*, b.name AS negocio, e.name AS empleado
+             FROM activity_logs al
+             LEFT JOIN businesses b ON b.id = al.business_id
+             LEFT JOIN employees  e ON e.id = al.employee_id
+             WHERE al.is_critical = 1
+             ORDER BY al.created_at DESC
+             LIMIT 50"
+        );
+        return $stmt->fetchAll();
+    }
+}

--- a/src/superadmin/controllers/SettingsController.php
+++ b/src/superadmin/controllers/SettingsController.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Controlador de configuración global del sistema.
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../core/Settings.php';
+require_once __DIR__ . '/../../core/Mailer.php';
+
+class SettingsController
+{
+    /**
+     * Devuelve todas las configuraciones actuales.
+     *
+     * @return array<string,string>
+     */
+    public function index(): array
+    {
+        return Settings::all();
+    }
+
+    /**
+     * Guarda la configuración general (app_name, registro, mantenimiento).
+     *
+     * @param array $data POST data.
+     * @return void
+     */
+    public function saveGeneral(array $data): void
+    {
+        $appName = trim($data['app_name'] ?? '');
+        if ($appName === '') {
+            throw new AppException('El nombre de la aplicación no puede estar vacío.', 422);
+        }
+
+        Settings::set('app_name',            htmlspecialchars($appName, ENT_QUOTES, 'UTF-8'));
+        Settings::set('registration_open',   isset($data['registration_open']) ? '1' : '0');
+        Settings::set('maintenance_mode',    isset($data['maintenance_mode'])  ? '1' : '0');
+        Settings::set('maintenance_message', trim($data['maintenance_message'] ?? ''));
+        Settings::set('default_plan',        in_array($data['default_plan'] ?? '', ['free','basic','pro']) ? $data['default_plan'] : 'free');
+        Settings::set('trial_days',          (string)max(0, (int)($data['trial_days'] ?? 14)));
+    }
+
+    /**
+     * Guarda la configuración de correo SMTP.
+     * La contraseña se cifra con APP_KEY antes de almacenar.
+     *
+     * @param array $data POST data.
+     * @return void
+     */
+    public function saveEmail(array $data): void
+    {
+        Settings::set('superadmin_email', trim($data['superadmin_email'] ?? ''));
+        Settings::set('smtp_host',        trim($data['smtp_host']        ?? ''));
+        Settings::set('smtp_port',        (string)(int)($data['smtp_port'] ?? 587));
+        Settings::set('smtp_user',        trim($data['smtp_user']        ?? ''));
+        Settings::set('smtp_from_name',   trim($data['smtp_from_name']   ?? ''));
+
+        $newPassword = $data['smtp_password'] ?? '';
+        if ($newPassword !== '') {
+            Settings::set('smtp_password', Mailer::encryptSmtpPassword($newPassword));
+        }
+    }
+
+    /**
+     * Envía un email de prueba al superadmin_email configurado.
+     *
+     * @return bool
+     */
+    public function testEmail(): bool
+    {
+        $to = Settings::get('superadmin_email') ?: getenv('SUPERADMIN_EMAIL') ?: '';
+        if (!$to) {
+            throw new AppException('No hay email de superadmin configurado en Ajustes → Correo.', 422);
+        }
+
+        Mailer::send(
+            $to,
+            'Email de prueba – es21plus',
+            '<h2>Email de prueba</h2>
+             <p>Si recibes este correo, la configuración SMTP funciona correctamente.</p>
+             <p><em>es21plus · ' . date('Y-m-d H:i:s') . '</em></p>'
+        );
+
+        return true;
+    }
+}

--- a/src/superadmin/dashboard.php
+++ b/src/superadmin/dashboard.php
@@ -2,9 +2,12 @@
 /**
  * Dashboard global del panel de superadmin.
  *
+ * Incluye KPIs con variación mensual, cuatro gráficos Chart.js,
+ * tabla resumen de negocios y feed de actividad con auto-refresco.
+ *
  * @package  Es21Plus\Superadmin
  * @author   Carlos Vico
- * @version  1.0.0
+ * @version  1.1.0
  */
 
 if (session_status() === PHP_SESSION_NONE) session_start();
@@ -16,8 +19,8 @@ require_once __DIR__ . '/controllers/DashboardController.php';
 
 SuperadminMiddleware::require();
 
-$ctrl    = new DashboardController();
-$data    = $ctrl->index();
+$ctrl = new DashboardController();
+$data = $ctrl->index();
 $base    = './';
 $cssBase = '../';
 
@@ -29,57 +32,146 @@ $flashSuccess = $_SESSION['flash_success'] ?? '';
 $flashError   = $_SESSION['flash_error']   ?? '';
 unset($_SESSION['flash_success'], $_SESSION['flash_error']);
 
-$movLabels = json_encode(array_column($data['movimientosPorNegocio'], 'negocio'));
-$movValues = json_encode(array_column($data['movimientosPorNegocio'], 'total'));
+$kpis = $data['kpis'];
+
+// Datos para gráficos — serializar a JSON para JS
+$lineLabels  = json_encode(array_column($data['negociosPorMes'],    'mes'));
+$lineValues  = json_encode(array_column($data['negociosPorMes'],    'total'));
+$barLabels   = json_encode(array_column($data['topMovimientos'],    'negocio'));
+$barValues   = json_encode(array_column($data['topMovimientos'],    'total'));
+$donutLabels = json_encode(array_column($data['planesDistrib'],     'plan'));
+$donutValues = json_encode(array_column($data['planesDistrib'],     'total'));
+$areaLabels  = json_encode(array_column($data['mensajesPorSemana'], 'semana_label'));
+$areaValues  = json_encode(array_column($data['mensajesPorSemana'], 'total'));
+
+/** Renderiza el badge de variación porcentual */
+function varBadge(array $v): string {
+    if ($v['dir'] === 'same') {
+        return '<span class="sa-metric-variation sa-var-same">→ sin cambio</span>';
+    }
+    $arrow = $v['dir'] === 'up' ? '↑' : '↓';
+    $cls   = $v['dir'] === 'up' ? 'sa-var-up' : 'sa-var-down';
+    return '<span class="sa-metric-variation ' . $cls . '">' . $arrow . ' ' . $v['pct'] . '%</span>';
+}
 
 ob_start();
 ?>
-<!-- Métricas -->
+<!-- KPIs con variación -->
 <div class="sa-metric-grid">
     <div class="sa-metric-card">
         <div class="sa-metric-label">Negocios activos</div>
-        <div class="sa-metric-value"><?= $data['totalNegocios'] ?></div>
+        <div class="sa-metric-value"><?= $kpis['negocios']['value'] ?></div>
+        <?= varBadge($kpis['negocios']['variation']) ?>
+        <div style="font-size:.72rem;color:var(--text-muted);margin-top:.25rem;">
+            <?= $kpis['negocios']['mes'] ?> nuevos este mes
+        </div>
     </div>
     <div class="sa-metric-card">
         <div class="sa-metric-label">Empleados activos</div>
-        <div class="sa-metric-value"><?= $data['totalEmpleados'] ?></div>
+        <div class="sa-metric-value"><?= $kpis['empleados']['value'] ?></div>
+        <?= varBadge($kpis['empleados']['variation']) ?>
+        <div style="font-size:.72rem;color:var(--text-muted);margin-top:.25rem;">
+            <?= $kpis['empleados']['mes'] ?> nuevos este mes
+        </div>
+    </div>
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Movimientos este mes</div>
+        <div class="sa-metric-value"><?= $kpis['movimientos']['value'] ?></div>
+        <?= varBadge($kpis['movimientos']['variation']) ?>
     </div>
     <div class="sa-metric-card">
         <div class="sa-metric-label">Mensajes sin leer</div>
-        <div class="sa-metric-value" style="<?= $data['mensajesSinLeer'] > 0 ? 'color:#ef4444' : '' ?>"><?= $data['mensajesSinLeer'] ?></div>
-    </div>
-    <div class="sa-metric-card">
-        <div class="sa-metric-label">Movimientos hoy</div>
-        <div class="sa-metric-value"><?= $data['movimientosHoy'] ?></div>
+        <div class="sa-metric-value" style="<?= $kpis['mensajes']['value'] > 0 ? 'color:#ef4444' : '' ?>">
+            <?= $kpis['mensajes']['value'] ?>
+        </div>
+        <?= varBadge($kpis['mensajes']['variation']) ?>
     </div>
 </div>
 
-<!-- Gráfico movimientos por negocio (7 días) -->
-<div class="sa-table-card" style="padding:1.25rem;">
-    <div class="sa-table-header" style="padding:0 0 1rem;">
-        <h3>Movimientos por negocio — últimos 7 días</h3>
+<!-- Gráficos -->
+<div class="sa-charts-grid">
+    <!-- Líneas: negocios registrados por mes -->
+    <div class="sa-table-card" style="padding:1.25rem;">
+        <div class="sa-table-header" style="padding:0 0 .75rem;">
+            <h3>Negocios registrados — últimos 12 meses</h3>
+        </div>
+        <canvas id="chartLinea" height="120"></canvas>
     </div>
-    <canvas id="chartMovimientos" height="80"></canvas>
+
+    <!-- Barras: top movimientos 30 días -->
+    <div class="sa-table-card" style="padding:1.25rem;">
+        <div class="sa-table-header" style="padding:0 0 .75rem;">
+            <h3>Top 5 empresas — movimientos (30 días)</h3>
+        </div>
+        <canvas id="chartBarras" height="120"></canvas>
+    </div>
+
+    <!-- Dona: distribución de planes -->
+    <div class="sa-table-card" style="padding:1.25rem;">
+        <div class="sa-table-header" style="padding:0 0 .75rem;">
+            <h3>Distribución de planes</h3>
+        </div>
+        <div style="max-width:260px;margin:0 auto;">
+            <canvas id="chartDona" height="160"></canvas>
+        </div>
+    </div>
+
+    <!-- Área: mensajes por semana -->
+    <div class="sa-table-card" style="padding:1.25rem;">
+        <div class="sa-table-header" style="padding:0 0 .75rem;">
+            <h3>Mensajes recibidos — últimas 8 semanas</h3>
+        </div>
+        <canvas id="chartArea" height="120"></canvas>
+    </div>
 </div>
 
-<!-- Últimos mensajes sin leer -->
-<div class="sa-table-card">
+<!-- Tabla resumen de negocios -->
+<div class="sa-table-card" style="margin-bottom:1.5rem;">
     <div class="sa-table-header">
-        <h3>Mensajes sin leer</h3>
-        <a href="contact.php" style="font-size:.82rem;color:var(--accent);">Ver todos →</a>
+        <h3>Resumen de negocios</h3>
+        <a href="businesses.php" style="font-size:.82rem;color:var(--accent);">Ver todos →</a>
     </div>
-    <?php if (empty($data['ultimosMensajes'])): ?>
-        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin mensajes pendientes.</p>
+    <?php if (empty($data['resumenNegocios'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin negocios registrados.</p>
     <?php else: ?>
     <table class="sa-table">
-        <thead><tr><th>Remitente</th><th>Negocio</th><th>Asunto</th><th>Fecha</th></tr></thead>
+        <thead>
+        <tr>
+            <th>Nombre</th><th>Plan</th><th>Vencimiento</th>
+            <th>Mov. mes</th><th>Empleados</th><th>Estado</th>
+        </tr>
+        </thead>
         <tbody>
-        <?php foreach ($data['ultimosMensajes'] as $m): ?>
-            <tr style="cursor:pointer;" onclick="location.href='contact.php?action=show&id=<?= $m['id'] ?>'">
-                <td><?= htmlspecialchars($m['sender_name'], ENT_QUOTES, 'UTF-8') ?></td>
-                <td><?= htmlspecialchars($m['negocio'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
-                <td><?= htmlspecialchars($m['subject'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
-                <td style="color:var(--text-muted)"><?= date('d/m H:i', strtotime($m['created_at'])) ?></td>
+        <?php foreach ($data['resumenNegocios'] as $neg):
+            $dias = $neg['dias_vencimiento'] !== null ? (int)$neg['dias_vencimiento'] : null;
+            $rowCls = '';
+            if ($dias !== null) {
+                if ($dias < 0) $rowCls = 'sa-row-danger';
+                elseif ($dias < 7) $rowCls = 'sa-row-warn';
+            }
+        ?>
+            <tr class="<?= $rowCls ?>" style="cursor:pointer;" onclick="location.href='businesses.php?action=show&id=<?= $neg['id'] ?>'">
+                <td><?= htmlspecialchars($neg['name'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td><span class="badge-<?= htmlspecialchars($neg['plan'], ENT_QUOTES, 'UTF-8') ?>"><?= htmlspecialchars($neg['plan'], ENT_QUOTES, 'UTF-8') ?></span></td>
+                <td>
+                    <?php if ($neg['plan_expires_at']): ?>
+                        <?= htmlspecialchars($neg['plan_expires_at'], ENT_QUOTES, 'UTF-8') ?>
+                        <?php if ($dias !== null): ?>
+                            <span style="font-size:.72rem;color:<?= $dias < 0 ? '#dc2626' : ($dias < 7 ? '#d97706' : 'var(--text-muted)') ?>">
+                                (<?= $dias < 0 ? 'vencido' : $dias . ' días' ?>)
+                            </span>
+                        <?php endif; ?>
+                    <?php else: ?>
+                        <span style="color:var(--text-muted)">—</span>
+                    <?php endif; ?>
+                </td>
+                <td><?= (int)$neg['movimientos_mes'] ?></td>
+                <td><?= (int)$neg['empleados_activos'] ?></td>
+                <td>
+                    <span class="<?= (int)$neg['is_active'] ? 'badge-active' : 'badge-inactive' ?>">
+                        <?= (int)$neg['is_active'] ? 'Activo' : 'Inactivo' ?>
+                    </span>
+                </td>
             </tr>
         <?php endforeach; ?>
         </tbody>
@@ -87,53 +179,173 @@ ob_start();
     <?php endif; ?>
 </div>
 
-<!-- Última actividad -->
-<div class="sa-table-card">
-    <div class="sa-table-header">
-        <h3>Últimas actividades</h3>
-        <a href="logs.php" style="font-size:.82rem;color:var(--accent);">Ver todas →</a>
+<!-- Grid: mensajes sin leer + feed de actividad -->
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;margin-bottom:1.5rem;">
+
+    <!-- Mensajes sin leer -->
+    <div class="sa-table-card" style="margin-bottom:0;">
+        <div class="sa-table-header">
+            <h3>Mensajes sin leer</h3>
+            <a href="contact.php" style="font-size:.82rem;color:var(--accent);">Ver todos →</a>
+        </div>
+        <?php if (empty($data['ultimosMensajes'])): ?>
+            <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin mensajes pendientes.</p>
+        <?php else: ?>
+        <table class="sa-table">
+            <thead><tr><th>Remitente</th><th>Negocio</th><th>Asunto</th><th>Fecha</th></tr></thead>
+            <tbody>
+            <?php foreach ($data['ultimosMensajes'] as $m): ?>
+                <tr style="cursor:pointer;" onclick="location.href='contact.php?action=show&id=<?= $m['id'] ?>'">
+                    <td><?= htmlspecialchars($m['sender_name'], ENT_QUOTES, 'UTF-8') ?></td>
+                    <td><?= htmlspecialchars($m['negocio'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+                    <td><?= htmlspecialchars($m['subject'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+                    <td style="color:var(--text-muted)"><?= date('d/m H:i', strtotime($m['created_at'])) ?></td>
+                </tr>
+            <?php endforeach; ?>
+            </tbody>
+        </table>
+        <?php endif; ?>
     </div>
-    <?php if (empty($data['ultimaActividad'])): ?>
-        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin actividad registrada.</p>
-    <?php else: ?>
-    <table class="sa-table">
-        <thead><tr><th>Negocio</th><th>Empleado</th><th>Acción</th><th>Fecha</th></tr></thead>
-        <tbody>
-        <?php foreach ($data['ultimaActividad'] as $a): ?>
-            <tr>
-                <td><?= htmlspecialchars($a['negocio'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
-                <td><?= htmlspecialchars($a['empleado'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
-                <td><?= htmlspecialchars($a['action'], ENT_QUOTES, 'UTF-8') ?></td>
-                <td style="color:var(--text-muted)"><?= date('d/m H:i', strtotime($a['created_at'])) ?></td>
-            </tr>
-        <?php endforeach; ?>
-        </tbody>
-    </table>
-    <?php endif; ?>
+
+    <!-- Feed de actividad (auto-refresco 30s) -->
+    <div class="sa-table-card" style="margin-bottom:0;">
+        <div class="sa-table-header">
+            <h3>Actividad reciente</h3>
+            <a href="logs.php" style="font-size:.82rem;color:var(--accent);">Ver todas →</a>
+        </div>
+        <div id="feedActividad" style="max-height:320px;overflow-y:auto;">
+            <?php foreach ($data['ultimaActividad'] as $a): ?>
+            <div style="display:flex;gap:.75rem;padding:.65rem 1rem;border-bottom:1px solid #f1f5f9;align-items:flex-start;">
+                <div style="width:8px;height:8px;border-radius:50%;margin-top:5px;flex-shrink:0;background:<?= $a['is_critical'] ? '#ef4444' : '#818cf8' ?>"></div>
+                <div style="flex:1;min-width:0;">
+                    <div style="font-size:.82rem;font-weight:500;color:var(--text-primary);">
+                        <?= htmlspecialchars($a['action'], ENT_QUOTES, 'UTF-8') ?>
+                        <?php if ($a['is_critical']): ?>
+                            <span style="font-size:.68rem;background:#fee2e2;color:#dc2626;padding:.1rem .35rem;border-radius:4px;margin-left:.25rem;">crítico</span>
+                        <?php endif; ?>
+                    </div>
+                    <div style="font-size:.74rem;color:var(--text-muted);">
+                        <?= htmlspecialchars($a['negocio'] ?? '—', ENT_QUOTES, 'UTF-8') ?>
+                        <?php if (!empty($a['empleado'])): ?> · <?= htmlspecialchars($a['empleado'], ENT_QUOTES, 'UTF-8') ?><?php endif; ?>
+                    </div>
+                </div>
+                <div style="font-size:.72rem;color:var(--text-muted);white-space:nowrap;"><?= date('d/m H:i', strtotime($a['created_at'])) ?></div>
+            </div>
+            <?php endforeach; ?>
+            <?php if (empty($data['ultimaActividad'])): ?>
+                <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin actividad registrada.</p>
+            <?php endif; ?>
+        </div>
+    </div>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
 <script>
 (function () {
-    const ctx = document.getElementById('chartMovimientos');
-    if (!ctx) return;
-    new Chart(ctx, {
-        type: 'bar',
-        data: {
-            labels: <?= $movLabels ?>,
-            datasets: [{
-                label: 'Movimientos',
-                data: <?= $movValues ?>,
-                backgroundColor: 'rgba(99,102,241,0.7)',
-                borderRadius: 6,
-            }]
-        },
-        options: {
-            responsive: true,
-            plugins: { legend: { display: false } },
-            scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } }
-        }
-    });
+    const C = Chart;
+
+    // — Gráfico líneas: negocios por mes —
+    const ctxLinea = document.getElementById('chartLinea');
+    if (ctxLinea) {
+        new C(ctxLinea, {
+            type: 'line',
+            data: {
+                labels: <?= $lineLabels ?>,
+                datasets: [{
+                    label: 'Negocios', data: <?= $lineValues ?>,
+                    borderColor: '#818cf8', backgroundColor: 'rgba(129,140,248,.1)',
+                    tension: .35, fill: true, pointRadius: 4,
+                }]
+            },
+            options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } } }
+        });
+    }
+
+    // — Gráfico barras: top movimientos —
+    const ctxBarras = document.getElementById('chartBarras');
+    if (ctxBarras) {
+        new C(ctxBarras, {
+            type: 'bar',
+            data: {
+                labels: <?= $barLabels ?>,
+                datasets: [{
+                    label: 'Movimientos', data: <?= $barValues ?>,
+                    backgroundColor: ['rgba(99,102,241,.8)','rgba(139,92,246,.8)','rgba(59,130,246,.8)','rgba(16,185,129,.8)','rgba(245,158,11,.8)'],
+                    borderRadius: 6,
+                }]
+            },
+            options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } } }
+        });
+    }
+
+    // — Gráfico dona: planes —
+    const ctxDona = document.getElementById('chartDona');
+    if (ctxDona) {
+        new C(ctxDona, {
+            type: 'doughnut',
+            data: {
+                labels: <?= $donutLabels ?>,
+                datasets: [{
+                    data: <?= $donutValues ?>,
+                    backgroundColor: ['#e2e8f0','#93c5fd','#a78bfa'],
+                    borderWidth: 0,
+                }]
+            },
+            options: {
+                responsive: true, cutout: '65%',
+                plugins: { legend: { position: 'bottom', labels: { font: { size: 11 } } } }
+            }
+        });
+    }
+
+    // — Gráfico área: mensajes por semana —
+    const ctxArea = document.getElementById('chartArea');
+    if (ctxArea) {
+        new C(ctxArea, {
+            type: 'line',
+            data: {
+                labels: <?= $areaLabels ?>,
+                datasets: [{
+                    label: 'Mensajes', data: <?= $areaValues ?>,
+                    borderColor: '#22c55e', backgroundColor: 'rgba(34,197,94,.12)',
+                    tension: .35, fill: true, pointRadius: 4,
+                }]
+            },
+            options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true, ticks: { stepSize: 1 } } } }
+        });
+    }
+
+    // — Feed de actividad: auto-refresco cada 30 segundos —
+    async function refreshFeed() {
+        try {
+            const res  = await fetch('./activity/recent.php');
+            const json = await res.json();
+            if (!json.success || !json.data) return;
+
+            const feed = document.getElementById('feedActividad');
+            if (!feed) return;
+
+            feed.innerHTML = json.data.map(a => `
+                <div style="display:flex;gap:.75rem;padding:.65rem 1rem;border-bottom:1px solid #f1f5f9;align-items:flex-start;">
+                    <div style="width:8px;height:8px;border-radius:50%;margin-top:5px;flex-shrink:0;background:${a.is_critical ? '#ef4444' : '#818cf8'}"></div>
+                    <div style="flex:1;min-width:0;">
+                        <div style="font-size:.82rem;font-weight:500;color:#0f172a;">
+                            ${escHtml(a.action)}
+                            ${a.is_critical ? '<span style="font-size:.68rem;background:#fee2e2;color:#dc2626;padding:.1rem .35rem;border-radius:4px;margin-left:.25rem;">crítico</span>' : ''}
+                        </div>
+                        <div style="font-size:.74rem;color:#64748b;">${escHtml(a.negocio || '—')}${a.empleado ? ' · ' + escHtml(a.empleado) : ''}</div>
+                    </div>
+                    <div style="font-size:.72rem;color:#64748b;white-space:nowrap;">${escHtml(a.tiempo_relativo)}</div>
+                </div>
+            `).join('') || '<p style="padding:1rem;color:#64748b;font-size:.85rem;">Sin actividad registrada.</p>';
+        } catch {}
+    }
+
+    function escHtml(str) {
+        return String(str ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+
+    setInterval(refreshFeed, 30000);
 })();
 </script>
 <?php

--- a/src/superadmin/middleware/SuperadminMiddleware.php
+++ b/src/superadmin/middleware/SuperadminMiddleware.php
@@ -2,12 +2,12 @@
 /**
  * Middleware exclusivo para el panel de superadministración.
  *
- * Verifica que la sesión activa corresponde a un usuario con rol superadmin.
- * Destruye la sesión y redirige al login si el acceso no está autorizado.
+ * Verifica sesión de superadmin, aplica timeout de inactividad,
+ * y comprueba planes de empresa próximos a vencer para generar notificaciones.
  *
  * @package  Es21Plus\Superadmin\Middleware
  * @author   Carlos Vico
- * @version  1.0.0
+ * @version  1.1.0
  */
 class SuperadminMiddleware
 {
@@ -44,6 +44,20 @@ class SuperadminMiddleware
         }
 
         $_SESSION['last_activity'] = time();
+
+        // Verificar planes próximos a vencer (una vez por sesión, máx. cada 5 min)
+        $lastPlanCheck = $_SESSION['sa_last_plan_check'] ?? 0;
+        if ((time() - $lastPlanCheck) > 300) {
+            $_SESSION['sa_last_plan_check'] = time();
+            try {
+                if (!class_exists('NotificationService')) {
+                    require_once __DIR__ . '/../../core/NotificationService.php';
+                }
+                NotificationService::checkExpiringPlans();
+            } catch (\Throwable) {
+                // No interrumpir flujo si falla
+            }
+        }
     }
 
     /**

--- a/src/superadmin/notifications/list.php
+++ b/src/superadmin/notifications/list.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Endpoint JSON: lista las últimas 10 notificaciones no leídas.
+ *
+ * GET /superadmin/notifications/list.php
+ *
+ * @package  Es21Plus\Superadmin\Notifications
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../../core/NotificationService.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+
+SuperadminMiddleware::require();
+
+echo json_encode([
+    'success' => true,
+    'data'    => NotificationService::getUnread(10),
+]);

--- a/src/superadmin/notifications/read-all.php
+++ b/src/superadmin/notifications/read-all.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Endpoint JSON: marca todas las notificaciones como leídas.
+ *
+ * POST /superadmin/notifications/read-all.php
+ *
+ * @package  Es21Plus\Superadmin\Notifications
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../../core/NotificationService.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Método no permitido.']);
+    exit;
+}
+
+SuperadminMiddleware::require();
+
+NotificationService::markAllRead();
+
+echo json_encode(['success' => true, 'message' => 'Todas las notificaciones marcadas como leídas.']);

--- a/src/superadmin/notifications/unread-count.php
+++ b/src/superadmin/notifications/unread-count.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Endpoint JSON: conteo de notificaciones no leídas.
+ *
+ * GET /superadmin/notifications/unread-count.php
+ *
+ * @package  Es21Plus\Superadmin\Notifications
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../../core/NotificationService.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+
+SuperadminMiddleware::require();
+
+echo json_encode([
+    'success' => true,
+    'data'    => ['count' => NotificationService::unreadCount()],
+]);

--- a/src/superadmin/settings.php
+++ b/src/superadmin/settings.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Página de configuración global del sistema.
+ *
+ * Tabs sin recarga de página: General | Correo | Seguridad.
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../core/Settings.php';
+require_once __DIR__ . '/../core/Mailer.php';
+require_once __DIR__ . '/controllers/SettingsController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl = new SettingsController();
+$flashSuccess = '';
+$flashError   = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['_action'] ?? '';
+    try {
+        if ($action === 'save_general') {
+            $ctrl->saveGeneral($_POST);
+            $flashSuccess = 'Configuración general guardada.';
+        } elseif ($action === 'save_email') {
+            $ctrl->saveEmail($_POST);
+            $flashSuccess = 'Configuración de correo guardada.';
+        }
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    } catch (\Throwable) {
+        $flashError = 'Error inesperado al guardar.';
+    }
+}
+
+$s = $ctrl->index(); // array de settings
+
+$base    = './';
+$cssBase = '../';
+$pageTitle  = 'Configuración';
+$activeMenu = 'settings';
+
+// Badge mensajes para sidebar
+try {
+    $mensajesSinLeer = (int)\Database::getInstance()->query(
+        'SELECT COUNT(*) FROM contact_messages WHERE is_read = 0'
+    )->fetchColumn();
+} catch (\Throwable) {
+    $mensajesSinLeer = 0;
+}
+
+$activeTab = $_GET['tab'] ?? 'general';
+
+ob_start();
+?>
+
+<nav class="sa-tabs-nav" id="settingsTabs">
+    <button class="sa-tab-btn <?= $activeTab === 'general' ? 'active' : '' ?>" onclick="showTab('general')">General</button>
+    <button class="sa-tab-btn <?= $activeTab === 'email'   ? 'active' : '' ?>" onclick="showTab('email')">Correo SMTP</button>
+    <button class="sa-tab-btn" onclick="location.href='settings/security.php'">Seguridad →</button>
+</nav>
+
+<!-- TAB: General -->
+<div id="tab-general" class="sa-tab-panel <?= $activeTab === 'general' ? 'active' : '' ?>">
+    <div class="sa-form-card" style="max-width:680px;">
+        <h2>Ajustes generales</h2>
+        <form method="POST">
+            <input type="hidden" name="_action" value="save_general">
+
+            <div class="form-field" style="margin-bottom:1rem;">
+                <label class="field-label">Nombre de la aplicación</label>
+                <input type="text" name="app_name" class="field-input" required
+                    value="<?= htmlspecialchars($s['app_name'] ?? 'es21plus', ENT_QUOTES, 'UTF-8') ?>">
+            </div>
+
+            <div class="form-field" style="margin-bottom:1rem;">
+                <label class="field-label">Plan por defecto en registro</label>
+                <select name="default_plan" class="field-input">
+                    <?php foreach (['free','basic','pro'] as $p): ?>
+                        <option value="<?= $p ?>" <?= ($s['default_plan'] ?? 'free') === $p ? 'selected' : '' ?>><?= ucfirst($p) ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+
+            <div class="form-field" style="margin-bottom:1rem;">
+                <label class="field-label">Días de prueba al registrarse</label>
+                <input type="number" name="trial_days" class="field-input" min="0" max="365"
+                    value="<?= (int)($s['trial_days'] ?? 14) ?>">
+            </div>
+
+            <div class="form-field" style="margin-bottom:1rem;">
+                <div class="toggle-wrap">
+                    <input type="checkbox" id="tgl_reg" name="registration_open" class="sa-toggle"
+                        <?= ($s['registration_open'] ?? '1') === '1' ? 'checked' : '' ?>>
+                    <label for="tgl_reg" style="font-size:.88rem;color:var(--text-primary);cursor:pointer;">
+                        Permitir registro público de nuevas empresas
+                    </label>
+                </div>
+            </div>
+
+            <div class="form-field" style="margin-bottom:1rem;">
+                <div class="toggle-wrap">
+                    <input type="checkbox" id="tgl_maint" name="maintenance_mode" class="sa-toggle"
+                        <?= ($s['maintenance_mode'] ?? '0') === '1' ? 'checked' : '' ?>>
+                    <label for="tgl_maint" style="font-size:.88rem;color:var(--text-primary);cursor:pointer;">
+                        Activar modo mantenimiento
+                    </label>
+                </div>
+                <p style="font-size:.78rem;color:var(--text-muted);margin-top:.35rem;">
+                    Los empleados verán la pantalla de mantenimiento. El superadmin accede con normalidad.
+                </p>
+            </div>
+
+            <div class="form-field" style="margin-bottom:1.5rem;">
+                <label class="field-label">Mensaje de mantenimiento</label>
+                <textarea name="maintenance_message" class="field-input" rows="3"
+                    placeholder="Estamos realizando mejoras. Vuelve pronto."><?= htmlspecialchars($s['maintenance_message'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Guardar cambios</button>
+        </form>
+    </div>
+</div>
+
+<!-- TAB: Correo SMTP -->
+<div id="tab-email" class="sa-tab-panel <?= $activeTab === 'email' ? 'active' : '' ?>">
+    <div class="sa-form-card" style="max-width:680px;">
+        <h2>Configuración SMTP</h2>
+        <form method="POST" id="emailForm">
+            <input type="hidden" name="_action" value="save_email">
+
+            <div class="sa-form-grid" style="margin-bottom:1rem;">
+                <div class="form-field">
+                    <label class="field-label">Email de notificaciones (superadmin)</label>
+                    <input type="email" name="superadmin_email" class="field-input"
+                        value="<?= htmlspecialchars($s['superadmin_email'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                        placeholder="superadmin@example.com">
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Nombre del remitente</label>
+                    <input type="text" name="smtp_from_name" class="field-input"
+                        value="<?= htmlspecialchars($s['smtp_from_name'] ?? 'es21plus', ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+            </div>
+
+            <div class="sa-form-grid" style="margin-bottom:1rem;">
+                <div class="form-field">
+                    <label class="field-label">Servidor SMTP (host)</label>
+                    <input type="text" name="smtp_host" class="field-input"
+                        value="<?= htmlspecialchars($s['smtp_host'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                        placeholder="smtp.gmail.com">
+                </div>
+                <div class="form-field">
+                    <label class="field-label">Puerto SMTP</label>
+                    <input type="number" name="smtp_port" class="field-input" min="1" max="65535"
+                        value="<?= (int)($s['smtp_port'] ?? 587) ?>">
+                </div>
+            </div>
+
+            <div class="sa-form-grid" style="margin-bottom:1.5rem;">
+                <div class="form-field">
+                    <label class="field-label">Usuario SMTP</label>
+                    <input type="text" name="smtp_user" class="field-input" autocomplete="off"
+                        value="<?= htmlspecialchars($s['smtp_user'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+                <div class="form-field">
+                    <label class="field-label">
+                        Contraseña SMTP
+                        <span style="font-size:.72rem;color:var(--text-muted);font-weight:400;">(dejar vacío para no cambiar)</span>
+                    </label>
+                    <input type="password" name="smtp_password" class="field-input" autocomplete="new-password"
+                        placeholder="••••••••">
+                </div>
+            </div>
+
+            <div style="display:flex;gap:.75rem;align-items:center;flex-wrap:wrap;">
+                <button type="submit" class="btn btn-primary">Guardar SMTP</button>
+                <button type="button" class="btn btn-secondary" id="btnTestEmail" onclick="testEmail()">
+                    Enviar email de prueba
+                </button>
+                <span id="testEmailMsg" style="font-size:.82rem;"></span>
+            </div>
+        </form>
+    </div>
+</div>
+
+<script>
+function showTab(name) {
+    document.querySelectorAll('.sa-tab-panel').forEach(p => p.classList.remove('active'));
+    document.querySelectorAll('.sa-tab-btn').forEach(b => b.classList.remove('active'));
+    const panel = document.getElementById('tab-' + name);
+    if (panel) panel.classList.add('active');
+    event.currentTarget.classList.add('active');
+}
+
+async function testEmail() {
+    const btn = document.getElementById('btnTestEmail');
+    const msg = document.getElementById('testEmailMsg');
+    btn.disabled = true;
+    btn.textContent = 'Enviando…';
+    msg.textContent = '';
+    msg.style.color = '';
+    try {
+        const res  = await fetch('./settings/test-email.php', { method: 'POST' });
+        const json = await res.json();
+        msg.textContent = json.message;
+        msg.style.color = json.success ? '#16a34a' : '#dc2626';
+    } catch {
+        msg.textContent = 'Error de conexión.';
+        msg.style.color = '#dc2626';
+    } finally {
+        btn.disabled = false;
+        btn.textContent = 'Enviar email de prueba';
+    }
+}
+</script>
+<?php
+$content = ob_get_clean();
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/settings/security.php
+++ b/src/superadmin/settings/security.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * Vista de seguridad del panel de superadmin.
+ *
+ * Muestra IPs bloqueadas, logs de sesión y acciones críticas.
+ *
+ * @package  Es21Plus\Superadmin\Settings
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../../core/SecurityService.php';
+require_once __DIR__ . '/../controllers/SecurityController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl = new SecurityController();
+$flashSuccess = '';
+$flashError   = '';
+
+// Desbloquear IP
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['_action'] ?? '') === 'unblock_ip') {
+    $ip = trim($_POST['ip'] ?? '');
+    if ($ip !== '') {
+        $ctrl->unblockIp($ip);
+        $flashSuccess = 'IP ' . htmlspecialchars($ip, ENT_QUOTES, 'UTF-8') . ' desbloqueada.';
+    }
+}
+
+$userTypeFilter = $_GET['user_type'] ?? null;
+$fechaDesde     = $_GET['fecha_desde'] ?? null;
+
+$data = $ctrl->index($userTypeFilter, $fechaDesde);
+
+$base    = '../';
+$cssBase = '../../';
+$pageTitle  = 'Seguridad';
+$activeMenu = 'settings';
+
+try {
+    $mensajesSinLeer = (int)\Database::getInstance()->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+} catch (\Throwable) {
+    $mensajesSinLeer = 0;
+}
+
+ob_start();
+?>
+<div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem;">
+    <a href="../settings.php" style="font-size:.84rem;color:var(--accent);text-decoration:none;">← Volver a Configuración</a>
+</div>
+
+<!-- IPs bloqueadas -->
+<div class="sa-table-card" style="margin-bottom:1.5rem;">
+    <div class="sa-table-header">
+        <h3>IPs bloqueadas actualmente</h3>
+        <span style="font-size:.78rem;color:var(--text-muted);">Más de 5 intentos en 15 minutos</span>
+    </div>
+    <?php if (empty($data['blockedIps'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin IPs bloqueadas.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th>IP</th><th>Intentos</th><th>Primer intento</th><th>Último intento</th><th>Acción</th></tr></thead>
+        <tbody>
+        <?php foreach ($data['blockedIps'] as $row): ?>
+            <tr>
+                <td><code><?= htmlspecialchars($row['ip_address'], ENT_QUOTES, 'UTF-8') ?></code></td>
+                <td><span class="badge-inactive"><?= (int)$row['intentos'] ?></span></td>
+                <td style="color:var(--text-muted)"><?= date('d/m/Y H:i', strtotime($row['primer_intento'])) ?></td>
+                <td style="color:var(--text-muted)"><?= date('d/m/Y H:i', strtotime($row['ultimo_intento'])) ?></td>
+                <td>
+                    <form method="POST" style="display:inline;" onsubmit="return confirm('¿Desbloquear IP?')">
+                        <input type="hidden" name="_action" value="unblock_ip">
+                        <input type="hidden" name="ip" value="<?= htmlspecialchars($row['ip_address'], ENT_QUOTES, 'UTF-8') ?>">
+                        <button type="submit" class="btn btn-secondary" style="padding:.25rem .6rem;font-size:.78rem;">Desbloquear</button>
+                    </form>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>
+
+<!-- Filtros para session_logs -->
+<div class="sa-form-card" style="margin-bottom:1rem;padding:1rem 1.25rem;">
+    <form method="GET" style="display:flex;gap:.75rem;align-items:flex-end;flex-wrap:wrap;">
+        <div class="form-field" style="margin:0;">
+            <label class="field-label" style="font-size:.78rem;">Tipo de usuario</label>
+            <select name="user_type" class="field-input" style="padding:.35rem .6rem;font-size:.82rem;">
+                <option value="">Todos</option>
+                <option value="superadmin" <?= $userTypeFilter === 'superadmin' ? 'selected' : '' ?>>Superadmin</option>
+                <option value="employee"   <?= $userTypeFilter === 'employee'   ? 'selected' : '' ?>>Empleado</option>
+            </select>
+        </div>
+        <div class="form-field" style="margin:0;">
+            <label class="field-label" style="font-size:.78rem;">Desde</label>
+            <input type="date" name="fecha_desde" class="field-input" style="padding:.35rem .6rem;font-size:.82rem;"
+                value="<?= htmlspecialchars($fechaDesde ?? '', ENT_QUOTES, 'UTF-8') ?>">
+        </div>
+        <button type="submit" class="btn btn-secondary" style="padding:.4rem .85rem;font-size:.82rem;">Filtrar</button>
+        <a href="security.php" class="btn" style="padding:.4rem .85rem;font-size:.82rem;background:var(--surface);border:1px solid var(--border);color:var(--text-muted);border-radius:.4rem;text-decoration:none;">Limpiar</a>
+    </form>
+</div>
+
+<!-- Logs de sesión -->
+<div class="sa-table-card" style="margin-bottom:1.5rem;">
+    <div class="sa-table-header">
+        <h3>Últimas 50 sesiones</h3>
+    </div>
+    <?php if (empty($data['sessionLogs'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin sesiones registradas.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th>Tipo</th><th>User ID</th><th>Negocio ID</th><th>IP</th><th>Acción</th><th>Fecha</th></tr></thead>
+        <tbody>
+        <?php foreach ($data['sessionLogs'] as $log): ?>
+            <tr>
+                <td>
+                    <span class="<?= $log['user_type'] === 'superadmin' ? 'badge-pro' : 'badge-basic' ?>">
+                        <?= htmlspecialchars($log['user_type'], ENT_QUOTES, 'UTF-8') ?>
+                    </span>
+                </td>
+                <td><?= (int)$log['user_id'] ?></td>
+                <td><?= $log['business_id'] ? (int)$log['business_id'] : '—' ?></td>
+                <td><code><?= htmlspecialchars($log['ip_address'] ?? '—', ENT_QUOTES, 'UTF-8') ?></code></td>
+                <td>
+                    <?php
+                    $aColors = ['login' => 'badge-active', 'logout' => 'badge-free', 'expired' => 'badge-unread'];
+                    ?>
+                    <span class="<?= $aColors[$log['action']] ?? 'badge-free' ?>">
+                        <?= htmlspecialchars($log['action'], ENT_QUOTES, 'UTF-8') ?>
+                    </span>
+                </td>
+                <td style="color:var(--text-muted)"><?= date('d/m/Y H:i', strtotime($log['created_at'])) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>
+
+<!-- Acciones críticas -->
+<div class="sa-table-card">
+    <div class="sa-table-header">
+        <h3>Acciones críticas recientes</h3>
+    </div>
+    <?php if (empty($data['criticalActions'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin acciones críticas registradas.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead><tr><th>Negocio</th><th>Empleado/SA</th><th>Acción</th><th>Metadata</th><th>IP</th><th>Fecha</th></tr></thead>
+        <tbody>
+        <?php foreach ($data['criticalActions'] as $act): ?>
+            <tr>
+                <td><?= htmlspecialchars($act['negocio'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars($act['empleado'] ?? 'superadmin', ENT_QUOTES, 'UTF-8') ?></td>
+                <td><?= htmlspecialchars($act['action'], ENT_QUOTES, 'UTF-8') ?></td>
+                <td>
+                    <?php if ($act['metadata']): ?>
+                        <details style="font-size:.75rem;">
+                            <summary style="cursor:pointer;color:var(--accent);">Ver</summary>
+                            <pre style="margin:.25rem 0 0;font-size:.72rem;background:#f8fafc;padding:.5rem;border-radius:.25rem;overflow:auto;max-width:260px;"><?= htmlspecialchars(
+                                json_encode(json_decode($act['metadata']), JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
+                                ENT_QUOTES, 'UTF-8'
+                            ) ?></pre>
+                        </details>
+                    <?php else: ?>—<?php endif; ?>
+                </td>
+                <td><code style="font-size:.75rem;"><?= htmlspecialchars($act['ip_address'] ?? '—', ENT_QUOTES, 'UTF-8') ?></code></td>
+                <td style="color:var(--text-muted)"><?= date('d/m/Y H:i', strtotime($act['created_at'])) ?></td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php endif; ?>
+</div>
+<?php
+$content = ob_get_clean();
+require __DIR__ . '/../views/layout.php';

--- a/src/superadmin/settings/test-email.php
+++ b/src/superadmin/settings/test-email.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Endpoint JSON: envía un email de prueba con la config SMTP actual.
+ *
+ * POST /superadmin/settings/test-email.php
+ *
+ * @package  Es21Plus\Superadmin\Settings
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../../core/Settings.php';
+require_once __DIR__ . '/../../core/Mailer.php';
+require_once __DIR__ . '/../controllers/SettingsController.php';
+
+header('Content-Type: application/json; charset=UTF-8');
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    echo json_encode(['success' => false, 'message' => 'Método no permitido.']);
+    exit;
+}
+
+SuperadminMiddleware::require();
+
+try {
+    $ctrl = new SettingsController();
+    $ctrl->testEmail();
+    echo json_encode(['success' => true, 'message' => 'Email de prueba enviado correctamente.']);
+} catch (AppException $e) {
+    echo json_encode(['success' => false, 'message' => $e->getMessage()]);
+} catch (\Throwable $e) {
+    echo json_encode(['success' => false, 'message' => 'Error SMTP: ' . $e->getMessage()]);
+}

--- a/src/superadmin/views/layout.php
+++ b/src/superadmin/views/layout.php
@@ -18,134 +18,71 @@
 
         /* ── Sidebar ── */
         .sa-sidebar {
-            width: 240px;
-            min-width: 240px;
+            width: 240px; min-width: 240px;
             background: var(--sa-sidebar-bg);
-            display: flex;
-            flex-direction: column;
-            position: fixed;
-            top: 0; left: 0; bottom: 0;
-            z-index: 100;
+            display: flex; flex-direction: column;
+            position: fixed; top: 0; left: 0; bottom: 0; z-index: 100;
         }
-        .sa-sidebar-brand {
-            padding: 1.25rem 1.25rem 1rem;
-            border-bottom: 1px solid rgba(255,255,255,.06);
-        }
+        .sa-sidebar-brand { padding: 1.25rem 1.25rem 1rem; border-bottom: 1px solid rgba(255,255,255,.06); }
         .sa-brand-badge {
-            display: inline-block;
-            background: var(--sa-accent-dark);
-            color: #fff;
-            font-size: .65rem;
-            font-weight: 700;
-            padding: .15rem .5rem;
-            border-radius: 20px;
-            letter-spacing: .05em;
-            text-transform: uppercase;
-            margin-bottom: .4rem;
+            display: inline-block; background: var(--sa-accent-dark); color: #fff;
+            font-size: .65rem; font-weight: 700; padding: .15rem .5rem; border-radius: 20px;
+            letter-spacing: .05em; text-transform: uppercase; margin-bottom: .4rem;
         }
         .sa-brand-name { color: #fff; font-weight: 700; font-size: 1.05rem; margin: 0; }
         .sa-nav { flex: 1; padding: .75rem 0; overflow-y: auto; }
         .sa-nav-section {
-            padding: .5rem 1.25rem .25rem;
-            font-size: .68rem;
-            font-weight: 600;
-            color: rgba(255,255,255,.3);
-            letter-spacing: .08em;
-            text-transform: uppercase;
+            padding: .5rem 1.25rem .25rem; font-size: .68rem; font-weight: 600;
+            color: rgba(255,255,255,.3); letter-spacing: .08em; text-transform: uppercase;
         }
         .sa-nav a {
-            display: flex;
-            align-items: center;
-            gap: .6rem;
-            padding: .55rem 1.25rem;
-            color: rgba(255,255,255,.6);
-            text-decoration: none;
-            font-size: .84rem;
-            transition: background .15s, color .15s;
-            border-left: 3px solid transparent;
+            display: flex; align-items: center; gap: .6rem; padding: .55rem 1.25rem;
+            color: rgba(255,255,255,.6); text-decoration: none; font-size: .84rem;
+            transition: background .15s, color .15s; border-left: 3px solid transparent;
         }
         .sa-nav a:hover { background: var(--sa-sidebar-hover); color: #fff; }
-        .sa-nav a.active {
-            background: rgba(99,102,241,.15);
-            color: var(--sa-accent);
-            border-left-color: var(--sa-accent);
-        }
+        .sa-nav a.active { background: rgba(99,102,241,.15); color: var(--sa-accent); border-left-color: var(--sa-accent); }
         .sa-nav a svg { opacity: .7; flex-shrink: 0; }
         .sa-nav a.active svg { opacity: 1; }
         .sa-badge-count {
-            margin-left: auto;
-            background: #ef4444;
-            color: #fff;
-            font-size: .65rem;
-            font-weight: 700;
-            padding: .1rem .4rem;
-            border-radius: 20px;
-            min-width: 18px;
-            text-align: center;
+            margin-left: auto; background: #ef4444; color: #fff;
+            font-size: .65rem; font-weight: 700; padding: .1rem .4rem;
+            border-radius: 20px; min-width: 18px; text-align: center;
         }
-        .sa-sidebar-footer {
-            padding: 1rem 1.25rem;
-            border-top: 1px solid rgba(255,255,255,.06);
-        }
-        .sa-user-mini {
-            display: flex;
-            align-items: center;
-            gap: .6rem;
-            color: rgba(255,255,255,.7);
-            font-size: .82rem;
-            margin-bottom: .75rem;
-        }
+        .sa-sidebar-footer { padding: 1rem 1.25rem; border-top: 1px solid rgba(255,255,255,.06); }
+        .sa-user-mini { display: flex; align-items: center; gap: .6rem; color: rgba(255,255,255,.7); font-size: .82rem; margin-bottom: .75rem; }
         .sa-avatar-mini {
-            width: 30px; height: 30px;
-            background: var(--sa-accent-dark);
-            border-radius: 50%;
+            width: 30px; height: 30px; background: var(--sa-accent-dark); border-radius: 50%;
             display: flex; align-items: center; justify-content: center;
-            font-size: .7rem;
-            font-weight: 700;
-            color: #fff;
-            flex-shrink: 0;
+            font-size: .7rem; font-weight: 700; color: #fff; flex-shrink: 0;
         }
         .sa-logout {
-            display: flex;
-            align-items: center;
-            gap: .5rem;
-            color: #f87171;
-            text-decoration: none;
-            font-size: .82rem;
-            padding: .4rem .5rem;
-            border-radius: .4rem;
-            transition: background .15s;
+            display: flex; align-items: center; gap: .5rem; color: #f87171;
+            text-decoration: none; font-size: .82rem; padding: .4rem .5rem;
+            border-radius: .4rem; transition: background .15s;
         }
         .sa-logout:hover { background: rgba(239,68,68,.1); }
 
         /* ── Main area ── */
         .sa-main { margin-left: 240px; flex: 1; display: flex; flex-direction: column; min-height: 100vh; }
         .sa-topbar {
-            height: 56px;
-            background: #fff;
-            border-bottom: 1px solid var(--border);
-            display: flex;
-            align-items: center;
-            padding: 0 1.5rem;
-            gap: 1rem;
-            position: sticky;
-            top: 0;
-            z-index: 50;
+            height: 56px; background: #fff; border-bottom: 1px solid var(--border);
+            display: flex; align-items: center; padding: 0 1.5rem; gap: 1rem;
+            position: sticky; top: 0; z-index: 50;
         }
         .sa-topbar-title { font-weight: 600; font-size: .95rem; color: var(--text-primary); flex: 1; }
         .sa-content { padding: 1.75rem; flex: 1; }
 
         /* ── Cards métricas ── */
         .sa-metric-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-bottom: 1.5rem; }
-        .sa-metric-card {
-            background: #fff;
-            border: 1px solid var(--border);
-            border-radius: var(--radius-lg);
-            padding: 1.25rem;
-        }
+        .sa-metric-card { background: #fff; border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 1.25rem; }
         .sa-metric-label { font-size: .78rem; color: var(--text-muted); margin-bottom: .4rem; }
         .sa-metric-value { font-size: 2rem; font-weight: 700; color: var(--text-primary); line-height: 1; }
         .sa-metric-icon { float: right; opacity: .15; }
+        .sa-metric-variation { margin-top: .5rem; font-size: .75rem; display: inline-flex; align-items: center; gap: .25rem; }
+        .sa-var-up   { color: #16a34a; background: #dcfce7; padding: .1rem .4rem; border-radius: 20px; }
+        .sa-var-down { color: #dc2626; background: #fee2e2; padding: .1rem .4rem; border-radius: 20px; }
+        .sa-var-same { color: #64748b; background: #f1f5f9; padding: .1rem .4rem; border-radius: 20px; }
 
         /* ── Table styles ── */
         .sa-table-card { background: #fff; border: 1px solid var(--border); border-radius: var(--radius-lg); overflow: hidden; margin-bottom: 1.5rem; }
@@ -158,6 +95,8 @@
         .sa-table tr:hover td { background: var(--surface); }
         .sa-table a { color: var(--accent); text-decoration: none; }
         .sa-table a:hover { text-decoration: underline; }
+        .sa-row-danger td { background: #fff1f2 !important; }
+        .sa-row-warn  td { background: #fffbeb !important; }
 
         /* ── Badge ── */
         .badge-active   { background: var(--success-light); color: #15803d; padding: .2rem .6rem; border-radius: 20px; font-size: .72rem; font-weight: 600; }
@@ -176,6 +115,84 @@
         .sa-form-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(260px, 1fr)); gap: 1rem; }
         .sa-form-card { background: #fff; border: 1px solid var(--border); border-radius: var(--radius-lg); padding: 1.5rem; }
         .sa-form-card h2 { margin: 0 0 1.25rem; font-size: 1rem; font-weight: 600; }
+
+        /* ── Bell notification ── */
+        .sa-bell-wrap { position: relative; }
+        .sa-bell-btn {
+            background: none; border: none; cursor: pointer; padding: .4rem;
+            color: var(--text-muted); display: flex; align-items: center; border-radius: .4rem;
+            transition: background .15s, color .15s;
+        }
+        .sa-bell-btn:hover { background: var(--surface); color: var(--text-primary); }
+        .sa-bell-badge {
+            position: absolute; top: 0; right: 0;
+            background: #ef4444; color: #fff;
+            font-size: .6rem; font-weight: 700;
+            min-width: 16px; height: 16px; border-radius: 10px;
+            display: flex; align-items: center; justify-content: center;
+            padding: 0 .25rem;
+        }
+        .sa-bell-badge.hidden { display: none; }
+        .sa-notif-dropdown {
+            position: absolute; right: 0; top: calc(100% + 8px);
+            width: 340px; background: #fff; border: 1px solid var(--border);
+            border-radius: .75rem; box-shadow: 0 10px 30px rgba(0,0,0,.12);
+            z-index: 200; display: none;
+        }
+        .sa-notif-dropdown.open { display: block; }
+        .sa-notif-header { padding: .75rem 1rem; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
+        .sa-notif-header span { font-weight: 600; font-size: .85rem; }
+        .sa-notif-read-all { background: none; border: none; color: var(--accent); font-size: .78rem; cursor: pointer; }
+        .sa-notif-read-all:hover { text-decoration: underline; }
+        .sa-notif-list { max-height: 360px; overflow-y: auto; }
+        .sa-notif-item { display: flex; gap: .75rem; padding: .75rem 1rem; border-bottom: 1px solid #f1f5f9; cursor: pointer; transition: background .1s; text-decoration: none; color: inherit; }
+        .sa-notif-item:hover { background: var(--surface); }
+        .sa-notif-item:last-child { border-bottom: none; }
+        .sa-notif-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--sa-accent); flex-shrink: 0; margin-top: 5px; }
+        .sa-notif-body { flex: 1; min-width: 0; }
+        .sa-notif-title { font-size: .82rem; font-weight: 600; color: var(--text-primary); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+        .sa-notif-desc  { font-size: .75rem; color: var(--text-muted); margin-top: .15rem; }
+        .sa-notif-time  { font-size: .7rem; color: var(--text-muted); white-space: nowrap; }
+        .sa-notif-empty { padding: 1.5rem 1rem; text-align: center; color: var(--text-muted); font-size: .84rem; }
+
+        /* ── Charts grid ── */
+        .sa-charts-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; margin-bottom: 1.5rem; }
+        @media (max-width: 900px) { .sa-charts-grid { grid-template-columns: 1fr; } }
+
+        /* ── Settings tabs ── */
+        .sa-tabs-nav { display: flex; gap: .25rem; margin-bottom: 1.25rem; border-bottom: 1px solid var(--border); }
+        .sa-tab-btn {
+            background: none; border: none; cursor: pointer;
+            padding: .6rem 1rem; font-size: .85rem; color: var(--text-muted);
+            border-bottom: 2px solid transparent; margin-bottom: -1px;
+            transition: color .15s, border-color .15s;
+        }
+        .sa-tab-btn.active { color: #6366f1; border-bottom-color: #6366f1; font-weight: 600; }
+        .sa-tab-btn:hover:not(.active) { color: var(--text-primary); }
+        .sa-tab-panel { display: none; }
+        .sa-tab-panel.active { display: block; }
+
+        /* ── Toggle switch — specificity > input[type="checkbox"] en estilos.css ── */
+        .toggle-wrap { display: flex; align-items: center; gap: .75rem; }
+        input.sa-toggle {
+            position: relative; display: inline-block;
+            width: 44px !important; height: 24px !important; flex-shrink: 0;
+            -webkit-appearance: none; -moz-appearance: none; appearance: none;
+            background: #cbd5e1; border-radius: 12px; cursor: pointer;
+            transition: background .2s; margin: 0; padding: 0; vertical-align: middle;
+            overflow: visible;
+        }
+        input.sa-toggle:checked { background: #6366f1; }
+        input.sa-toggle::after {
+            content: ''; position: absolute;
+            top: 3px; left: 3px;
+            width: 18px; height: 18px; border-radius: 50%;
+            background: #fff; transition: transform .2s; box-shadow: 0 1px 3px rgba(0,0,0,.2);
+        }
+        input.sa-toggle:checked::after { transform: translateX(20px); }
+
+        /* ── Extra page styles injected per-page ── */
+        <?= $pageStyles ?? '' ?>
     </style>
 </head>
 <body>
@@ -189,44 +206,44 @@
         </div>
         <nav class="sa-nav">
             <div class="sa-nav-section">Panel</div>
-            <a href="<?= $base ?? '../' ?>dashboard.php"
-               class="<?= ($activeMenu ?? '') === 'dashboard' ? 'active' : '' ?>">
+            <a href="<?= $base ?? './' ?>dashboard.php" class="<?= ($activeMenu ?? '') === 'dashboard' ? 'active' : '' ?>">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>
                 Dashboard
             </a>
 
             <div class="sa-nav-section">Gestión</div>
-            <a href="<?= $base ?? '../' ?>businesses.php"
-               class="<?= ($activeMenu ?? '') === 'businesses' ? 'active' : '' ?>">
+            <a href="<?= $base ?? './' ?>businesses.php" class="<?= ($activeMenu ?? '') === 'businesses' ? 'active' : '' ?>">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
                 Negocios
             </a>
-            <a href="<?= $base ?? '../' ?>employees.php"
-               class="<?= ($activeMenu ?? '') === 'employees' ? 'active' : '' ?>">
+            <a href="<?= $base ?? './' ?>employees.php" class="<?= ($activeMenu ?? '') === 'employees' ? 'active' : '' ?>">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
                 Empleados
             </a>
 
             <div class="sa-nav-section">Comunicación</div>
-            <a href="<?= $base ?? '../' ?>contact.php"
-               class="<?= ($activeMenu ?? '') === 'contact' ? 'active' : '' ?>">
+            <a href="<?= $base ?? './' ?>contact.php" class="<?= ($activeMenu ?? '') === 'contact' ? 'active' : '' ?>">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z"/><polyline points="22,6 12,13 2,6"/></svg>
                 Mensajes
                 <?php if (($mensajesSinLeer ?? 0) > 0): ?>
-                    <span class="sa-badge-count"><?= $mensajesSinLeer ?></span>
+                    <span class="sa-badge-count"><?= (int)$mensajesSinLeer ?></span>
                 <?php endif; ?>
             </a>
-            <a href="<?= $base ?? '../' ?>announcements.php"
-               class="<?= ($activeMenu ?? '') === 'announcements' ? 'active' : '' ?>">
+            <a href="<?= $base ?? './' ?>announcements.php" class="<?= ($activeMenu ?? '') === 'announcements' ? 'active' : '' ?>">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 17H2a3 3 0 000 6h20a3 3 0 000-6z"/><path d="M6 17V3a2 2 0 012-2h8a2 2 0 012 2v14"/></svg>
                 Anuncios
             </a>
 
             <div class="sa-nav-section">Auditoría</div>
-            <a href="<?= $base ?? '../' ?>logs.php"
-               class="<?= ($activeMenu ?? '') === 'logs' ? 'active' : '' ?>">
+            <a href="<?= $base ?? './' ?>logs.php" class="<?= ($activeMenu ?? '') === 'logs' ? 'active' : '' ?>">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg>
                 Actividad
+            </a>
+
+            <div class="sa-nav-section">Sistema</div>
+            <a href="<?= $base ?? './' ?>settings.php" class="<?= ($activeMenu ?? '') === 'settings' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
+                Configuración
             </a>
         </nav>
 
@@ -242,7 +259,7 @@
                     <div style="font-size:.72rem;color:rgba(255,255,255,.4);">Superadmin</div>
                 </div>
             </div>
-            <a href="<?= $base ?? '../' ?>../logout.php" class="sa-logout">
+            <a href="<?= $base ?? './' ?>../logout.php" class="sa-logout">
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 01-2-2V5a2 2 0 012-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg>
                 Cerrar sesión
             </a>
@@ -253,10 +270,43 @@
     <main class="sa-main">
         <div class="sa-topbar">
             <span class="sa-topbar-title"><?= htmlspecialchars($pageTitle ?? '', ENT_QUOTES, 'UTF-8') ?></span>
+
             <?php if (!empty($topbarActions)): ?>
                 <?= $topbarActions ?>
             <?php endif; ?>
+
+            <!-- Campana de notificaciones -->
+            <?php
+            if (!isset($notifCount)) {
+                $notifCount = 0;
+                try {
+                    require_once __DIR__ . '/../../core/NotificationService.php';
+                    $notifCount = NotificationService::unreadCount();
+                } catch (\Throwable) {}
+            }
+            ?>
+            <div class="sa-bell-wrap" id="bellWrap">
+                <button class="sa-bell-btn" id="bellBtn" aria-label="Notificaciones" onclick="toggleNotifDropdown(event)">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M18 8A6 6 0 006 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 01-3.46 0"/>
+                    </svg>
+                    <span class="sa-bell-badge <?= $notifCount === 0 ? 'hidden' : '' ?>" id="bellBadge">
+                        <?= $notifCount > 99 ? '99+' : $notifCount ?>
+                    </span>
+                </button>
+
+                <div class="sa-notif-dropdown" id="notifDropdown">
+                    <div class="sa-notif-header">
+                        <span>Notificaciones</span>
+                        <button class="sa-notif-read-all" onclick="markAllRead()">Marcar todas leídas</button>
+                    </div>
+                    <div class="sa-notif-list" id="notifList">
+                        <div class="sa-notif-empty">Cargando…</div>
+                    </div>
+                </div>
+            </div>
         </div>
+
         <div class="sa-content">
             <?php if (!empty($flashSuccess)): ?>
                 <div class="sa-alert sa-alert-success"><?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?></div>
@@ -269,5 +319,119 @@
         </div>
     </main>
 </div>
+
+<script>
+/**
+ * Gestión del dropdown de notificaciones y auto-actualización del badge.
+ */
+(function () {
+    const BASE = '<?= rtrim($base ?? './', '/') ?>';
+
+    // Cerrar dropdown al hacer clic fuera
+    document.addEventListener('click', (e) => {
+        const wrap = document.getElementById('bellWrap');
+        if (wrap && !wrap.contains(e.target)) {
+            document.getElementById('notifDropdown').classList.remove('open');
+        }
+    });
+
+    window.toggleNotifDropdown = function (e) {
+        e.stopPropagation();
+        const dd = document.getElementById('notifDropdown');
+        const isOpen = dd.classList.toggle('open');
+        if (isOpen) loadNotifications();
+    };
+
+    /**
+     * Carga las últimas notificaciones no leídas y renderiza el dropdown.
+     */
+    async function loadNotifications() {
+        const list = document.getElementById('notifList');
+        try {
+            const res  = await fetch(BASE + '/notifications/unread-count.php');
+            const json = await res.json();
+            updateBadge(json?.data?.count ?? 0);
+        } catch {}
+
+        // Cargar lista de notifs
+        try {
+            const res   = await fetch(BASE + '/notifications/list.php');
+            const json  = await res.json();
+            if (!json.success || !json.data?.length) {
+                list.innerHTML = '<div class="sa-notif-empty">Sin notificaciones pendientes.</div>';
+                return;
+            }
+            list.innerHTML = json.data.map(n => `
+                <a href="${n.link || '#'}" class="sa-notif-item" onclick="handleNotifClick(event, '${n.link || '#'}')">
+                    <div class="sa-notif-dot" style="background:${notifColor(n.type)}"></div>
+                    <div class="sa-notif-body">
+                        <div class="sa-notif-title">${escHtml(n.title)}</div>
+                        <div class="sa-notif-desc">${escHtml(n.body || '')}</div>
+                    </div>
+                    <div class="sa-notif-time">${timeAgo(n.created_at)}</div>
+                </a>
+            `).join('');
+        } catch {
+            list.innerHTML = '<div class="sa-notif-empty">Error al cargar notificaciones.</div>';
+        }
+    }
+
+    function notifColor(type) {
+        const colors = {
+            new_business: '#818cf8', plan_expiring: '#f59e0b',
+            critical_ticket: '#ef4444', new_message: '#22c55e',
+            business_deactivated: '#ef4444',
+        };
+        return colors[type] || '#818cf8';
+    }
+
+    function timeAgo(dateStr) {
+        const diff = Math.floor((Date.now() - new Date(dateStr)) / 1000);
+        if (diff < 60)   return 'ahora';
+        if (diff < 3600) return Math.floor(diff/60) + 'm';
+        if (diff < 86400) return Math.floor(diff/3600) + 'h';
+        return Math.floor(diff/86400) + 'd';
+    }
+
+    function escHtml(str) {
+        return String(str).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+    }
+
+    window.handleNotifClick = function(e, link) {
+        document.getElementById('notifDropdown').classList.remove('open');
+    };
+
+    /**
+     * Marca todas las notificaciones como leídas.
+     */
+    window.markAllRead = async function () {
+        try {
+            await fetch(BASE + '/notifications/read-all.php', { method: 'POST' });
+            updateBadge(0);
+            document.getElementById('notifList').innerHTML =
+                '<div class="sa-notif-empty">Sin notificaciones pendientes.</div>';
+            document.getElementById('notifDropdown').classList.remove('open');
+        } catch {}
+    };
+
+    function updateBadge(count) {
+        const badge = document.getElementById('bellBadge');
+        if (!badge) return;
+        badge.textContent = count > 99 ? '99+' : count;
+        badge.classList.toggle('hidden', count === 0);
+    }
+
+    // Auto-actualizar badge cada 60 segundos
+    async function refreshBadge() {
+        try {
+            const res  = await fetch(BASE + '/notifications/unread-count.php');
+            const json = await res.json();
+            updateBadge(json?.data?.count ?? 0);
+        } catch {}
+    }
+
+    setInterval(refreshBadge, 60000);
+})();
+</script>
 </body>
 </html>

--- a/src/views/maintenance.php
+++ b/src/views/maintenance.php
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mantenimiento – es21plus</title>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: linear-gradient(135deg, #0f172a 0%, #1e293b 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1.5rem;
+        }
+        .card {
+            background: #fff;
+            border-radius: 16px;
+            padding: 3rem 2.5rem;
+            max-width: 480px;
+            width: 100%;
+            text-align: center;
+            box-shadow: 0 25px 50px rgba(0,0,0,.4);
+        }
+        .icon {
+            width: 64px; height: 64px;
+            background: #fef3c7;
+            border-radius: 50%;
+            display: flex; align-items: center; justify-content: center;
+            margin: 0 auto 1.5rem;
+        }
+        h1 { font-size: 1.5rem; color: #0f172a; margin-bottom: .5rem; }
+        p { color: #64748b; line-height: 1.6; font-size: .95rem; }
+        .msg {
+            margin-top: 1.25rem;
+            background: #f1f5f9;
+            border-radius: .5rem;
+            padding: 1rem;
+            color: #334155;
+            font-size: .9rem;
+            text-align: left;
+        }
+        .footer { margin-top: 2rem; font-size: .78rem; color: #94a3b8; }
+    </style>
+</head>
+<body>
+<div class="card">
+    <div class="icon">
+        <svg width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="#f59e0b" stroke-width="2">
+            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
+        </svg>
+    </div>
+    <h1>Sistema en mantenimiento</h1>
+    <p>Estamos realizando mejoras. Vuelve en unos minutos.</p>
+    <?php if (!empty($maintenanceMessage)): ?>
+        <div class="msg"><?= htmlspecialchars($maintenanceMessage, ENT_QUOTES, 'UTF-8') ?></div>
+    <?php endif; ?>
+    <div class="footer">es21plus &copy; <?= date('Y') ?></div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Bloque 1 — Seguridad**: protección fuerza bruta (tabla `login_attempts`, bloqueo por IP tras 5 intentos / 15 min), registro de sesiones (`session_logs`), auditoría crítica con `metadata` JSON en `activity_logs`; vista `/superadmin/settings/security.php` con IPs bloqueadas, histórico de sesiones y acciones críticas
- **Bloque 2 — Dashboard profesional**: KPIs con variación mes-a-mes, 4 gráficos Chart.js (líneas, barras, dona, área), tabla resumen de negocios con colores por vencimiento de plan, feed de actividad con auto-refresco cada 30 s
- **Bloque 3 — Notificaciones internas**: tabla `superadmin_notifications`, campana en topbar con badge y dropdown, auto-refresh cada 60 s, comprobación automática de planes próximos a vencer al inicio de sesión
- **Bloque 4 — Configuración global**: tabla `system_settings` (13 claves), `Settings` con caché estática, `Mailer` usa settings de BD con fallback a env, modo mantenimiento (bloquea empleados, superadmin pasa), página de ajustes con tabs General/SMTP + botón test-email en vivo

## Migraciones a ejecutar

```bash
# Dentro del contenedor web (DB no expone root externo)
docker exec inventario_motos_web php -r "..."
```

Las 3 migraciones ya se aplicaron al entorno de desarrollo:
- `database/migrations/security.sql`
- `database/migrations/notifications.sql`
- `database/migrations/settings.sql`

## Test plan

- [ ] Login con credenciales incorrectas 5 veces → 6.º intento muestra "Demasiados intentos. Espera 15 minutos."
- [ ] Login correcto → registro en `session_logs` con `action = login`
- [ ] Logout → registro en `session_logs` con `action = logout`
- [ ] `/superadmin/settings/security.php` → lista IPs bloqueadas; botón desbloquear funciona
- [ ] Dashboard carga sin errores con 0 datos y con datos reales; gráficos renderizan
- [ ] Variación porcentual: mes anterior 0 negocios, este mes 2 → muestra `↑ 100%`
- [ ] Feed de actividad se actualiza cada 30 s
- [ ] Crear negocio → aparece notificación `new_business` en campana
- [ ] Desactivar empresa → `activity_logs` tiene `is_critical = 1` con metadata antes/después
- [ ] Marcar todas las notificaciones leídas → badge vuelve a 0
- [ ] Activar modo mantenimiento → empleado de empresa ve pantalla de mantenimiento; superadmin accede normal
- [ ] Guardar SMTP + botón "Enviar email de prueba" → muestra éxito o error sin romper página
- [ ] Toggles de Configuración General renderizan correctamente (sin desbordamiento)

🤖 Generated with [Claude Code](https://claude.com/claude-code)