### PR TITLE
feat(superadmin): tickets de soporte, facturación y reportes

### DIFF
--- a/database/migrations/tickets_billing.sql
+++ b/database/migrations/tickets_billing.sql
@@ -1,0 +1,76 @@
+-- =============================================================
+-- Migración: Tickets de Soporte + Facturación
+--
+-- Tablas: support_tickets, ticket_messages, ticket_attachments,
+--         plan_prices, invoices
+--
+-- @author  Carlos Vico
+-- @version 1.0.0
+-- =============================================================
+
+-- Support tickets
+CREATE TABLE IF NOT EXISTS support_tickets (
+    id             INT           AUTO_INCREMENT PRIMARY KEY,
+    business_id    INT           NOT NULL,
+    employee_id    INT           NULL,
+    ticket_number  VARCHAR(20)   NOT NULL UNIQUE,
+    subject        VARCHAR(255)  NOT NULL,
+    status         ENUM('open','in_progress','resolved','closed') NOT NULL DEFAULT 'open',
+    priority       ENUM('low','normal','high','urgent')           NOT NULL DEFAULT 'normal',
+    created_at     TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMP     DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    closed_at      TIMESTAMP     NULL DEFAULT NULL,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ticket_messages (
+    id           INT          AUTO_INCREMENT PRIMARY KEY,
+    ticket_id    INT          NOT NULL,
+    sender_type  ENUM('business','superadmin') NOT NULL,
+    sender_id    INT          NOT NULL,
+    message      TEXT         NOT NULL,
+    created_at   TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (ticket_id) REFERENCES support_tickets(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ticket_attachments (
+    id            INT          AUTO_INCREMENT PRIMARY KEY,
+    message_id    INT          NOT NULL,
+    filename      VARCHAR(255) NOT NULL,
+    original_name VARCHAR(255) NOT NULL,
+    mime_type     VARCHAR(100) NOT NULL,
+    size          INT          NOT NULL DEFAULT 0,
+    uploaded_at   TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (message_id) REFERENCES ticket_messages(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Plan pricing table
+CREATE TABLE IF NOT EXISTS plan_prices (
+    id            INT              AUTO_INCREMENT PRIMARY KEY,
+    plan          ENUM('free','basic','pro') NOT NULL UNIQUE,
+    monthly_price DECIMAL(8,2)     NOT NULL DEFAULT 0.00,
+    annual_price  DECIMAL(8,2)     NOT NULL DEFAULT 0.00,
+    features      JSON,
+    updated_at    TIMESTAMP        DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO plan_prices (plan, monthly_price, annual_price, features) VALUES
+('free',   0.00,   0.00,   '{"max_products": 50, "max_employees": 2, "reports": false}'),
+('basic', 29.99, 299.99,   '{"max_products": 500, "max_employees": 10, "reports": true}'),
+('pro',   79.99, 799.99,   '{"max_products": -1, "max_employees": -1, "reports": true}')
+ON DUPLICATE KEY UPDATE updated_at = updated_at;
+
+-- Invoices
+CREATE TABLE IF NOT EXISTS invoices (
+    id             INT           AUTO_INCREMENT PRIMARY KEY,
+    business_id    INT           NOT NULL,
+    invoice_number VARCHAR(20)   NOT NULL UNIQUE,
+    amount         DECIMAL(10,2) NOT NULL,
+    status         ENUM('pending','paid','cancelled') NOT NULL DEFAULT 'pending',
+    period_start   DATE          NULL,
+    period_end     DATE          NULL,
+    notes          TEXT          NULL,
+    paid_at        TIMESTAMP     NULL DEFAULT NULL,
+    created_at     TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -218,3 +218,64 @@ CREATE TABLE IF NOT EXISTS compatibilidades (
     FOREIGN KEY (producto_id) REFERENCES productos(id) ON DELETE CASCADE,
     FOREIGN KEY (modelo_id)   REFERENCES modelos_moto(id) ON DELETE CASCADE
 ) ENGINE=InnoDB;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Tickets de soporte, Facturación y Planes
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS support_tickets (
+    id             INT          AUTO_INCREMENT PRIMARY KEY,
+    business_id    INT          NOT NULL,
+    employee_id    INT          NULL,
+    ticket_number  VARCHAR(20)  NOT NULL UNIQUE,
+    subject        VARCHAR(255) NOT NULL,
+    status         ENUM('open','in_progress','resolved','closed') NOT NULL DEFAULT 'open',
+    priority       ENUM('low','normal','high','urgent')           NOT NULL DEFAULT 'normal',
+    created_at     TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    updated_at     TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    closed_at      TIMESTAMP    NULL DEFAULT NULL,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ticket_messages (
+    id           INT         AUTO_INCREMENT PRIMARY KEY,
+    ticket_id    INT         NOT NULL,
+    sender_type  ENUM('business','superadmin') NOT NULL,
+    sender_id    INT         NOT NULL,
+    message      TEXT        NOT NULL,
+    created_at   TIMESTAMP   DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (ticket_id) REFERENCES support_tickets(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS ticket_attachments (
+    id            INT         AUTO_INCREMENT PRIMARY KEY,
+    message_id    INT         NOT NULL,
+    filename      VARCHAR(255) NOT NULL,
+    original_name VARCHAR(255) NOT NULL,
+    mime_type     VARCHAR(100) NOT NULL,
+    size          INT         NOT NULL DEFAULT 0,
+    uploaded_at   TIMESTAMP   DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (message_id) REFERENCES ticket_messages(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS plan_prices (
+    id            INT              AUTO_INCREMENT PRIMARY KEY,
+    plan          ENUM('free','basic','pro') NOT NULL UNIQUE,
+    monthly_price DECIMAL(8,2)     NOT NULL DEFAULT 0.00,
+    annual_price  DECIMAL(8,2)     NOT NULL DEFAULT 0.00,
+    features      JSON,
+    updated_at    TIMESTAMP        DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS invoices (
+    id             INT           AUTO_INCREMENT PRIMARY KEY,
+    business_id    INT           NOT NULL,
+    invoice_number VARCHAR(20)   NOT NULL UNIQUE,
+    amount         DECIMAL(10,2) NOT NULL,
+    status         ENUM('pending','paid','cancelled') NOT NULL DEFAULT 'pending',
+    period_start   DATE          NULL,
+    period_end     DATE          NULL,
+    notes          TEXT          NULL,
+    paid_at        TIMESTAMP     NULL DEFAULT NULL,
+    created_at     TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -220,6 +220,137 @@ CREATE TABLE IF NOT EXISTS compatibilidades (
 ) ENGINE=InnoDB;
 
 -- ─────────────────────────────────────────────────────────────────────────────
+-- Multi-tenant: negocios, empleados, contacto, actividad, anuncios
+-- (originadas en database/migrations/superadmin_panel.sql)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS businesses (
+    id              INT           AUTO_INCREMENT PRIMARY KEY,
+    name            VARCHAR(150)  NOT NULL,
+    slug            VARCHAR(100)  NOT NULL UNIQUE,
+    logo_path       VARCHAR(255),
+    contact_email   VARCHAR(150),
+    phone           VARCHAR(30),
+    address         TEXT,
+    email           VARCHAR(150),
+    plan            ENUM('free','basic','pro') DEFAULT 'free',
+    plan_expires_at DATE,
+    is_active       TINYINT(1)    DEFAULT 1,
+    created_at      TIMESTAMP     DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS employees (
+    id          INT           AUTO_INCREMENT PRIMARY KEY,
+    business_id INT           NOT NULL,
+    name        VARCHAR(100)  NOT NULL,
+    email       VARCHAR(150)  NOT NULL,
+    password    VARCHAR(255)  NOT NULL,
+    role        ENUM('admin','employee') DEFAULT 'employee',
+    is_active   TINYINT(1)    DEFAULT 1,
+    created_at  TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS contact_messages (
+    id           INT           AUTO_INCREMENT PRIMARY KEY,
+    business_id  INT,
+    sender_name  VARCHAR(100)  NOT NULL,
+    sender_email VARCHAR(150)  NOT NULL,
+    subject      VARCHAR(200),
+    message      TEXT          NOT NULL,
+    is_read      TINYINT(1)    DEFAULT 0,
+    replied_at   TIMESTAMP     NULL,
+    created_at   TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS activity_logs (
+    id          INT           AUTO_INCREMENT PRIMARY KEY,
+    business_id INT,
+    employee_id INT,
+    action      VARCHAR(200)  NOT NULL,
+    entity      VARCHAR(100),
+    entity_id   INT,
+    ip_address  VARCHAR(45),
+    metadata    JSON          NULL,
+    is_critical TINYINT(1)    DEFAULT 0,
+    created_at  TIMESTAMP     DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (business_id) REFERENCES businesses(id) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS announcements (
+    id         INT           AUTO_INCREMENT PRIMARY KEY,
+    title      VARCHAR(200)  NOT NULL,
+    body       TEXT          NOT NULL,
+    is_active  TINYINT(1)    DEFAULT 1,
+    created_at TIMESTAMP     DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Seguridad: intentos de login, sesiones
+-- (database/migrations/security.sql)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS login_attempts (
+    id           INT          AUTO_INCREMENT PRIMARY KEY,
+    ip_address   VARCHAR(45)  NOT NULL,
+    email        VARCHAR(150),
+    attempted_at TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_ip   (ip_address),
+    INDEX idx_time (attempted_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS session_logs (
+    id          INT          AUTO_INCREMENT PRIMARY KEY,
+    user_type   ENUM('superadmin','employee') NOT NULL,
+    user_id     INT          NOT NULL,
+    business_id INT          NULL,
+    ip_address  VARCHAR(45)  NULL,
+    user_agent  VARCHAR(500) NULL,
+    action      ENUM('login','logout','expired') NOT NULL,
+    created_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Notificaciones y configuración global
+-- (database/migrations/notifications.sql + settings.sql)
+-- ─────────────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS superadmin_notifications (
+    id         INT          AUTO_INCREMENT PRIMARY KEY,
+    type       VARCHAR(100) NOT NULL,
+    title      VARCHAR(200) NOT NULL,
+    body       TEXT,
+    link       VARCHAR(255),
+    is_read    TINYINT(1)   DEFAULT 0,
+    created_at TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_read    (is_read),
+    INDEX idx_created (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS system_settings (
+    id          INT          AUTO_INCREMENT PRIMARY KEY,
+    setting_key VARCHAR(100) NOT NULL UNIQUE,
+    value       TEXT,
+    type        ENUM('string','integer','boolean','json') DEFAULT 'string',
+    description VARCHAR(255),
+    updated_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+INSERT INTO system_settings (setting_key, value, type, description) VALUES
+('app_name',            'es21plus', 'string',  'Nombre de la aplicación'),
+('registration_open',   '1',        'boolean', 'Permitir registro público'),
+('maintenance_mode',    '0',        'boolean', 'Modo mantenimiento'),
+('maintenance_message', '',         'string',  'Mensaje de mantenimiento'),
+('default_plan',        'free',     'string',  'Plan por defecto en registro'),
+('trial_days',          '14',       'integer', 'Días de prueba al registrarse'),
+('max_file_upload_mb',  '5',        'integer', 'Tamaño máximo de subida en MB'),
+('superadmin_email',    '',         'string',  'Email de notificaciones'),
+('smtp_host',           '',         'string',  'Servidor SMTP'),
+('smtp_port',           '587',      'integer', 'Puerto SMTP'),
+('smtp_user',           '',         'string',  'Usuario SMTP'),
+('smtp_password',       '',         'string',  'Contraseña SMTP cifrada'),
+('smtp_from_name',      'es21plus', 'string',  'Nombre remitente de correos')
+ON DUPLICATE KEY UPDATE setting_key = setting_key;
+
+-- ─────────────────────────────────────────────────────────────────────────────
 -- Tickets de soporte, Facturación y Planes
 -- ─────────────────────────────────────────────────────────────────────────────
 CREATE TABLE IF NOT EXISTS support_tickets (

--- a/src/core/CsvExporter.php
+++ b/src/core/CsvExporter.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Exporta datos en formato CSV con BOM UTF-8 para compatibilidad con Excel.
+ *
+ * @package  Es21Plus\Core
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+class CsvExporter
+{
+    /**
+     * Envía un CSV al navegador para descarga inmediata.
+     *
+     * BOM UTF-8 (\xEF\xBB\xBF) garantiza apertura correcta en Excel.
+     * Separador punto y coma (;) para compatibilidad con Excel español.
+     *
+     * @param array<string>       $headers  Cabeceras de columna.
+     * @param array<array<mixed>> $rows     Filas de datos.
+     * @param string              $filename Nombre del archivo sin extensión .csv.
+     * @return void
+     */
+    public static function download(array $headers, array $rows, string $filename): void
+    {
+        header('Content-Type: text/csv; charset=UTF-8');
+        header('Content-Disposition: attachment; filename="' . $filename . '.csv"');
+        header('Cache-Control: no-cache, no-store, must-revalidate');
+        header('Pragma: no-cache');
+        header('Expires: 0');
+
+        $out = fopen('php://output', 'w');
+        fputs($out, "\xEF\xBB\xBF");
+        fputcsv($out, $headers, ';');
+        foreach ($rows as $row) {
+            fputcsv($out, array_values($row), ';');
+        }
+        fclose($out);
+        exit;
+    }
+}

--- a/src/core/PdfGenerator.php
+++ b/src/core/PdfGenerator.php
@@ -1,0 +1,192 @@
+<?php
+/**
+ * Generador de PDFs usando FPDF (ya instalado vía Composer).
+ *
+ * Dos métodos públicos:
+ *   - downloadReport(): informe genérico en formato tabla (orientación landscape).
+ *   - downloadInvoice(): factura formal con datos del negocio.
+ *
+ * @package  Es21Plus\Core
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+class PdfGenerator
+{
+    /**
+     * Convierte texto UTF-8 a ISO-8859-1 para compatibilidad con FPDF.
+     *
+     * @param  string $text
+     * @return string
+     */
+    private static function enc(string $text): string
+    {
+        return mb_convert_encoding($text, 'ISO-8859-1', 'UTF-8');
+    }
+
+    /**
+     * Genera y descarga un PDF de informe genérico en tabla.
+     *
+     * @param string              $title    Título del informe.
+     * @param array<string>       $headers  Cabeceras de columna.
+     * @param array<array<mixed>> $rows     Filas de datos.
+     * @param string              $filename Nombre del archivo sin extensión.
+     * @throws \RuntimeException Si FPDF no está disponible.
+     * @return void
+     */
+    public static function downloadReport(
+        string $title,
+        array  $headers,
+        array  $rows,
+        string $filename
+    ): void {
+        self::loadFpdf();
+
+        $pdf = new \FPDF('L', 'mm', 'A4');
+        $pdf->AddPage();
+        $pdf->SetFont('Arial', 'B', 14);
+        $pdf->Cell(0, 10, self::enc($title), 0, 1, 'C');
+        $pdf->SetFont('Arial', '', 8);
+        $pdf->Cell(0, 5, self::enc('Generado: ' . date('d/m/Y H:i')), 0, 1, 'R');
+        $pdf->Ln(3);
+
+        $pageWidth = 277;
+        $count     = count($headers);
+        $colWidth  = $count > 0 ? $pageWidth / $count : $pageWidth;
+
+        // Header row
+        $pdf->SetFont('Arial', 'B', 8);
+        $pdf->SetFillColor(99, 102, 241);
+        $pdf->SetTextColor(255, 255, 255);
+        foreach ($headers as $h) {
+            $pdf->Cell($colWidth, 7, self::enc($h), 1, 0, 'C', true);
+        }
+        $pdf->Ln();
+
+        // Data rows
+        $pdf->SetFont('Arial', '', 7);
+        $pdf->SetTextColor(0, 0, 0);
+        $fill = false;
+        foreach ($rows as $row) {
+            $pdf->SetFillColor($fill ? 248 : 255, $fill ? 250 : 255, $fill ? 252 : 255);
+            foreach (array_values($row) as $cell) {
+                $pdf->Cell($colWidth, 6, self::enc((string)$cell), 1, 0, 'L', true);
+            }
+            $pdf->Ln();
+            $fill = !$fill;
+        }
+
+        header('Content-Type: application/pdf');
+        header('Content-Disposition: attachment; filename="' . $filename . '.pdf"');
+        header('Cache-Control: no-cache, no-store, must-revalidate');
+        $pdf->Output('D', $filename . '.pdf');
+        exit;
+    }
+
+    /**
+     * Genera y descarga un PDF de factura formal.
+     *
+     * @param array<string,mixed> $invoice  Fila de la tabla invoices.
+     * @param array<string,mixed> $business Fila de la tabla businesses.
+     * @throws \RuntimeException Si FPDF no está disponible.
+     * @return void
+     */
+    public static function downloadInvoice(array $invoice, array $business): void
+    {
+        self::loadFpdf();
+
+        $pdf = new \FPDF('P', 'mm', 'A4');
+        $pdf->AddPage();
+
+        // Marca / título
+        $pdf->SetFont('Arial', 'B', 18);
+        $pdf->SetTextColor(99, 102, 241);
+        $pdf->Cell(0, 12, 'es21plus', 0, 1, 'L');
+        $pdf->SetTextColor(0, 0, 0);
+
+        $pdf->SetFont('Arial', 'B', 14);
+        $pdf->Cell(0, 8, self::enc('FACTURA'), 0, 1, 'R');
+        $pdf->SetFont('Arial', '', 9);
+        $pdf->Cell(0, 5, self::enc('N.° ' . $invoice['invoice_number']), 0, 1, 'R');
+        $pdf->Cell(0, 5, self::enc('Fecha: ' . date('d/m/Y', strtotime($invoice['created_at']))), 0, 1, 'R');
+
+        $pdf->Ln(4);
+        $pdf->SetDrawColor(220, 220, 220);
+        $pdf->Line(10, $pdf->GetY(), 200, $pdf->GetY());
+        $pdf->Ln(5);
+
+        // Datos del cliente
+        $pdf->SetFont('Arial', 'B', 9);
+        $pdf->Cell(0, 5, self::enc('Facturar a:'), 0, 1);
+        $pdf->SetFont('Arial', '', 9);
+        $pdf->Cell(0, 5, self::enc($business['name'] ?? ''), 0, 1);
+        $pdf->Cell(0, 5, self::enc($business['email'] ?? ''), 0, 1);
+
+        $pdf->Ln(8);
+
+        // Tabla de ítems
+        $pdf->SetFont('Arial', 'B', 9);
+        $pdf->SetFillColor(99, 102, 241);
+        $pdf->SetTextColor(255, 255, 255);
+        $pdf->Cell(110, 8, self::enc('Descripción'), 1, 0, 'L', true);
+        $pdf->Cell(40,  8, self::enc('Periodo'),     1, 0, 'C', true);
+        $pdf->Cell(40,  8, self::enc('Importe'),     1, 1, 'R', true);
+
+        $pdf->SetFont('Arial', '', 9);
+        $pdf->SetTextColor(0, 0, 0);
+        $pdf->SetFillColor(248, 250, 252);
+
+        $plan    = ucfirst($business['plan'] ?? '');
+        $periodo = '';
+        if (!empty($invoice['period_start']) && !empty($invoice['period_end'])) {
+            $periodo = date('d/m/Y', strtotime($invoice['period_start']))
+                . ' - '
+                . date('d/m/Y', strtotime($invoice['period_end']));
+        }
+        $pdf->Cell(110, 7, self::enc("Plan {$plan} - Suscripción"), 1, 0, 'L', true);
+        $pdf->Cell(40,  7, self::enc($periodo), 1, 0, 'C', true);
+        $pdf->Cell(40,  7, self::enc(number_format((float)$invoice['amount'], 2, ',', '.') . ' €'), 1, 1, 'R', true);
+
+        // Total
+        $pdf->Ln(3);
+        $pdf->SetFont('Arial', 'B', 10);
+        $pdf->Cell(150, 8, self::enc('Total:'), 0, 0, 'R');
+        $pdf->Cell(40,  8, self::enc(number_format((float)$invoice['amount'], 2, ',', '.') . ' €'), 0, 1, 'R');
+
+        // Estado de la factura
+        $pdf->Ln(4);
+        $statusLabel = match($invoice['status'] ?? '') {
+            'paid'      => 'PAGADA',
+            'cancelled' => 'CANCELADA',
+            default     => 'PENDIENTE',
+        };
+        $pdf->SetFont('Arial', 'B', 11);
+        match($invoice['status'] ?? '') {
+            'paid'      => $pdf->SetTextColor(21, 128, 61),
+            'cancelled' => $pdf->SetTextColor(185, 28, 28),
+            default     => $pdf->SetTextColor(146, 64, 14),
+        };
+        $pdf->Cell(0, 10, self::enc($statusLabel), 0, 1, 'R');
+
+        if (!empty($invoice['notes'])) {
+            $pdf->SetTextColor(100, 116, 139);
+            $pdf->SetFont('Arial', 'I', 8);
+            $pdf->Ln(4);
+            $pdf->Cell(0, 5, self::enc('Notas: ' . $invoice['notes']), 0, 1);
+        }
+
+        header('Content-Type: application/pdf');
+        header('Content-Disposition: attachment; filename="' . $invoice['invoice_number'] . '.pdf"');
+        header('Cache-Control: no-cache, no-store, must-revalidate');
+        $pdf->Output('D', $invoice['invoice_number'] . '.pdf');
+        exit;
+    }
+
+    private static function loadFpdf(): void
+    {
+        $autoload = __DIR__ . '/../../vendor/autoload.php';
+        if (!file_exists($autoload)) {
+            throw new \RuntimeException('vendor/autoload.php no encontrado. Ejecuta: composer install');
+        }
+        require_once $autoload;
+    }
+}

--- a/src/index.php
+++ b/src/index.php
@@ -143,6 +143,13 @@ try {
             </a>
             <?php endif; ?>
         </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
+        </div>
     </nav>
 
     <div class="sidebar-footer">

--- a/src/middleware/BusinessMiddleware.php
+++ b/src/middleware/BusinessMiddleware.php
@@ -99,6 +99,23 @@ class BusinessMiddleware
             }
         }
 
+        // 7. Cargar límites de plan en sesión (con caché de 5 min)
+        if (empty($_SESSION['plan_features']) || (time() - ($_SESSION['plan_features_loaded_at'] ?? 0)) > 300) {
+            try {
+                $plan    = $business['plan'] ?? 'free';
+                $pdo2    = Database::getInstance();
+                $featRow = $pdo2->prepare('SELECT features FROM plan_prices WHERE plan = ?');
+                $featRow->execute([$plan]);
+                $row = $featRow->fetch();
+                if ($row && $row['features']) {
+                    $_SESSION['plan_features']           = json_decode($row['features'], true) ?? [];
+                    $_SESSION['plan_features_loaded_at'] = time();
+                }
+            } catch (\Throwable) {
+                // plan_prices puede no existir aún; no bloquear
+            }
+        }
+
         return $business;
     }
 

--- a/src/soporte/crear-ticket.php
+++ b/src/soporte/crear-ticket.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Formulario de creación de ticket de soporte — panel de empresa.
+ *
+ * @package  Es21Plus
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../includes/auth_check.php';
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../superadmin/controllers/TicketController.php';
+
+$flashError = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $ctrl       = new TicketController();
+    $businessId = (int)($_SESSION['business_id'] ?? 0);
+    $employeeId = (int)($_SESSION['user_id']     ?? 0);
+
+    try {
+        $ticketId = $ctrl->createTicket(
+            trim($_POST['subject']  ?? ''),
+            trim($_POST['message']  ?? ''),
+            $businessId,
+            $employeeId
+        );
+        $_SESSION['flash_success'] = 'Ticket creado correctamente. Recibirás una respuesta pronto.';
+        header('Location: ticket.php?id=' . $ticketId);
+        exit;
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    }
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Nuevo Ticket – es21plus</title>
+    <link rel="stylesheet" href="../css/estilos.css">
+</head>
+<body class="layout">
+
+<aside class="sidebar" id="sidebar">
+    <div class="sidebar-header">
+        <div class="sidebar-logo">
+            <svg class="logo-icon" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/>
+            </svg>
+            <span class="logo-text">es21<strong>plus</strong></span>
+        </div>
+        <button class="sidebar-close" id="sidebarClose" aria-label="Cerrar menú">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+        </button>
+    </div>
+    <nav class="sidebar-nav">
+        <div class="nav-section">
+            <span class="nav-section-label">Principal</span>
+            <a href="../index.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
+                <span class="nav-label">Dashboard</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="mis-tickets.php" class="nav-item active">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
+        </div>
+    </nav>
+</aside>
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<div class="main-wrapper">
+    <header class="topbar">
+        <div class="topbar-left">
+            <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+                </svg>
+            </button>
+            <nav class="breadcrumb-nav">
+                <a href="../index.php" class="breadcrumb-item">Inicio</a>
+                <span class="breadcrumb-sep">›</span>
+                <a href="mis-tickets.php" class="breadcrumb-item">Soporte</a>
+                <span class="breadcrumb-sep">›</span>
+                <span class="breadcrumb-item active">Nuevo Ticket</span>
+            </nav>
+        </div>
+        <div class="topbar-right">
+            <?php require_once __DIR__ . '/../includes/topbar_user.php'; ?>
+        </div>
+    </header>
+
+    <main class="content-wrapper">
+        <div class="page-header">
+            <h1 class="page-title">Nuevo Ticket de Soporte</h1>
+            <p class="page-subtitle">Describe tu problema y te responderemos lo antes posible.</p>
+        </div>
+
+        <?php if ($flashError): ?>
+            <div class="alert alert-error" style="margin-bottom:1rem;"><?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?></div>
+        <?php endif; ?>
+
+        <div style="max-width:640px;">
+            <div style="background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:1.75rem;">
+                <form method="POST">
+                    <div class="form-field" style="margin-bottom:1rem;">
+                        <label class="field-label">Asunto <span style="color:#dc2626;">*</span></label>
+                        <input type="text" name="subject" class="field-input" required maxlength="255"
+                            placeholder="Describe brevemente el problema…"
+                            value="<?= htmlspecialchars($_POST['subject'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                    </div>
+
+                    <div class="form-field" style="margin-bottom:1.5rem;">
+                        <label class="field-label">Descripción detallada <span style="color:#dc2626;">*</span></label>
+                        <textarea name="message" class="field-input" rows="6" required
+                            placeholder="Explica el problema con el mayor detalle posible: qué ocurrió, cuándo, qué esperabas que pasara…"
+                            style="resize:vertical;"><?= htmlspecialchars($_POST['message'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+                    </div>
+
+                    <div style="display:flex;gap:.75rem;align-items:center;">
+                        <button type="submit" class="btn btn-primary">Enviar ticket</button>
+                        <a href="mis-tickets.php" class="btn btn-secondary">Cancelar</a>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+</div>
+
+<script>
+const menuToggle   = document.getElementById('menuToggle');
+const sidebar      = document.getElementById('sidebar');
+const sidebarClose = document.getElementById('sidebarClose');
+const overlay      = document.getElementById('sidebarOverlay');
+function toggleSidebar(){ sidebar.classList.toggle('open'); overlay.classList.toggle('active'); }
+menuToggle?.addEventListener('click', toggleSidebar);
+sidebarClose?.addEventListener('click', toggleSidebar);
+overlay?.addEventListener('click', toggleSidebar);
+</script>
+</body>
+</html>

--- a/src/soporte/mis-tickets.php
+++ b/src/soporte/mis-tickets.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Listado de tickets de soporte del negocio.
+ *
+ * @package  Es21Plus
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../includes/auth_check.php';
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../superadmin/controllers/TicketController.php';
+
+$ctrl       = new TicketController();
+$businessId = (int)($_SESSION['business_id'] ?? 0);
+$tickets    = $ctrl->listForBusiness($businessId);
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+$statusColors = ['open'=>'badge-unread','in_progress'=>'badge-basic','resolved'=>'badge-active','closed'=>'badge-free'];
+$statusLabels = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resuelto','closed'=>'Cerrado'];
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mis Tickets – es21plus</title>
+    <link rel="stylesheet" href="../css/estilos.css">
+</head>
+<body class="layout">
+
+<aside class="sidebar" id="sidebar">
+    <div class="sidebar-header">
+        <div class="sidebar-logo">
+            <svg class="logo-icon" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/>
+            </svg>
+            <span class="logo-text">es21<strong>plus</strong></span>
+        </div>
+        <button class="sidebar-close" id="sidebarClose" aria-label="Cerrar menú">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+        </button>
+    </div>
+    <nav class="sidebar-nav">
+        <div class="nav-section">
+            <span class="nav-section-label">Principal</span>
+            <a href="../index.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
+                <span class="nav-label">Dashboard</span>
+            </a>
+            <a href="../productos.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg></span>
+                <span class="nav-label">Productos</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="mis-tickets.php" class="nav-item active">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
+        </div>
+    </nav>
+</aside>
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<div class="main-wrapper">
+    <header class="topbar">
+        <div class="topbar-left">
+            <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+                </svg>
+            </button>
+            <nav class="breadcrumb-nav">
+                <a href="../index.php" class="breadcrumb-item">Inicio</a>
+                <span class="breadcrumb-sep">›</span>
+                <span class="breadcrumb-item active">Mis Tickets</span>
+            </nav>
+        </div>
+        <div class="topbar-right">
+            <?php require_once __DIR__ . '/../includes/topbar_user.php'; ?>
+        </div>
+    </header>
+
+    <main class="content-wrapper">
+        <div class="page-header" style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.75rem;">
+            <div>
+                <h1 class="page-title">Mis Tickets de Soporte</h1>
+                <p class="page-subtitle">Consulta y gestiona tus solicitudes de ayuda.</p>
+            </div>
+            <a href="crear-ticket.php" class="btn btn-primary">+ Nuevo ticket</a>
+        </div>
+
+        <?php if ($flashSuccess): ?>
+            <div class="alert alert-success" style="margin-bottom:1rem;"><?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?></div>
+        <?php endif; ?>
+        <?php if ($flashError): ?>
+            <div class="alert alert-error" style="margin-bottom:1rem;"><?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?></div>
+        <?php endif; ?>
+
+        <?php if (empty($tickets)): ?>
+        <div style="background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:3rem;text-align:center;">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#cbd5e1" stroke-width="1.5" style="margin:0 auto 1rem;display:block;"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+            <p style="color:var(--text-muted);margin-bottom:1.25rem;">Aún no tienes tickets. ¿Necesitas ayuda?</p>
+            <a href="crear-ticket.php" class="btn btn-primary">Abrir primer ticket</a>
+        </div>
+        <?php else: ?>
+        <div class="table-card">
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>Ticket</th>
+                        <th>Asunto</th>
+                        <th>Estado</th>
+                        <th>Mensajes</th>
+                        <th>Actualizado</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($tickets as $t): ?>
+                    <tr>
+                        <td><code style="font-size:.78rem;"><?= htmlspecialchars($t['ticket_number'], ENT_QUOTES, 'UTF-8') ?></code></td>
+                        <td><?= htmlspecialchars($t['subject'], ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><span class="<?= $statusColors[$t['status']] ?? 'badge-free' ?>"><?= $statusLabels[$t['status']] ?? $t['status'] ?></span></td>
+                        <td style="color:var(--text-muted);"><?= (int)$t['msg_count'] ?></td>
+                        <td style="color:var(--text-muted);font-size:.78rem;"><?= date('d/m/Y H:i', strtotime($t['updated_at'])) ?></td>
+                        <td><a href="ticket.php?id=<?= $t['id'] ?>" class="btn btn-secondary" style="padding:.25rem .6rem;font-size:.78rem;">Ver</a></td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php endif; ?>
+    </main>
+</div>
+
+<script>
+const menuToggle   = document.getElementById('menuToggle');
+const sidebar      = document.getElementById('sidebar');
+const sidebarClose = document.getElementById('sidebarClose');
+const overlay      = document.getElementById('sidebarOverlay');
+function toggleSidebar(){ sidebar.classList.toggle('open'); overlay.classList.toggle('active'); }
+menuToggle?.addEventListener('click', toggleSidebar);
+sidebarClose?.addEventListener('click', toggleSidebar);
+overlay?.addEventListener('click', toggleSidebar);
+</script>
+</body>
+</html>

--- a/src/soporte/ticket.php
+++ b/src/soporte/ticket.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ * Vista de hilo de ticket — panel de empresa.
+ *
+ * @package  Es21Plus
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../includes/auth_check.php';
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../superadmin/controllers/TicketController.php';
+
+$ctrl       = new TicketController();
+$businessId = (int)($_SESSION['business_id'] ?? 0);
+$employeeId = (int)($_SESSION['user_id']     ?? 0);
+$id         = (int)($_GET['id'] ?? 0);
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['_action'] ?? '') === 'reply') {
+    try {
+        $ctrl->replyFromBusiness($id, $businessId, $employeeId, trim($_POST['message'] ?? ''));
+        $flashSuccess = 'Respuesta enviada.';
+        header('Location: ticket.php?id=' . $id);
+        exit;
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    }
+}
+
+try {
+    $data = $ctrl->getTicketForBusiness($id, $businessId);
+} catch (AppException $e) {
+    http_response_code(404);
+    die('Ticket no encontrado o no tienes acceso.');
+}
+
+$ticket   = $data['ticket'];
+$messages = $data['messages'];
+
+$statusLabels = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resuelto','closed'=>'Cerrado'];
+$statusColors = ['open'=>'badge-unread','in_progress'=>'badge-basic','resolved'=>'badge-active','closed'=>'badge-free'];
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title><?= htmlspecialchars($ticket['ticket_number'], ENT_QUOTES, 'UTF-8') ?> – es21plus</title>
+    <link rel="stylesheet" href="../css/estilos.css">
+</head>
+<body class="layout">
+
+<aside class="sidebar" id="sidebar">
+    <div class="sidebar-header">
+        <div class="sidebar-logo">
+            <svg class="logo-icon" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/>
+            </svg>
+            <span class="logo-text">es21<strong>plus</strong></span>
+        </div>
+        <button class="sidebar-close" id="sidebarClose" aria-label="Cerrar menú">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+        </button>
+    </div>
+    <nav class="sidebar-nav">
+        <div class="nav-section">
+            <span class="nav-section-label">Principal</span>
+            <a href="../index.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
+                <span class="nav-label">Dashboard</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="mis-tickets.php" class="nav-item active">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
+        </div>
+    </nav>
+</aside>
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<div class="main-wrapper">
+    <header class="topbar">
+        <div class="topbar-left">
+            <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+                </svg>
+            </button>
+            <nav class="breadcrumb-nav">
+                <a href="../index.php" class="breadcrumb-item">Inicio</a>
+                <span class="breadcrumb-sep">›</span>
+                <a href="mis-tickets.php" class="breadcrumb-item">Soporte</a>
+                <span class="breadcrumb-sep">›</span>
+                <span class="breadcrumb-item active"><?= htmlspecialchars($ticket['ticket_number'], ENT_QUOTES, 'UTF-8') ?></span>
+            </nav>
+        </div>
+        <div class="topbar-right">
+            <?php require_once __DIR__ . '/../includes/topbar_user.php'; ?>
+        </div>
+    </header>
+
+    <main class="content-wrapper">
+
+        <?php if ($flashSuccess): ?>
+            <div class="alert alert-success" style="margin-bottom:1rem;"><?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?></div>
+        <?php endif; ?>
+        <?php if ($flashError): ?>
+            <div class="alert alert-error" style="margin-bottom:1rem;"><?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?></div>
+        <?php endif; ?>
+
+        <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1.25rem;">
+            <a href="mis-tickets.php" style="font-size:.84rem;color:var(--accent);text-decoration:none;">← Mis tickets</a>
+            <code style="font-size:.78rem;color:var(--text-muted);"><?= htmlspecialchars($ticket['ticket_number'], ENT_QUOTES, 'UTF-8') ?></code>
+            <span class="<?= $statusColors[$ticket['status']] ?? 'badge-free' ?>">
+                <?= $statusLabels[$ticket['status']] ?? $ticket['status'] ?>
+            </span>
+        </div>
+
+        <div style="max-width:720px;">
+            <!-- Título -->
+            <div style="background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:1.25rem 1.5rem;margin-bottom:1rem;">
+                <h2 style="margin:0 0 .25rem;font-size:1.05rem;color:var(--text-primary);">
+                    <?= htmlspecialchars($ticket['subject'], ENT_QUOTES, 'UTF-8') ?>
+                </h2>
+                <p style="margin:0;font-size:.78rem;color:var(--text-muted);">
+                    Abierto el <?= date('d/m/Y H:i', strtotime($ticket['created_at'])) ?>
+                </p>
+            </div>
+
+            <!-- Mensajes -->
+            <div style="display:flex;flex-direction:column;gap:.75rem;margin-bottom:1rem;">
+                <?php foreach ($messages as $msg): ?>
+                <?php $isSA = $msg['sender_type'] === 'superadmin'; ?>
+                <div style="display:flex;gap:.75rem;<?= $isSA ? 'justify-content:flex-start;' : 'justify-content:flex-end;' ?>">
+                    <?php if ($isSA): ?>
+                    <div style="width:34px;height:34px;border-radius:50%;background:#6366f1;display:flex;align-items:center;justify-content:center;font-size:.7rem;font-weight:700;color:#fff;flex-shrink:0;">SA</div>
+                    <?php endif; ?>
+                    <div style="max-width:78%;background:<?= $isSA ? '#f0f1ff' : '#f8fafc' ?>;border:1px solid <?= $isSA ? '#c7d2fe' : 'var(--border)' ?>;border-radius:<?= $isSA ? '0 1rem 1rem 1rem' : '1rem 1rem 0 1rem' ?>;padding:.75rem 1rem;">
+                        <p style="margin:0 0 .4rem;font-size:.7rem;color:var(--text-muted);">
+                            <?= $isSA ? 'Soporte es21plus' : htmlspecialchars($_SESSION['user_name'] ?? 'Tú', ENT_QUOTES, 'UTF-8') ?>
+                            · <?= date('d/m/Y H:i', strtotime($msg['created_at'])) ?>
+                        </p>
+                        <p style="margin:0;font-size:.85rem;white-space:pre-wrap;color:var(--text-primary);"><?= htmlspecialchars($msg['message'], ENT_QUOTES, 'UTF-8') ?></p>
+                    </div>
+                    <?php if (!$isSA): ?>
+                    <div style="width:34px;height:34px;border-radius:50%;background:#e0e7ff;display:flex;align-items:center;justify-content:center;font-size:.7rem;font-weight:700;color:#4338ca;flex-shrink:0;">
+                        <?= mb_strtoupper(mb_substr($_SESSION['user_name'] ?? 'U', 0, 2)) ?>
+                    </div>
+                    <?php endif; ?>
+                </div>
+                <?php endforeach; ?>
+            </div>
+
+            <!-- Responder (solo si no cerrado) -->
+            <?php if (!in_array($ticket['status'], ['closed'], true)): ?>
+            <div style="background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:1.25rem 1.5rem;">
+                <form method="POST">
+                    <input type="hidden" name="_action" value="reply">
+                    <div class="form-field" style="margin-bottom:.75rem;">
+                        <label class="field-label">Tu respuesta</label>
+                        <textarea name="message" class="field-input" rows="4" required
+                            placeholder="Escribe tu respuesta…" style="resize:vertical;"></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary">Enviar respuesta</button>
+                </form>
+            </div>
+            <?php else: ?>
+            <p style="color:var(--text-muted);font-size:.84rem;text-align:center;padding:1rem 0;">
+                Este ticket está cerrado. Si necesitas más ayuda, abre un nuevo ticket.
+            </p>
+            <?php endif; ?>
+        </div>
+    </main>
+</div>
+
+<script>
+const menuToggle   = document.getElementById('menuToggle');
+const sidebar      = document.getElementById('sidebar');
+const sidebarClose = document.getElementById('sidebarClose');
+const overlay      = document.getElementById('sidebarOverlay');
+function toggleSidebar(){ sidebar.classList.toggle('open'); overlay.classList.toggle('active'); }
+menuToggle?.addEventListener('click', toggleSidebar);
+sidebarClose?.addEventListener('click', toggleSidebar);
+overlay?.addEventListener('click', toggleSidebar);
+</script>
+</body>
+</html>

--- a/src/superadmin/billing.php
+++ b/src/superadmin/billing.php
@@ -1,0 +1,178 @@
+<?php
+/**
+ * Listado y gestión de facturas — panel superadmin.
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/controllers/BillingController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl = new BillingController();
+$flashSuccess = '';
+$flashError   = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['_action'] ?? '';
+    try {
+        if ($action === 'mark_paid') {
+            $ctrl->markPaid((int)$_POST['id']);
+            $flashSuccess = 'Factura marcada como pagada.';
+        } elseif ($action === 'cancel') {
+            $ctrl->cancel((int)$_POST['id']);
+            $flashSuccess = 'Factura cancelada.';
+        }
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    }
+}
+
+$filters = [
+    'status'      => $_GET['status']      ?? '',
+    'business_id' => (int)($_GET['business_id'] ?? 0) ?: null,
+    'q'           => trim($_GET['q'] ?? ''),
+];
+$page = max(1, (int)($_GET['page'] ?? 1));
+$data = $ctrl->list($filters, $page);
+$kpis = $ctrl->kpis();
+
+$base    = './';
+$cssBase = '../';
+$pageTitle  = 'Facturación';
+$activeMenu = 'billing';
+
+try {
+    $mensajesSinLeer = (int)\Database::getInstance()->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+} catch (\Throwable) {
+    $mensajesSinLeer = 0;
+}
+
+$statusColors = ['pending'=>'badge-unread','paid'=>'badge-active','cancelled'=>'badge-inactive'];
+$statusLabels = ['pending'=>'Pendiente','paid'=>'Pagada','cancelled'=>'Cancelada'];
+
+ob_start();
+?>
+<!-- KPIs -->
+<div class="sa-metric-grid" style="margin-bottom:1.25rem;">
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Por cobrar (pendientes)</div>
+        <div class="sa-metric-value"><?= number_format($kpis['paid_total'], 2, ',', '.') ?> €</div>
+        <div style="font-size:.78rem;color:var(--text-muted);margin-top:.3rem;"><?= $kpis['pending_count'] ?> facturas</div>
+    </div>
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Total cobrado</div>
+        <div class="sa-metric-value"><?= number_format($kpis['paid_total'], 2, ',', '.') ?> €</div>
+        <div style="font-size:.78rem;color:var(--text-muted);margin-top:.3rem;"><?= $kpis['paid_count'] ?> facturas</div>
+    </div>
+    <div class="sa-metric-card">
+        <div class="sa-metric-label">Acciones</div>
+        <div style="display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.5rem;">
+            <a href="billing/create.php" class="btn btn-primary" style="font-size:.82rem;padding:.4rem .85rem;">+ Nueva factura</a>
+            <a href="settings/plans.php" class="btn btn-secondary" style="font-size:.82rem;padding:.4rem .85rem;">Precios planes</a>
+        </div>
+    </div>
+</div>
+
+<!-- Filtros -->
+<div class="sa-form-card" style="margin-bottom:1rem;padding:1rem 1.25rem;">
+    <form method="GET" style="display:flex;gap:.75rem;align-items:flex-end;flex-wrap:wrap;">
+        <div class="form-field" style="margin:0;flex:1;min-width:160px;">
+            <label class="field-label" style="font-size:.78rem;">Buscar</label>
+            <input type="text" name="q" class="field-input" style="padding:.35rem .6rem;font-size:.82rem;"
+                placeholder="N.° factura, empresa…"
+                value="<?= htmlspecialchars($filters['q'], ENT_QUOTES, 'UTF-8') ?>">
+        </div>
+        <div class="form-field" style="margin:0;">
+            <label class="field-label" style="font-size:.78rem;">Estado</label>
+            <select name="status" class="field-input" style="padding:.35rem .6rem;font-size:.82rem;">
+                <option value="">Todos</option>
+                <option value="pending"   <?= $filters['status'] === 'pending'   ? 'selected' : '' ?>>Pendiente</option>
+                <option value="paid"      <?= $filters['status'] === 'paid'      ? 'selected' : '' ?>>Pagada</option>
+                <option value="cancelled" <?= $filters['status'] === 'cancelled' ? 'selected' : '' ?>>Cancelada</option>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-secondary" style="padding:.4rem .85rem;font-size:.82rem;">Filtrar</button>
+        <a href="billing.php" class="btn" style="padding:.4rem .85rem;font-size:.82rem;background:var(--surface);border:1px solid var(--border);color:var(--text-muted);border-radius:.4rem;text-decoration:none;">Limpiar</a>
+    </form>
+</div>
+
+<!-- Tabla -->
+<div class="sa-table-card">
+    <div class="sa-table-header">
+        <h3>Facturas (<?= number_format($data['total']) ?>)</h3>
+    </div>
+    <?php if (empty($data['items'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin facturas con los filtros aplicados.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead>
+            <tr>
+                <th>N.° Factura</th>
+                <th>Empresa</th>
+                <th>Plan</th>
+                <th>Importe</th>
+                <th>Estado</th>
+                <th>Emitida</th>
+                <th>Acciones</th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($data['items'] as $inv): ?>
+            <tr>
+                <td><code style="font-size:.78rem;"><?= htmlspecialchars($inv['invoice_number'], ENT_QUOTES, 'UTF-8') ?></code></td>
+                <td><?= htmlspecialchars($inv['business_name'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+                <td><span class="badge-<?= $inv['business_plan'] ?? 'free' ?>"><?= ucfirst($inv['business_plan'] ?? 'free') ?></span></td>
+                <td style="font-weight:600;"><?= number_format((float)$inv['amount'], 2, ',', '.') ?> €</td>
+                <td><span class="<?= $statusColors[$inv['status']] ?? 'badge-free' ?>"><?= $statusLabels[$inv['status']] ?? $inv['status'] ?></span></td>
+                <td style="color:var(--text-muted);font-size:.78rem;"><?= date('d/m/Y', strtotime($inv['created_at'])) ?></td>
+                <td>
+                    <div style="display:flex;gap:.35rem;flex-wrap:wrap;">
+                        <a href="billing/pdf.php?id=<?= $inv['id'] ?>" class="btn btn-secondary" style="padding:.25rem .5rem;font-size:.72rem;" target="_blank">PDF</a>
+                        <?php if ($inv['status'] === 'pending'): ?>
+                        <form method="POST" style="display:inline;" onsubmit="return confirm('¿Marcar como pagada?')">
+                            <input type="hidden" name="_action" value="mark_paid">
+                            <input type="hidden" name="id" value="<?= $inv['id'] ?>">
+                            <button type="submit" class="btn btn-secondary" style="padding:.25rem .5rem;font-size:.72rem;color:#15803d;">Pagada</button>
+                        </form>
+                        <form method="POST" style="display:inline;" onsubmit="return confirm('¿Cancelar factura?')">
+                            <input type="hidden" name="_action" value="cancel">
+                            <input type="hidden" name="id" value="<?= $inv['id'] ?>">
+                            <button type="submit" class="btn btn-secondary" style="padding:.25rem .5rem;font-size:.72rem;color:#dc2626;">Cancelar</button>
+                        </form>
+                        <?php endif; ?>
+                    </div>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+
+    <?php if ($data['pages'] > 1): ?>
+    <div style="padding:.75rem 1.25rem;display:flex;gap:.4rem;align-items:center;border-top:1px solid var(--border);">
+        <?php
+        $baseUrl = 'billing.php?' . http_build_query(array_filter(['status'=>$filters['status'],'q'=>$filters['q']]));
+        for ($p = 1; $p <= $data['pages']; $p++):
+        ?>
+            <a href="<?= $baseUrl ?>&page=<?= $p ?>"
+               style="padding:.3rem .6rem;border-radius:.35rem;font-size:.78rem;text-decoration:none;
+                      background:<?= $p === $page ? '#6366f1' : 'var(--surface)' ?>;
+                      color:<?= $p === $page ? '#fff' : 'var(--text-muted)' ?>;
+                      border:1px solid <?= $p === $page ? '#6366f1' : 'var(--border)' ?>;">
+                <?= $p ?>
+            </a>
+        <?php endfor; ?>
+    </div>
+    <?php endif; ?>
+    <?php endif; ?>
+</div>
+<?php
+$content = ob_get_clean();
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/billing/create.php
+++ b/src/superadmin/billing/create.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * Formulario para crear nueva factura — superadmin.
+ *
+ * @package  Es21Plus\Superadmin\Billing
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../controllers/BillingController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl = new BillingController();
+$businesses   = $ctrl->getActiveBusinesses();
+$flashSuccess = '';
+$flashError   = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    try {
+        $id = $ctrl->store($_POST);
+        $_SESSION['flash_success'] = 'Factura creada correctamente.';
+        header('Location: ../billing.php');
+        exit;
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    }
+}
+
+$base    = '../';
+$cssBase = '../../';
+$pageTitle  = 'Nueva factura';
+$activeMenu = 'billing';
+
+try {
+    $mensajesSinLeer = (int)\Database::getInstance()->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+} catch (\Throwable) {
+    $mensajesSinLeer = 0;
+}
+
+ob_start();
+?>
+<div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem;">
+    <a href="../billing.php" style="font-size:.84rem;color:var(--accent);text-decoration:none;">← Volver a Facturación</a>
+</div>
+
+<div class="sa-form-card" style="max-width:600px;">
+    <h2>Nueva factura</h2>
+    <form method="POST">
+        <div class="form-field" style="margin-bottom:1rem;">
+            <label class="field-label">Empresa</label>
+            <select name="business_id" class="field-input" required>
+                <option value="">— Selecciona empresa —</option>
+                <?php foreach ($businesses as $b): ?>
+                    <option value="<?= $b['id'] ?>" <?= (int)($_POST['business_id'] ?? 0) === $b['id'] ? 'selected' : '' ?>>
+                        <?= htmlspecialchars($b['name'], ENT_QUOTES, 'UTF-8') ?>
+                        (<?= ucfirst($b['plan']) ?>)
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+
+        <div class="form-field" style="margin-bottom:1rem;">
+            <label class="field-label">Importe (€)</label>
+            <input type="number" name="amount" class="field-input" min="0.01" step="0.01" required
+                value="<?= htmlspecialchars($_POST['amount'] ?? '', ENT_QUOTES, 'UTF-8') ?>"
+                placeholder="29.99">
+        </div>
+
+        <div class="sa-form-grid" style="margin-bottom:1rem;">
+            <div class="form-field">
+                <label class="field-label">Periodo inicio</label>
+                <input type="date" name="period_start" class="field-input"
+                    value="<?= htmlspecialchars($_POST['period_start'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+            </div>
+            <div class="form-field">
+                <label class="field-label">Periodo fin</label>
+                <input type="date" name="period_end" class="field-input"
+                    value="<?= htmlspecialchars($_POST['period_end'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+            </div>
+        </div>
+
+        <div class="form-field" style="margin-bottom:1.5rem;">
+            <label class="field-label">Notas (opcional)</label>
+            <textarea name="notes" class="field-input" rows="3"
+                placeholder="Observaciones internas…"><?= htmlspecialchars($_POST['notes'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+        </div>
+
+        <div style="display:flex;gap:.75rem;">
+            <button type="submit" class="btn btn-primary">Crear factura</button>
+            <a href="../billing.php" class="btn btn-secondary">Cancelar</a>
+        </div>
+    </form>
+</div>
+<?php
+$content = ob_get_clean();
+require __DIR__ . '/../views/layout.php';

--- a/src/superadmin/billing/pdf.php
+++ b/src/superadmin/billing/pdf.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Descarga PDF de una factura.
+ *
+ * GET /superadmin/billing/pdf.php?id=X
+ *
+ * @package  Es21Plus\Superadmin\Billing
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../controllers/BillingController.php';
+require_once __DIR__ . '/../../core/PdfGenerator.php';
+
+SuperadminMiddleware::require();
+
+$id = (int)($_GET['id'] ?? 0);
+if ($id <= 0) {
+    http_response_code(400);
+    die('ID inválido.');
+}
+
+try {
+    $ctrl    = new BillingController();
+    $row     = $ctrl->find($id);
+    $invoice = [
+        'invoice_number' => $row['invoice_number'],
+        'amount'         => $row['amount'],
+        'status'         => $row['status'],
+        'period_start'   => $row['period_start'],
+        'period_end'     => $row['period_end'],
+        'notes'          => $row['notes'],
+        'created_at'     => $row['created_at'],
+    ];
+    $business = [
+        'name'  => $row['name']  ?? '',
+        'email' => $row['email'] ?? '',
+        'plan'  => $row['plan']  ?? '',
+    ];
+    PdfGenerator::downloadInvoice($invoice, $business);
+} catch (AppException $e) {
+    http_response_code(404);
+    die(htmlspecialchars($e->getMessage(), ENT_QUOTES, 'UTF-8'));
+} catch (\Throwable $e) {
+    http_response_code(500);
+    die('Error al generar PDF: ' . htmlspecialchars($e->getMessage(), ENT_QUOTES, 'UTF-8'));
+}

--- a/src/superadmin/controllers/BillingController.php
+++ b/src/superadmin/controllers/BillingController.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Controlador de facturación y precios de planes.
+ *
+ * Gestiona facturas (CRUD) y la tabla plan_prices.
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/AppException.php';
+
+class BillingController
+{
+    private \PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    // ──────────────────────────────────────────
+    //  Facturas: listado paginado
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve facturas paginadas con filtros opcionales.
+     *
+     * @param array<string,mixed> $filters  Keys: status, business_id, q
+     * @param int                 $page
+     * @param int                 $perPage
+     * @return array{items: array, total: int, pages: int}
+     */
+    public function list(array $filters = [], int $page = 1, int $perPage = 20): array
+    {
+        $where  = ['1=1'];
+        $params = [];
+
+        if (!empty($filters['status'])) {
+            $where[]  = 'i.status = ?';
+            $params[] = $filters['status'];
+        }
+        if (!empty($filters['business_id'])) {
+            $where[]  = 'i.business_id = ?';
+            $params[] = (int)$filters['business_id'];
+        }
+        if (!empty($filters['q'])) {
+            $where[]  = '(i.invoice_number LIKE ? OR b.name LIKE ?)';
+            $like     = '%' . $filters['q'] . '%';
+            $params[] = $like;
+            $params[] = $like;
+        }
+
+        $sql = implode(' AND ', $where);
+
+        $countStmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM invoices i
+             LEFT JOIN businesses b ON b.id = i.business_id
+             WHERE {$sql}"
+        );
+        $countStmt->execute($params);
+        $total = (int)$countStmt->fetchColumn();
+
+        $pages  = max(1, (int)ceil($total / $perPage));
+        $offset = ($page - 1) * $perPage;
+
+        $itemStmt = $this->pdo->prepare(
+            "SELECT i.*, b.name AS business_name, b.plan AS business_plan
+             FROM invoices i
+             LEFT JOIN businesses b ON b.id = i.business_id
+             WHERE {$sql}
+             ORDER BY i.created_at DESC
+             LIMIT ? OFFSET ?"
+        );
+        $itemStmt->execute(array_merge($params, [$perPage, $offset]));
+
+        return ['items' => $itemStmt->fetchAll(), 'total' => $total, 'pages' => $pages];
+    }
+
+    // ──────────────────────────────────────────
+    //  Facturas: crear
+    // ──────────────────────────────────────────
+
+    /**
+     * Crea una nueva factura con número auto-generado.
+     *
+     * @param array<string,mixed> $data Keys: business_id, amount, period_start, period_end, notes
+     * @throws AppException Si los datos son inválidos.
+     * @return int ID de la factura creada.
+     */
+    public function store(array $data): int
+    {
+        $businessId = (int)($data['business_id'] ?? 0);
+        $amount     = (float)($data['amount'] ?? 0);
+
+        if ($businessId <= 0) {
+            throw new AppException('Selecciona un negocio válido.');
+        }
+        if ($amount <= 0) {
+            throw new AppException('El importe debe ser mayor que 0.');
+        }
+
+        // Verificar que el negocio existe
+        $stmt = $this->pdo->prepare('SELECT id FROM businesses WHERE id = ?');
+        $stmt->execute([$businessId]);
+        if (!$stmt->fetch()) {
+            throw new AppException('Negocio no encontrado.');
+        }
+
+        $invoiceNumber = $this->generateInvoiceNumber();
+        $periodStart   = !empty($data['period_start']) ? $data['period_start'] : null;
+        $periodEnd     = !empty($data['period_end'])   ? $data['period_end']   : null;
+        $notes         = trim($data['notes'] ?? '');
+
+        $this->pdo->prepare(
+            'INSERT INTO invoices (business_id, invoice_number, amount, period_start, period_end, notes)
+             VALUES (?, ?, ?, ?, ?, ?)'
+        )->execute([$businessId, $invoiceNumber, $amount, $periodStart, $periodEnd, $notes ?: null]);
+
+        return (int)$this->pdo->lastInsertId();
+    }
+
+    // ──────────────────────────────────────────
+    //  Facturas: marcar como pagada
+    // ──────────────────────────────────────────
+
+    /**
+     * Marca una factura como pagada.
+     *
+     * @param  int $id
+     * @throws AppException Si la factura no existe o no está en estado pendiente.
+     */
+    public function markPaid(int $id): void
+    {
+        $stmt = $this->pdo->prepare('SELECT status FROM invoices WHERE id = ?');
+        $stmt->execute([$id]);
+        $invoice = $stmt->fetch();
+
+        if (!$invoice) {
+            throw new AppException('Factura no encontrada.');
+        }
+        if ($invoice['status'] !== 'pending') {
+            throw new AppException('Solo se pueden marcar como pagadas las facturas pendientes.');
+        }
+
+        $this->pdo->prepare(
+            "UPDATE invoices SET status = 'paid', paid_at = NOW() WHERE id = ?"
+        )->execute([$id]);
+    }
+
+    // ──────────────────────────────────────────
+    //  Facturas: cancelar
+    // ──────────────────────────────────────────
+
+    /**
+     * Cancela una factura pendiente.
+     *
+     * @param  int $id
+     * @throws AppException Si la factura no existe o no está pendiente.
+     */
+    public function cancel(int $id): void
+    {
+        $stmt = $this->pdo->prepare('SELECT status FROM invoices WHERE id = ?');
+        $stmt->execute([$id]);
+        $invoice = $stmt->fetch();
+
+        if (!$invoice) {
+            throw new AppException('Factura no encontrada.');
+        }
+        if ($invoice['status'] !== 'pending') {
+            throw new AppException('Solo se pueden cancelar facturas pendientes.');
+        }
+
+        $this->pdo->prepare(
+            "UPDATE invoices SET status = 'cancelled' WHERE id = ?"
+        )->execute([$id]);
+    }
+
+    // ──────────────────────────────────────────
+    //  Facturas: obtener por ID (para PDF)
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve una factura con los datos del negocio.
+     *
+     * @param  int   $id
+     * @return array
+     * @throws AppException Si no existe.
+     */
+    public function find(int $id): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT i.*, b.name, b.email, b.plan
+             FROM invoices i
+             LEFT JOIN businesses b ON b.id = i.business_id
+             WHERE i.id = ?'
+        );
+        $stmt->execute([$id]);
+        $row = $stmt->fetch();
+        if (!$row) {
+            throw new AppException('Factura no encontrada.');
+        }
+        return $row;
+    }
+
+    // ──────────────────────────────────────────
+    //  Plan prices: leer y actualizar
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve los tres planes con sus precios y features.
+     *
+     * @return array<string,array>
+     */
+    public function getPlanPrices(): array
+    {
+        $rows = $this->pdo->query(
+            "SELECT * FROM plan_prices ORDER BY FIELD(plan,'free','basic','pro')"
+        )->fetchAll();
+
+        $plans = [];
+        foreach ($rows as $r) {
+            $r['features'] = json_decode($r['features'] ?? '{}', true) ?? [];
+            $plans[$r['plan']] = $r;
+        }
+        return $plans;
+    }
+
+    /**
+     * Actualiza el precio mensual, anual y features de un plan.
+     *
+     * @param string $plan         'free'|'basic'|'pro'
+     * @param float  $monthly
+     * @param float  $annual
+     * @param array  $features
+     * @throws AppException Si el plan no es válido.
+     */
+    public function updatePlanPrice(string $plan, float $monthly, float $annual, array $features): void
+    {
+        if (!in_array($plan, ['free', 'basic', 'pro'], true)) {
+            throw new AppException('Plan no válido.');
+        }
+        $this->pdo->prepare(
+            'UPDATE plan_prices SET monthly_price = ?, annual_price = ?, features = ? WHERE plan = ?'
+        )->execute([$monthly, $annual, json_encode($features, JSON_UNESCAPED_UNICODE), $plan]);
+    }
+
+    /**
+     * Lista todos los negocios activos (para el select de crear factura).
+     *
+     * @return array
+     */
+    public function getActiveBusinesses(): array
+    {
+        return $this->pdo->query(
+            "SELECT id, name, plan FROM businesses WHERE is_active = 1 ORDER BY name"
+        )->fetchAll();
+    }
+
+    // ──────────────────────────────────────────
+    //  KPIs rápidos
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve totales de facturación por estado.
+     *
+     * @return array{pending_total: float, paid_total: float, cancelled_total: float, pending_count: int, paid_count: int}
+     */
+    public function kpis(): array
+    {
+        $row = $this->pdo->query(
+            "SELECT
+                SUM(CASE WHEN status='pending'   THEN amount ELSE 0 END) AS pending_total,
+                SUM(CASE WHEN status='paid'       THEN amount ELSE 0 END) AS paid_total,
+                SUM(CASE WHEN status='cancelled'  THEN amount ELSE 0 END) AS cancelled_total,
+                SUM(CASE WHEN status='pending'    THEN 1 ELSE 0 END)     AS pending_count,
+                SUM(CASE WHEN status='paid'       THEN 1 ELSE 0 END)     AS paid_count
+             FROM invoices"
+        )->fetch();
+
+        return [
+            'pending_total'   => (float)($row['pending_total']   ?? 0),
+            'paid_total'      => (float)($row['paid_total']       ?? 0),
+            'cancelled_total' => (float)($row['cancelled_total']  ?? 0),
+            'pending_count'   => (int)($row['pending_count']      ?? 0),
+            'paid_count'      => (int)($row['paid_count']         ?? 0),
+        ];
+    }
+
+    // ──────────────────────────────────────────
+    //  Helper privado
+    // ──────────────────────────────────────────
+
+    private function generateInvoiceNumber(): string
+    {
+        $year  = date('Y');
+        $count = (int)$this->pdo->query(
+            "SELECT COUNT(*) FROM invoices WHERE YEAR(created_at) = {$year}"
+        )->fetchColumn();
+        return 'FAC-' . $year . '-' . str_pad($count + 1, 5, '0', STR_PAD_LEFT);
+    }
+}

--- a/src/superadmin/controllers/ReportsController.php
+++ b/src/superadmin/controllers/ReportsController.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * Controlador de reportes para el superadmin.
+ *
+ * Genera datos para los 4 tipos de informe:
+ *   - businesses: listado de negocios con estado/plan
+ *   - billing:    facturas filtradas por estado y período
+ *   - activity:   últimos N registros de actividad
+ *   - tickets:    tickets por estado / negocio
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/AppException.php';
+
+class ReportsController
+{
+    private \PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    // ──────────────────────────────────────────
+    //  Reporte: negocios
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve datos de negocios para exportación.
+     *
+     * @param array<string,mixed> $filters  Keys: status (active|inactive), plan
+     * @return array{headers: array, rows: array}
+     */
+    public function businesses(array $filters = []): array
+    {
+        $where  = ['1=1'];
+        $params = [];
+
+        if (isset($filters['status']) && $filters['status'] !== '') {
+            $where[]  = 'b.is_active = ?';
+            $params[] = $filters['status'] === 'active' ? 1 : 0;
+        }
+        if (!empty($filters['plan'])) {
+            $where[]  = 'b.plan = ?';
+            $params[] = $filters['plan'];
+        }
+
+        $sql = implode(' AND ', $where);
+        $stmt = $this->pdo->prepare(
+            "SELECT b.id, b.name, b.email, b.plan,
+                    b.plan_expires_at, b.is_active,
+                    COUNT(e.id) AS total_empleados,
+                    b.created_at
+             FROM businesses b
+             LEFT JOIN employees e ON e.business_id = b.id AND e.is_active = 1
+             WHERE {$sql}
+             GROUP BY b.id
+             ORDER BY b.created_at DESC"
+        );
+        $stmt->execute($params);
+        $rows = $stmt->fetchAll();
+
+        $headers = ['ID', 'Nombre', 'Email', 'Plan', 'Vence', 'Activo', 'Empleados', 'Registrado'];
+        $data    = array_map(fn($r) => [
+            $r['id'],
+            $r['name'],
+            $r['email'],
+            ucfirst($r['plan']),
+            $r['plan_expires_at'] ? date('d/m/Y', strtotime($r['plan_expires_at'])) : '—',
+            $r['is_active'] ? 'Sí' : 'No',
+            $r['total_empleados'],
+            date('d/m/Y', strtotime($r['created_at'])),
+        ], $rows);
+
+        return ['headers' => $headers, 'rows' => $data];
+    }
+
+    // ──────────────────────────────────────────
+    //  Reporte: facturación
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve datos de facturas para exportación.
+     *
+     * @param array<string,mixed> $filters  Keys: status, fecha_desde, fecha_hasta
+     * @return array{headers: array, rows: array}
+     */
+    public function billing(array $filters = []): array
+    {
+        $where  = ['1=1'];
+        $params = [];
+
+        if (!empty($filters['status'])) {
+            $where[]  = 'i.status = ?';
+            $params[] = $filters['status'];
+        }
+        if (!empty($filters['fecha_desde'])) {
+            $where[]  = 'i.created_at >= ?';
+            $params[] = $filters['fecha_desde'] . ' 00:00:00';
+        }
+        if (!empty($filters['fecha_hasta'])) {
+            $where[]  = 'i.created_at <= ?';
+            $params[] = $filters['fecha_hasta'] . ' 23:59:59';
+        }
+
+        $sql = implode(' AND ', $where);
+        $stmt = $this->pdo->prepare(
+            "SELECT i.invoice_number, b.name AS business_name, i.amount,
+                    i.status, i.period_start, i.period_end, i.paid_at, i.created_at
+             FROM invoices i
+             LEFT JOIN businesses b ON b.id = i.business_id
+             WHERE {$sql}
+             ORDER BY i.created_at DESC"
+        );
+        $stmt->execute($params);
+        $rows = $stmt->fetchAll();
+
+        $statusMap = ['pending' => 'Pendiente', 'paid' => 'Pagada', 'cancelled' => 'Cancelada'];
+        $headers   = ['N.° Factura', 'Negocio', 'Importe (€)', 'Estado', 'Periodo inicio', 'Periodo fin', 'Pagado el', 'Emitida'];
+        $data      = array_map(fn($r) => [
+            $r['invoice_number'],
+            $r['business_name'],
+            number_format((float)$r['amount'], 2, ',', '.'),
+            $statusMap[$r['status']] ?? $r['status'],
+            $r['period_start'] ? date('d/m/Y', strtotime($r['period_start'])) : '—',
+            $r['period_end']   ? date('d/m/Y', strtotime($r['period_end']))   : '—',
+            $r['paid_at']      ? date('d/m/Y H:i', strtotime($r['paid_at']))  : '—',
+            date('d/m/Y', strtotime($r['created_at'])),
+        ], $rows);
+
+        return ['headers' => $headers, 'rows' => $data];
+    }
+
+    // ──────────────────────────────────────────
+    //  Reporte: actividad
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve registros de actividad para exportación.
+     *
+     * @param array<string,mixed> $filters  Keys: fecha_desde, fecha_hasta, business_id
+     * @return array{headers: array, rows: array}
+     */
+    public function activity(array $filters = []): array
+    {
+        $where  = ['1=1'];
+        $params = [];
+
+        if (!empty($filters['fecha_desde'])) {
+            $where[]  = 'al.created_at >= ?';
+            $params[] = $filters['fecha_desde'] . ' 00:00:00';
+        }
+        if (!empty($filters['fecha_hasta'])) {
+            $where[]  = 'al.created_at <= ?';
+            $params[] = $filters['fecha_hasta'] . ' 23:59:59';
+        }
+        if (!empty($filters['business_id'])) {
+            $where[]  = 'al.business_id = ?';
+            $params[] = (int)$filters['business_id'];
+        }
+
+        $sql = implode(' AND ', $where);
+        $stmt = $this->pdo->prepare(
+            "SELECT al.created_at, b.name AS negocio, e.name AS empleado,
+                    al.action, al.entity, al.ip_address
+             FROM activity_logs al
+             LEFT JOIN businesses b ON b.id = al.business_id
+             LEFT JOIN employees  e ON e.id = al.employee_id
+             WHERE {$sql}
+             ORDER BY al.created_at DESC
+             LIMIT 5000"
+        );
+        $stmt->execute($params);
+        $rows = $stmt->fetchAll();
+
+        $headers = ['Fecha', 'Negocio', 'Empleado', 'Acción', 'Entidad', 'IP'];
+        $data    = array_map(fn($r) => [
+            date('d/m/Y H:i', strtotime($r['created_at'])),
+            $r['negocio']  ?? '—',
+            $r['empleado'] ?? 'superadmin',
+            $r['action'],
+            $r['entity']     ?? '—',
+            $r['ip_address'] ?? '—',
+        ], $rows);
+
+        return ['headers' => $headers, 'rows' => $data];
+    }
+
+    // ──────────────────────────────────────────
+    //  Reporte: tickets
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve tickets para exportación.
+     *
+     * @param array<string,mixed> $filters  Keys: status, priority, fecha_desde, fecha_hasta
+     * @return array{headers: array, rows: array}
+     */
+    public function tickets(array $filters = []): array
+    {
+        $where  = ['1=1'];
+        $params = [];
+
+        if (!empty($filters['status'])) {
+            $where[]  = 'st.status = ?';
+            $params[] = $filters['status'];
+        }
+        if (!empty($filters['priority'])) {
+            $where[]  = 'st.priority = ?';
+            $params[] = $filters['priority'];
+        }
+        if (!empty($filters['fecha_desde'])) {
+            $where[]  = 'st.created_at >= ?';
+            $params[] = $filters['fecha_desde'] . ' 00:00:00';
+        }
+        if (!empty($filters['fecha_hasta'])) {
+            $where[]  = 'st.created_at <= ?';
+            $params[] = $filters['fecha_hasta'] . ' 23:59:59';
+        }
+
+        $sql = implode(' AND ', $where);
+        $stmt = $this->pdo->prepare(
+            "SELECT st.ticket_number, b.name AS negocio, st.subject,
+                    st.status, st.priority,
+                    (SELECT COUNT(*) FROM ticket_messages tm WHERE tm.ticket_id = st.id) AS mensajes,
+                    st.created_at, st.closed_at
+             FROM support_tickets st
+             LEFT JOIN businesses b ON b.id = st.business_id
+             WHERE {$sql}
+             ORDER BY st.created_at DESC"
+        );
+        $stmt->execute($params);
+        $rows = $stmt->fetchAll();
+
+        $statusMap   = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resuelto','closed'=>'Cerrado'];
+        $priorityMap = ['low'=>'Baja','normal'=>'Normal','high'=>'Alta','urgent'=>'Urgente'];
+
+        $headers = ['Ticket', 'Negocio', 'Asunto', 'Estado', 'Prioridad', 'Mensajes', 'Creado', 'Cerrado'];
+        $data    = array_map(fn($r) => [
+            $r['ticket_number'],
+            $r['negocio'] ?? '—',
+            $r['subject'],
+            $statusMap[$r['status']]     ?? $r['status'],
+            $priorityMap[$r['priority']] ?? $r['priority'],
+            $r['mensajes'],
+            date('d/m/Y H:i', strtotime($r['created_at'])),
+            $r['closed_at'] ? date('d/m/Y', strtotime($r['closed_at'])) : '—',
+        ], $rows);
+
+        return ['headers' => $headers, 'rows' => $data];
+    }
+}

--- a/src/superadmin/controllers/TicketController.php
+++ b/src/superadmin/controllers/TicketController.php
@@ -1,0 +1,464 @@
+<?php
+/**
+ * Controlador de tickets de soporte.
+ *
+ * Gestiona tanto la perspectiva del superadmin (todas las empresas)
+ * como la del panel de empresa (sus propios tickets).
+ *
+ * @package  Es21Plus\Superadmin\Controllers
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../core/NotificationService.php';
+require_once __DIR__ . '/../../core/Mailer.php';
+require_once __DIR__ . '/../../core/Settings.php';
+
+class TicketController
+{
+    private \PDO $pdo;
+
+    public function __construct()
+    {
+        $this->pdo = Database::getInstance();
+    }
+
+    // ──────────────────────────────────────────
+    //  Superadmin: listado paginado con filtros
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve tickets paginados con filtros opcionales.
+     *
+     * @param array<string,mixed> $filters  Keys: status, priority, business_id, q (búsqueda)
+     * @param int                 $page     Página actual (1-based)
+     * @param int                 $perPage  Items por página
+     * @return array{items: array, total: int, pages: int}
+     */
+    public function list(array $filters = [], int $page = 1, int $perPage = 20): array
+    {
+        $where  = ['1=1'];
+        $params = [];
+
+        if (!empty($filters['status'])) {
+            $where[]  = 'st.status = ?';
+            $params[] = $filters['status'];
+        }
+        if (!empty($filters['priority'])) {
+            $where[]  = 'st.priority = ?';
+            $params[] = $filters['priority'];
+        }
+        if (!empty($filters['business_id'])) {
+            $where[]  = 'st.business_id = ?';
+            $params[] = (int)$filters['business_id'];
+        }
+        if (!empty($filters['q'])) {
+            $where[]  = '(st.subject LIKE ? OR st.ticket_number LIKE ? OR b.name LIKE ?)';
+            $like     = '%' . $filters['q'] . '%';
+            $params[] = $like;
+            $params[] = $like;
+            $params[] = $like;
+        }
+
+        $sql = implode(' AND ', $where);
+
+        $total = (int)$this->pdo->prepare(
+            "SELECT COUNT(*) FROM support_tickets st
+             LEFT JOIN businesses b ON b.id = st.business_id
+             WHERE {$sql}"
+        )->execute($params) ? $this->pdo->prepare(
+            "SELECT COUNT(*) FROM support_tickets st
+             LEFT JOIN businesses b ON b.id = st.business_id
+             WHERE {$sql}"
+        )->execute($params) && 1 : 0;
+
+        // Count correctly
+        $countStmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM support_tickets st
+             LEFT JOIN businesses b ON b.id = st.business_id
+             WHERE {$sql}"
+        );
+        $countStmt->execute($params);
+        $total = (int)$countStmt->fetchColumn();
+
+        $pages  = max(1, (int)ceil($total / $perPage));
+        $offset = ($page - 1) * $perPage;
+
+        $itemStmt = $this->pdo->prepare(
+            "SELECT st.*, b.name AS business_name,
+                    (SELECT COUNT(*) FROM ticket_messages tm WHERE tm.ticket_id = st.id) AS msg_count
+             FROM support_tickets st
+             LEFT JOIN businesses b ON b.id = st.business_id
+             WHERE {$sql}
+             ORDER BY
+                CASE st.priority WHEN 'urgent' THEN 1 WHEN 'high' THEN 2 WHEN 'normal' THEN 3 ELSE 4 END,
+                st.updated_at DESC
+             LIMIT ? OFFSET ?"
+        );
+        $itemStmt->execute(array_merge($params, [$perPage, $offset]));
+
+        return ['items' => $itemStmt->fetchAll(), 'total' => $total, 'pages' => $pages];
+    }
+
+    // ──────────────────────────────────────────
+    //  Superadmin: detalle de ticket
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve datos completos de un ticket con sus mensajes.
+     *
+     * @param  int   $id
+     * @return array{ticket: array, messages: array}
+     * @throws AppException Si el ticket no existe.
+     */
+    public function view(int $id): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT st.*, b.name AS business_name, b.email AS business_email
+             FROM support_tickets st
+             LEFT JOIN businesses b ON b.id = st.business_id
+             WHERE st.id = ?'
+        );
+        $stmt->execute([$id]);
+        $ticket = $stmt->fetch();
+        if (!$ticket) {
+            throw new AppException('Ticket no encontrado.');
+        }
+
+        $msgStmt = $this->pdo->prepare(
+            'SELECT tm.*,
+                    (SELECT GROUP_CONCAT(ta.original_name ORDER BY ta.id SEPARATOR ",")
+                     FROM ticket_attachments ta WHERE ta.message_id = tm.id) AS attachments
+             FROM ticket_messages tm WHERE tm.ticket_id = ? ORDER BY tm.created_at ASC'
+        );
+        $msgStmt->execute([$id]);
+
+        return ['ticket' => $ticket, 'messages' => $msgStmt->fetchAll()];
+    }
+
+    // ──────────────────────────────────────────
+    //  Superadmin: actualizar estado / prioridad
+    // ──────────────────────────────────────────
+
+    /**
+     * Actualiza el estado y/o prioridad de un ticket.
+     *
+     * @param int    $id
+     * @param string $status   'open'|'in_progress'|'resolved'|'closed'
+     * @param string $priority 'low'|'normal'|'high'|'urgent'
+     * @throws AppException Si el ticket no existe.
+     */
+    public function updateStatus(int $id, string $status, string $priority): void
+    {
+        $validStatuses   = ['open', 'in_progress', 'resolved', 'closed'];
+        $validPriorities = ['low', 'normal', 'high', 'urgent'];
+
+        if (!in_array($status, $validStatuses, true)) {
+            throw new AppException('Estado no válido.');
+        }
+        if (!in_array($priority, $validPriorities, true)) {
+            throw new AppException('Prioridad no válida.');
+        }
+
+        $closedAt = in_array($status, ['resolved', 'closed'], true) ? 'NOW()' : 'NULL';
+
+        $stmt = $this->pdo->prepare(
+            "UPDATE support_tickets
+             SET status = ?, priority = ?, closed_at = {$closedAt}
+             WHERE id = ?"
+        );
+        $stmt->execute([$status, $priority, $id]);
+
+        if ($stmt->rowCount() === 0) {
+            throw new AppException('Ticket no encontrado.');
+        }
+
+        // Notificar al negocio por email si resuelto/cerrado
+        if (in_array($status, ['resolved', 'closed'], true)) {
+            $this->sendStatusEmail($id, $status);
+        }
+    }
+
+    // ──────────────────────────────────────────
+    //  Superadmin: responder ticket
+    // ──────────────────────────────────────────
+
+    /**
+     * El superadmin publica un mensaje en el ticket.
+     *
+     * @param int    $id         ID del ticket.
+     * @param string $message    Texto del mensaje.
+     * @param int    $saUserId   ID del superadmin (de sesión).
+     * @throws AppException Si el mensaje está vacío o el ticket no existe.
+     */
+    public function replyAsSuperadmin(int $id, string $message, int $saUserId): void
+    {
+        $message = trim($message);
+        if ($message === '') {
+            throw new AppException('El mensaje no puede estar vacío.');
+        }
+
+        $ticket = $this->getTicketRaw($id);
+
+        $this->pdo->prepare(
+            'INSERT INTO ticket_messages (ticket_id, sender_type, sender_id, message)
+             VALUES (?, "superadmin", ?, ?)'
+        )->execute([$id, $saUserId, $message]);
+
+        $this->pdo->prepare(
+            'UPDATE support_tickets SET status = "in_progress", updated_at = NOW() WHERE id = ? AND status = "open"'
+        )->execute([$id]);
+
+        // Email al negocio
+        $this->sendReplyEmail($ticket, $message, 'superadmin');
+    }
+
+    // ──────────────────────────────────────────
+    //  Panel de empresa: crear ticket
+    // ──────────────────────────────────────────
+
+    /**
+     * Crea un nuevo ticket desde el panel de empresa.
+     *
+     * @param string $subject    Asunto del ticket.
+     * @param string $message    Mensaje inicial.
+     * @param int    $businessId ID del negocio.
+     * @param int    $employeeId ID del empleado que abre el ticket.
+     * @return int ID del ticket creado.
+     * @throws AppException Si los datos son inválidos.
+     */
+    public function createTicket(
+        string $subject,
+        string $message,
+        int    $businessId,
+        int    $employeeId
+    ): int {
+        $subject = trim($subject);
+        $message = trim($message);
+
+        if ($subject === '') {
+            throw new AppException('El asunto es obligatorio.');
+        }
+        if ($message === '') {
+            throw new AppException('El mensaje es obligatorio.');
+        }
+
+        $ticketNumber = $this->generateTicketNumber();
+
+        $this->pdo->prepare(
+            'INSERT INTO support_tickets
+             (business_id, employee_id, ticket_number, subject, status, priority)
+             VALUES (?, ?, ?, ?, "open", "normal")'
+        )->execute([$businessId, $employeeId, $ticketNumber, $subject]);
+
+        $ticketId = (int)$this->pdo->lastInsertId();
+
+        // Mensaje inicial
+        $this->pdo->prepare(
+            'INSERT INTO ticket_messages (ticket_id, sender_type, sender_id, message)
+             VALUES (?, "business", ?, ?)'
+        )->execute([$ticketId, $employeeId, $message]);
+
+        // Notificación y email al superadmin
+        NotificationService::notify(
+            'critical_ticket',
+            'Nuevo ticket: ' . $subject,
+            'Empresa ID ' . $businessId . ' abrió el ticket ' . $ticketNumber,
+            '/superadmin/tickets/view.php?id=' . $ticketId
+        );
+
+        $saEmail = Settings::get('superadmin_email', '');
+        if ($saEmail) {
+            try {
+                $html = "<h3>Nuevo ticket de soporte: {$ticketNumber}</h3>"
+                    . "<p><strong>Asunto:</strong> " . htmlspecialchars($subject, ENT_QUOTES, 'UTF-8') . "</p>"
+                    . "<p><strong>Mensaje:</strong></p>"
+                    . "<blockquote>" . nl2br(htmlspecialchars($message, ENT_QUOTES, 'UTF-8')) . "</blockquote>"
+                    . "<p><a href='/superadmin/tickets/view.php?id={$ticketId}'>Ver ticket en el panel</a></p>";
+                Mailer::send($saEmail, "Nuevo ticket #{$ticketNumber}: " . $subject, $html);
+            } catch (\Throwable) {
+                // No interrumpir el flujo
+            }
+        }
+
+        return $ticketId;
+    }
+
+    // ──────────────────────────────────────────
+    //  Panel de empresa: listar tickets propios
+    // ──────────────────────────────────────────
+
+    /**
+     * Lista los tickets de un negocio, más reciente primero.
+     *
+     * @param  int $businessId
+     * @return array
+     */
+    public function listForBusiness(int $businessId): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT st.*,
+                    (SELECT COUNT(*) FROM ticket_messages tm WHERE tm.ticket_id = st.id) AS msg_count
+             FROM support_tickets st
+             WHERE st.business_id = ?
+             ORDER BY st.updated_at DESC'
+        );
+        $stmt->execute([$businessId]);
+        return $stmt->fetchAll();
+    }
+
+    // ──────────────────────────────────────────
+    //  Panel de empresa: ver ticket propio
+    // ──────────────────────────────────────────
+
+    /**
+     * Devuelve un ticket con sus mensajes, verificando que pertenece al negocio.
+     *
+     * @param  int   $id
+     * @param  int   $businessId
+     * @return array{ticket: array, messages: array}
+     * @throws AppException Si el ticket no existe o no pertenece al negocio.
+     */
+    public function getTicketForBusiness(int $id, int $businessId): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT * FROM support_tickets WHERE id = ? AND business_id = ?'
+        );
+        $stmt->execute([$id, $businessId]);
+        $ticket = $stmt->fetch();
+        if (!$ticket) {
+            throw new AppException('Ticket no encontrado.');
+        }
+
+        $msgStmt = $this->pdo->prepare(
+            'SELECT * FROM ticket_messages WHERE ticket_id = ? ORDER BY created_at ASC'
+        );
+        $msgStmt->execute([$id]);
+
+        return ['ticket' => $ticket, 'messages' => $msgStmt->fetchAll()];
+    }
+
+    // ──────────────────────────────────────────
+    //  Panel de empresa: responder ticket
+    // ──────────────────────────────────────────
+
+    /**
+     * El negocio añade un mensaje a un ticket existente.
+     *
+     * @param int    $ticketId   ID del ticket.
+     * @param int    $businessId ID del negocio (para verificar pertenencia).
+     * @param int    $employeeId ID del empleado.
+     * @param string $message    Texto del mensaje.
+     * @throws AppException Si el ticket está cerrado o no existe.
+     */
+    public function replyFromBusiness(
+        int    $ticketId,
+        int    $businessId,
+        int    $employeeId,
+        string $message
+    ): void {
+        $message = trim($message);
+        if ($message === '') {
+            throw new AppException('El mensaje no puede estar vacío.');
+        }
+
+        $stmt = $this->pdo->prepare(
+            'SELECT * FROM support_tickets WHERE id = ? AND business_id = ?'
+        );
+        $stmt->execute([$ticketId, $businessId]);
+        $ticket = $stmt->fetch();
+        if (!$ticket) {
+            throw new AppException('Ticket no encontrado.');
+        }
+        if ($ticket['status'] === 'closed') {
+            throw new AppException('El ticket está cerrado y no acepta más respuestas.');
+        }
+
+        $this->pdo->prepare(
+            'INSERT INTO ticket_messages (ticket_id, sender_type, sender_id, message)
+             VALUES (?, "business", ?, ?)'
+        )->execute([$ticketId, $employeeId, $message]);
+
+        $this->pdo->prepare(
+            'UPDATE support_tickets SET updated_at = NOW() WHERE id = ?'
+        )->execute([$ticketId]);
+
+        // Notificar al superadmin
+        NotificationService::notify(
+            'critical_ticket',
+            'Respuesta en ticket: ' . $ticket['ticket_number'],
+            'Nueva respuesta del negocio en el ticket ' . $ticket['ticket_number'],
+            '/superadmin/tickets/view.php?id=' . $ticketId
+        );
+
+        $saEmail = Settings::get('superadmin_email', '');
+        if ($saEmail) {
+            try {
+                $html = "<h3>Respuesta en ticket {$ticket['ticket_number']}</h3>"
+                    . "<p><strong>Asunto:</strong> " . htmlspecialchars($ticket['subject'], ENT_QUOTES, 'UTF-8') . "</p>"
+                    . "<blockquote>" . nl2br(htmlspecialchars($message, ENT_QUOTES, 'UTF-8')) . "</blockquote>"
+                    . "<p><a href='/superadmin/tickets/view.php?id={$ticketId}'>Ver ticket</a></p>";
+                Mailer::send($saEmail, "Respuesta en #{$ticket['ticket_number']}", $html);
+            } catch (\Throwable) {}
+        }
+    }
+
+    // ──────────────────────────────────────────
+    //  Helpers privados
+    // ──────────────────────────────────────────
+
+    private function generateTicketNumber(): string
+    {
+        $year  = date('Y');
+        $count = (int)$this->pdo->query(
+            "SELECT COUNT(*) FROM support_tickets WHERE YEAR(created_at) = {$year}"
+        )->fetchColumn();
+        return 'TK-' . $year . '-' . str_pad($count + 1, 5, '0', STR_PAD_LEFT);
+    }
+
+    private function getTicketRaw(int $id): array
+    {
+        $stmt = $this->pdo->prepare(
+            'SELECT st.*, b.email AS business_email
+             FROM support_tickets st
+             LEFT JOIN businesses b ON b.id = st.business_id
+             WHERE st.id = ?'
+        );
+        $stmt->execute([$id]);
+        $ticket = $stmt->fetch();
+        if (!$ticket) {
+            throw new AppException('Ticket no encontrado.');
+        }
+        return $ticket;
+    }
+
+    private function sendReplyEmail(array $ticket, string $message, string $from): void
+    {
+        try {
+            if ($from === 'superadmin' && !empty($ticket['business_email'])) {
+                $html = "<h3>Nueva respuesta en tu ticket {$ticket['ticket_number']}</h3>"
+                    . "<p><strong>Asunto:</strong> " . htmlspecialchars($ticket['subject'], ENT_QUOTES, 'UTF-8') . "</p>"
+                    . "<blockquote>" . nl2br(htmlspecialchars($message, ENT_QUOTES, 'UTF-8')) . "</blockquote>"
+                    . "<p>Ingresa a tu panel para responder o ver el hilo completo.</p>";
+                Mailer::send($ticket['business_email'], "Respuesta en #{$ticket['ticket_number']}", $html);
+            }
+        } catch (\Throwable) {}
+    }
+
+    private function sendStatusEmail(int $ticketId, string $status): void
+    {
+        try {
+            $ticket = $this->getTicketRaw($ticketId);
+            if (empty($ticket['business_email'])) {
+                return;
+            }
+            $label = $status === 'resolved' ? 'resuelto' : 'cerrado';
+            $html  = "<h3>Tu ticket {$ticket['ticket_number']} fue {$label}</h3>"
+                . "<p><strong>Asunto:</strong> " . htmlspecialchars($ticket['subject'], ENT_QUOTES, 'UTF-8') . "</p>"
+                . "<p>Si tienes más dudas, abre un nuevo ticket desde tu panel.</p>";
+            Mailer::send($ticket['business_email'], "Ticket #{$ticket['ticket_number']} {$label}", $html);
+        } catch (\Throwable) {}
+    }
+}

--- a/src/superadmin/reports.php
+++ b/src/superadmin/reports.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * Centro de reportes y exportaciones — panel superadmin.
+ *
+ * Permite generar CSV y PDF de: negocios, facturación,
+ * actividad y tickets.
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+
+SuperadminMiddleware::require();
+
+$base    = './';
+$cssBase = '../';
+$pageTitle  = 'Reportes';
+$activeMenu = 'reports';
+
+try {
+    $mensajesSinLeer = (int)\Database::getInstance()->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+} catch (\Throwable) {
+    $mensajesSinLeer = 0;
+}
+
+// Lista de negocios para filtros
+try {
+    $businesses = \Database::getInstance()->query(
+        "SELECT id, name FROM businesses WHERE is_active = 1 ORDER BY name"
+    )->fetchAll();
+} catch (\Throwable) {
+    $businesses = [];
+}
+
+ob_start();
+?>
+<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:1.25rem;">
+
+    <!-- Reporte: Negocios -->
+    <div class="sa-form-card">
+        <h2 style="margin-bottom:.25rem;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6366f1" stroke-width="2" style="vertical-align:-.2em;margin-right:.4em;"><path d="M3 9l9-7 9 7v11a2 2 0 01-2 2H5a2 2 0 01-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            Negocios
+        </h2>
+        <p style="font-size:.8rem;color:var(--text-muted);margin-bottom:1rem;">Listado completo con estado, plan y empleados activos.</p>
+        <form action="reports/export.php" method="GET" target="_blank">
+            <input type="hidden" name="type" value="businesses">
+            <div class="form-field" style="margin-bottom:.75rem;">
+                <label class="field-label" style="font-size:.78rem;">Estado</label>
+                <select name="status" class="field-input" style="font-size:.82rem;">
+                    <option value="">Todos</option>
+                    <option value="active">Activos</option>
+                    <option value="inactive">Inactivos</option>
+                </select>
+            </div>
+            <div class="form-field" style="margin-bottom:1rem;">
+                <label class="field-label" style="font-size:.78rem;">Plan</label>
+                <select name="plan" class="field-input" style="font-size:.82rem;">
+                    <option value="">Todos</option>
+                    <option value="free">Free</option>
+                    <option value="basic">Basic</option>
+                    <option value="pro">Pro</option>
+                </select>
+            </div>
+            <div style="display:flex;gap:.5rem;">
+                <button type="submit" name="format" value="csv" class="btn btn-secondary" style="font-size:.8rem;flex:1;">CSV</button>
+                <button type="submit" name="format" value="pdf" class="btn btn-secondary" style="font-size:.8rem;flex:1;">PDF</button>
+            </div>
+        </form>
+    </div>
+
+    <!-- Reporte: Facturación -->
+    <div class="sa-form-card">
+        <h2 style="margin-bottom:.25rem;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6366f1" stroke-width="2" style="vertical-align:-.2em;margin-right:.4em;"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
+            Facturación
+        </h2>
+        <p style="font-size:.8rem;color:var(--text-muted);margin-bottom:1rem;">Facturas con importes, estados y periodos.</p>
+        <form action="reports/export.php" method="GET" target="_blank">
+            <input type="hidden" name="type" value="billing">
+            <div class="form-field" style="margin-bottom:.75rem;">
+                <label class="field-label" style="font-size:.78rem;">Estado</label>
+                <select name="status" class="field-input" style="font-size:.82rem;">
+                    <option value="">Todos</option>
+                    <option value="pending">Pendiente</option>
+                    <option value="paid">Pagada</option>
+                    <option value="cancelled">Cancelada</option>
+                </select>
+            </div>
+            <div class="sa-form-grid" style="margin-bottom:1rem;">
+                <div class="form-field">
+                    <label class="field-label" style="font-size:.78rem;">Desde</label>
+                    <input type="date" name="fecha_desde" class="field-input" style="font-size:.82rem;">
+                </div>
+                <div class="form-field">
+                    <label class="field-label" style="font-size:.78rem;">Hasta</label>
+                    <input type="date" name="fecha_hasta" class="field-input" style="font-size:.82rem;">
+                </div>
+            </div>
+            <div style="display:flex;gap:.5rem;">
+                <button type="submit" name="format" value="csv" class="btn btn-secondary" style="font-size:.8rem;flex:1;">CSV</button>
+                <button type="submit" name="format" value="pdf" class="btn btn-secondary" style="font-size:.8rem;flex:1;">PDF</button>
+            </div>
+        </form>
+    </div>
+
+    <!-- Reporte: Actividad -->
+    <div class="sa-form-card">
+        <h2 style="margin-bottom:.25rem;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6366f1" stroke-width="2" style="vertical-align:-.2em;margin-right:.4em;"><path d="M14 2H6a2 2 0 00-2 2v16a2 2 0 002 2h12a2 2 0 002-2V8z"/><polyline points="14 2 14 8 20 8"/></svg>
+            Actividad
+        </h2>
+        <p style="font-size:.8rem;color:var(--text-muted);margin-bottom:1rem;">Registro de acciones de empleados y superadmin.</p>
+        <form action="reports/export.php" method="GET" target="_blank">
+            <input type="hidden" name="type" value="activity">
+            <div class="form-field" style="margin-bottom:.75rem;">
+                <label class="field-label" style="font-size:.78rem;">Empresa</label>
+                <select name="business_id" class="field-input" style="font-size:.82rem;">
+                    <option value="">Todas</option>
+                    <?php foreach ($businesses as $b): ?>
+                        <option value="<?= $b['id'] ?>"><?= htmlspecialchars($b['name'], ENT_QUOTES, 'UTF-8') ?></option>
+                    <?php endforeach; ?>
+                </select>
+            </div>
+            <div class="sa-form-grid" style="margin-bottom:1rem;">
+                <div class="form-field">
+                    <label class="field-label" style="font-size:.78rem;">Desde</label>
+                    <input type="date" name="fecha_desde" class="field-input" style="font-size:.82rem;">
+                </div>
+                <div class="form-field">
+                    <label class="field-label" style="font-size:.78rem;">Hasta</label>
+                    <input type="date" name="fecha_hasta" class="field-input" style="font-size:.82rem;">
+                </div>
+            </div>
+            <div style="display:flex;gap:.5rem;">
+                <button type="submit" name="format" value="csv" class="btn btn-secondary" style="font-size:.8rem;flex:1;">CSV</button>
+            </div>
+        </form>
+    </div>
+
+    <!-- Reporte: Tickets -->
+    <div class="sa-form-card">
+        <h2 style="margin-bottom:.25rem;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#6366f1" stroke-width="2" style="vertical-align:-.2em;margin-right:.4em;"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+            Tickets de soporte
+        </h2>
+        <p style="font-size:.8rem;color:var(--text-muted);margin-bottom:1rem;">Histórico de tickets con estado, prioridad y mensajes.</p>
+        <form action="reports/export.php" method="GET" target="_blank">
+            <input type="hidden" name="type" value="tickets">
+            <div class="form-field" style="margin-bottom:.75rem;">
+                <label class="field-label" style="font-size:.78rem;">Estado</label>
+                <select name="status" class="field-input" style="font-size:.82rem;">
+                    <option value="">Todos</option>
+                    <option value="open">Abierto</option>
+                    <option value="in_progress">En proceso</option>
+                    <option value="resolved">Resuelto</option>
+                    <option value="closed">Cerrado</option>
+                </select>
+            </div>
+            <div class="sa-form-grid" style="margin-bottom:1rem;">
+                <div class="form-field">
+                    <label class="field-label" style="font-size:.78rem;">Desde</label>
+                    <input type="date" name="fecha_desde" class="field-input" style="font-size:.82rem;">
+                </div>
+                <div class="form-field">
+                    <label class="field-label" style="font-size:.78rem;">Hasta</label>
+                    <input type="date" name="fecha_hasta" class="field-input" style="font-size:.82rem;">
+                </div>
+            </div>
+            <div style="display:flex;gap:.5rem;">
+                <button type="submit" name="format" value="csv" class="btn btn-secondary" style="font-size:.8rem;flex:1;">CSV</button>
+                <button type="submit" name="format" value="pdf" class="btn btn-secondary" style="font-size:.8rem;flex:1;">PDF</button>
+            </div>
+        </form>
+    </div>
+
+</div>
+<?php
+$content = ob_get_clean();
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/reports/export.php
+++ b/src/superadmin/reports/export.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Endpoint de exportación de reportes (CSV / PDF).
+ *
+ * GET /superadmin/reports/export.php?type=X&format=csv|pdf&...filtros
+ *
+ * @package  Es21Plus\Superadmin\Reports
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../controllers/ReportsController.php';
+require_once __DIR__ . '/../../core/CsvExporter.php';
+require_once __DIR__ . '/../../core/PdfGenerator.php';
+
+SuperadminMiddleware::require();
+
+$type   = $_GET['type']   ?? '';
+$format = $_GET['format'] ?? 'csv';
+
+$validTypes   = ['businesses', 'billing', 'activity', 'tickets'];
+$validFormats = ['csv', 'pdf'];
+
+if (!in_array($type, $validTypes, true)) {
+    http_response_code(400);
+    die('Tipo de reporte inválido.');
+}
+if (!in_array($format, $validFormats, true)) {
+    http_response_code(400);
+    die('Formato inválido.');
+}
+
+// Los reportes de actividad solo exportan CSV
+if ($type === 'activity' && $format === 'pdf') {
+    http_response_code(400);
+    die('El reporte de actividad solo está disponible en CSV.');
+}
+
+$ctrl    = new ReportsController();
+$filters = array_intersect_key($_GET, array_flip([
+    'status', 'plan', 'business_id', 'fecha_desde', 'fecha_hasta', 'priority'
+]));
+
+try {
+    $data = match($type) {
+        'businesses' => $ctrl->businesses($filters),
+        'billing'    => $ctrl->billing($filters),
+        'activity'   => $ctrl->activity($filters),
+        'tickets'    => $ctrl->tickets($filters),
+    };
+} catch (\Throwable $e) {
+    http_response_code(500);
+    die('Error al generar el reporte: ' . htmlspecialchars($e->getMessage(), ENT_QUOTES, 'UTF-8'));
+}
+
+$typeLabels = [
+    'businesses' => 'negocios',
+    'billing'    => 'facturacion',
+    'activity'   => 'actividad',
+    'tickets'    => 'tickets',
+];
+$filename = $typeLabels[$type] . '_' . date('Ymd_Hi');
+$title    = match($type) {
+    'businesses' => 'Reporte de Negocios — es21plus',
+    'billing'    => 'Reporte de Facturación — es21plus',
+    'activity'   => 'Reporte de Actividad — es21plus',
+    'tickets'    => 'Reporte de Tickets — es21plus',
+};
+
+if ($format === 'csv') {
+    CsvExporter::download($data['headers'], $data['rows'], $filename);
+} else {
+    PdfGenerator::downloadReport($title, $data['headers'], $data['rows'], $filename);
+}

--- a/src/superadmin/settings/plans.php
+++ b/src/superadmin/settings/plans.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * Gestión de precios y límites de planes — superadmin.
+ *
+ * @package  Es21Plus\Superadmin\Settings
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../controllers/BillingController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl = new BillingController();
+$flashSuccess = '';
+$flashError   = '';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    foreach (['free', 'basic', 'pro'] as $plan) {
+        if (!isset($_POST["monthly_{$plan}"])) {
+            continue;
+        }
+        try {
+            $features = [
+                'max_products'  => $_POST["max_products_{$plan}"]  === '-1' ? -1 : (int)$_POST["max_products_{$plan}"],
+                'max_employees' => $_POST["max_employees_{$plan}"] === '-1' ? -1 : (int)$_POST["max_employees_{$plan}"],
+                'reports'       => isset($_POST["reports_{$plan}"]),
+            ];
+            $ctrl->updatePlanPrice(
+                $plan,
+                (float)$_POST["monthly_{$plan}"],
+                (float)$_POST["annual_{$plan}"],
+                $features
+            );
+        } catch (AppException $e) {
+            $flashError = $e->getMessage();
+        }
+    }
+    if (!$flashError) {
+        $flashSuccess = 'Precios de planes actualizados.';
+    }
+}
+
+$plans = $ctrl->getPlanPrices();
+
+$base    = '../';
+$cssBase = '../../';
+$pageTitle  = 'Precios de Planes';
+$activeMenu = 'settings';
+
+try {
+    $mensajesSinLeer = (int)\Database::getInstance()->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+} catch (\Throwable) {
+    $mensajesSinLeer = 0;
+}
+
+ob_start();
+?>
+<div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem;">
+    <a href="../settings.php" style="font-size:.84rem;color:var(--accent);text-decoration:none;">← Volver a Configuración</a>
+</div>
+
+<form method="POST">
+<div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:1.25rem;">
+<?php foreach (['free'=>'Free','basic'=>'Basic','pro'=>'Pro'] as $planKey => $planLabel):
+    $p = $plans[$planKey] ?? [];
+    $f = $p['features'] ?? [];
+    $maxProducts  = $f['max_products']  ?? 50;
+    $maxEmployees = $f['max_employees'] ?? 2;
+    $reports      = $f['reports']       ?? false;
+?>
+<div class="sa-form-card">
+    <h2 style="margin-bottom:1.25rem;">
+        <span class="badge-<?= $planKey ?>"><?= $planLabel ?></span>
+    </h2>
+
+    <div class="form-field" style="margin-bottom:.75rem;">
+        <label class="field-label" style="font-size:.78rem;">Precio mensual (€)</label>
+        <input type="number" name="monthly_<?= $planKey ?>" class="field-input" min="0" step="0.01"
+            value="<?= number_format((float)($p['monthly_price'] ?? 0), 2, '.', '') ?>">
+    </div>
+    <div class="form-field" style="margin-bottom:.75rem;">
+        <label class="field-label" style="font-size:.78rem;">Precio anual (€)</label>
+        <input type="number" name="annual_<?= $planKey ?>" class="field-input" min="0" step="0.01"
+            value="<?= number_format((float)($p['annual_price'] ?? 0), 2, '.', '') ?>">
+    </div>
+
+    <div style="border-top:1px solid var(--border);margin:.75rem 0;padding-top:.75rem;">
+        <p style="font-size:.75rem;font-weight:600;color:var(--text-muted);margin-bottom:.5rem;text-transform:uppercase;letter-spacing:.05em;">Límites del plan</p>
+
+        <div class="form-field" style="margin-bottom:.75rem;">
+            <label class="field-label" style="font-size:.78rem;">Máx. productos (-1 = ilimitado)</label>
+            <input type="number" name="max_products_<?= $planKey ?>" class="field-input" min="-1"
+                value="<?= (int)$maxProducts ?>">
+        </div>
+        <div class="form-field" style="margin-bottom:.75rem;">
+            <label class="field-label" style="font-size:.78rem;">Máx. empleados (-1 = ilimitado)</label>
+            <input type="number" name="max_employees_<?= $planKey ?>" class="field-input" min="-1"
+                value="<?= (int)$maxEmployees ?>">
+        </div>
+        <div class="toggle-wrap" style="margin-top:.5rem;">
+            <input type="checkbox" id="reports_<?= $planKey ?>" name="reports_<?= $planKey ?>"
+                class="sa-toggle" <?= $reports ? 'checked' : '' ?>>
+            <label for="reports_<?= $planKey ?>" style="font-size:.82rem;color:var(--text-primary);cursor:pointer;">
+                Acceso a reportes
+            </label>
+        </div>
+    </div>
+</div>
+<?php endforeach; ?>
+</div>
+
+<div style="margin-top:1.5rem;">
+    <button type="submit" class="btn btn-primary">Guardar todos los planes</button>
+</div>
+</form>
+<?php
+$content = ob_get_clean();
+require __DIR__ . '/../views/layout.php';

--- a/src/superadmin/tickets.php
+++ b/src/superadmin/tickets.php
@@ -1,0 +1,171 @@
+<?php
+/**
+ * Listado de tickets de soporte — panel superadmin.
+ *
+ * @package  Es21Plus\Superadmin
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/controllers/TicketController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl = new TicketController();
+
+$filters = [
+    'status'      => $_GET['status']      ?? '',
+    'priority'    => $_GET['priority']    ?? '',
+    'business_id' => (int)($_GET['business_id'] ?? 0) ?: null,
+    'q'           => trim($_GET['q'] ?? ''),
+];
+
+$page = max(1, (int)($_GET['page'] ?? 1));
+$data = $ctrl->list($filters, $page);
+
+$base    = './';
+$cssBase = '../';
+$pageTitle  = 'Tickets de soporte';
+$activeMenu = 'tickets';
+
+try {
+    $mensajesSinLeer = (int)\Database::getInstance()->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+} catch (\Throwable) {
+    $mensajesSinLeer = 0;
+}
+
+// Labels
+$statusColors = [
+    'open'        => 'badge-unread',
+    'in_progress' => 'badge-basic',
+    'resolved'    => 'badge-active',
+    'closed'      => 'badge-free',
+];
+$statusLabels = [
+    'open'        => 'Abierto',
+    'in_progress' => 'En proceso',
+    'resolved'    => 'Resuelto',
+    'closed'      => 'Cerrado',
+];
+$priorityColors = [
+    'urgent' => '#dc2626',
+    'high'   => '#ea580c',
+    'normal' => '#2563eb',
+    'low'    => '#64748b',
+];
+$priorityLabels = [
+    'urgent' => 'Urgente',
+    'high'   => 'Alta',
+    'normal' => 'Normal',
+    'low'    => 'Baja',
+];
+
+ob_start();
+?>
+<!-- Filtros -->
+<div class="sa-form-card" style="margin-bottom:1rem;padding:1rem 1.25rem;">
+    <form method="GET" style="display:flex;gap:.75rem;align-items:flex-end;flex-wrap:wrap;">
+        <div class="form-field" style="margin:0;flex:1;min-width:160px;">
+            <label class="field-label" style="font-size:.78rem;">Buscar</label>
+            <input type="text" name="q" class="field-input" style="padding:.35rem .6rem;font-size:.82rem;"
+                placeholder="Ticket, asunto, empresa…"
+                value="<?= htmlspecialchars($filters['q'], ENT_QUOTES, 'UTF-8') ?>">
+        </div>
+        <div class="form-field" style="margin:0;">
+            <label class="field-label" style="font-size:.78rem;">Estado</label>
+            <select name="status" class="field-input" style="padding:.35rem .6rem;font-size:.82rem;">
+                <option value="">Todos</option>
+                <?php foreach (['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resuelto','closed'=>'Cerrado'] as $k=>$v): ?>
+                    <option value="<?= $k ?>" <?= $filters['status'] === $k ? 'selected' : '' ?>><?= $v ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="form-field" style="margin:0;">
+            <label class="field-label" style="font-size:.78rem;">Prioridad</label>
+            <select name="priority" class="field-input" style="padding:.35rem .6rem;font-size:.82rem;">
+                <option value="">Todas</option>
+                <?php foreach (['urgent'=>'Urgente','high'=>'Alta','normal'=>'Normal','low'=>'Baja'] as $k=>$v): ?>
+                    <option value="<?= $k ?>" <?= $filters['priority'] === $k ? 'selected' : '' ?>><?= $v ?></option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <button type="submit" class="btn btn-secondary" style="padding:.4rem .85rem;font-size:.82rem;">Filtrar</button>
+        <a href="tickets.php" class="btn" style="padding:.4rem .85rem;font-size:.82rem;background:var(--surface);border:1px solid var(--border);color:var(--text-muted);border-radius:.4rem;text-decoration:none;">Limpiar</a>
+    </form>
+</div>
+
+<!-- Tabla -->
+<div class="sa-table-card">
+    <div class="sa-table-header">
+        <h3>Tickets (<?= number_format($data['total']) ?>)</h3>
+    </div>
+    <?php if (empty($data['items'])): ?>
+        <p style="padding:1rem 1.25rem;color:var(--text-muted);font-size:.85rem;">Sin tickets con los filtros aplicados.</p>
+    <?php else: ?>
+    <table class="sa-table">
+        <thead>
+            <tr>
+                <th>Ticket</th>
+                <th>Empresa</th>
+                <th>Asunto</th>
+                <th>Estado</th>
+                <th>Prioridad</th>
+                <th>Mensajes</th>
+                <th>Actualizado</th>
+                <th></th>
+            </tr>
+        </thead>
+        <tbody>
+        <?php foreach ($data['items'] as $t): ?>
+            <tr>
+                <td><code style="font-size:.78rem;"><?= htmlspecialchars($t['ticket_number'], ENT_QUOTES, 'UTF-8') ?></code></td>
+                <td><?= htmlspecialchars($t['business_name'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
+                <td style="max-width:240px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">
+                    <?= htmlspecialchars($t['subject'], ENT_QUOTES, 'UTF-8') ?>
+                </td>
+                <td>
+                    <span class="<?= $statusColors[$t['status']] ?? 'badge-free' ?>">
+                        <?= $statusLabels[$t['status']] ?? $t['status'] ?>
+                    </span>
+                </td>
+                <td>
+                    <span style="font-size:.72rem;font-weight:600;color:<?= $priorityColors[$t['priority']] ?? '#64748b' ?>;">
+                        <?= $priorityLabels[$t['priority']] ?? $t['priority'] ?>
+                    </span>
+                </td>
+                <td style="color:var(--text-muted);"><?= (int)$t['msg_count'] ?></td>
+                <td style="color:var(--text-muted);font-size:.78rem;"><?= date('d/m/Y H:i', strtotime($t['updated_at'])) ?></td>
+                <td>
+                    <a href="tickets/view.php?id=<?= $t['id'] ?>" class="btn btn-secondary" style="padding:.25rem .6rem;font-size:.75rem;">Ver</a>
+                </td>
+            </tr>
+        <?php endforeach; ?>
+        </tbody>
+    </table>
+
+    <?php if ($data['pages'] > 1): ?>
+    <div style="padding:.75rem 1.25rem;display:flex;gap:.4rem;align-items:center;border-top:1px solid var(--border);">
+        <?php
+        $baseUrl = 'tickets.php?' . http_build_query(array_filter(array_merge($filters, ['status'=>$filters['status'],'priority'=>$filters['priority'],'q'=>$filters['q']])));
+        for ($p = 1; $p <= $data['pages']; $p++):
+        ?>
+            <a href="<?= $baseUrl ?>&page=<?= $p ?>"
+               style="padding:.3rem .6rem;border-radius:.35rem;font-size:.78rem;text-decoration:none;
+                      background:<?= $p === $page ? '#6366f1' : 'var(--surface)' ?>;
+                      color:<?= $p === $page ? '#fff' : 'var(--text-muted)' ?>;
+                      border:1px solid <?= $p === $page ? '#6366f1' : 'var(--border)' ?>;">
+                <?= $p ?>
+            </a>
+        <?php endfor; ?>
+    </div>
+    <?php endif; ?>
+    <?php endif; ?>
+</div>
+<?php
+$content = ob_get_clean();
+require __DIR__ . '/views/layout.php';

--- a/src/superadmin/tickets/view.php
+++ b/src/superadmin/tickets/view.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Vista detalle de ticket — chat entre negocio y superadmin.
+ *
+ * @package  Es21Plus\Superadmin\Tickets
+ * @author   Carlos Vico
+ * @version  1.0.0
+ */
+
+if (session_status() === PHP_SESSION_NONE) session_start();
+
+require_once __DIR__ . '/../../includes/AppException.php';
+require_once __DIR__ . '/../../includes/Database.php';
+require_once __DIR__ . '/../middleware/SuperadminMiddleware.php';
+require_once __DIR__ . '/../controllers/TicketController.php';
+
+SuperadminMiddleware::require();
+
+$ctrl = new TicketController();
+$id   = (int)($_GET['id'] ?? 0);
+
+$flashSuccess = '';
+$flashError   = '';
+
+// Responder
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $action = $_POST['_action'] ?? '';
+    try {
+        if ($action === 'reply') {
+            $saId = (int)($_SESSION['usuario_id'] ?? 1);
+            $ctrl->replyAsSuperadmin($id, trim($_POST['message'] ?? ''), $saId);
+            $flashSuccess = 'Respuesta enviada.';
+        } elseif ($action === 'update_status') {
+            $ctrl->updateStatus($id, $_POST['status'] ?? 'open', $_POST['priority'] ?? 'normal');
+            $flashSuccess = 'Estado actualizado.';
+        }
+    } catch (AppException $e) {
+        $flashError = $e->getMessage();
+    }
+}
+
+try {
+    $data = $ctrl->view($id);
+} catch (AppException $e) {
+    http_response_code(404);
+    die('Ticket no encontrado.');
+}
+
+$ticket   = $data['ticket'];
+$messages = $data['messages'];
+
+$base    = '../';
+$cssBase = '../../';
+$pageTitle  = 'Ticket ' . htmlspecialchars($ticket['ticket_number'], ENT_QUOTES, 'UTF-8');
+$activeMenu = 'tickets';
+
+try {
+    $mensajesSinLeer = (int)\Database::getInstance()->query('SELECT COUNT(*) FROM contact_messages WHERE is_read = 0')->fetchColumn();
+} catch (\Throwable) {
+    $mensajesSinLeer = 0;
+}
+
+$statusColors = ['open'=>'badge-unread','in_progress'=>'badge-basic','resolved'=>'badge-active','closed'=>'badge-free'];
+$statusLabels = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resuelto','closed'=>'Cerrado'];
+$priorityLabels = ['urgent'=>'Urgente','high'=>'Alta','normal'=>'Normal','low'=>'Baja'];
+$priorityColors = ['urgent'=>'#dc2626','high'=>'#ea580c','normal'=>'#2563eb','low'=>'#64748b'];
+
+ob_start();
+?>
+<div style="display:flex;align-items:center;gap:1rem;margin-bottom:1.25rem;flex-wrap:wrap;">
+    <a href="../tickets.php" style="font-size:.84rem;color:var(--accent);text-decoration:none;">← Volver a Tickets</a>
+    <span class="<?= $statusColors[$ticket['status']] ?? 'badge-free' ?>">
+        <?= $statusLabels[$ticket['status']] ?? $ticket['status'] ?>
+    </span>
+    <span style="font-size:.72rem;font-weight:600;color:<?= $priorityColors[$ticket['priority']] ?? '#64748b' ?>;">
+        Prioridad: <?= $priorityLabels[$ticket['priority']] ?? $ticket['priority'] ?>
+    </span>
+    <span style="font-size:.78rem;color:var(--text-muted);margin-left:auto;">
+        <?= htmlspecialchars($ticket['business_name'] ?? '—', ENT_QUOTES, 'UTF-8') ?>
+        · <?= date('d/m/Y H:i', strtotime($ticket['created_at'])) ?>
+    </span>
+</div>
+
+<div style="display:grid;grid-template-columns:1fr 260px;gap:1.25rem;align-items:start;">
+
+    <!-- Hilo de mensajes -->
+    <div>
+        <div class="sa-table-card" style="margin-bottom:1rem;">
+            <div class="sa-table-header">
+                <h3><?= htmlspecialchars($ticket['subject'], ENT_QUOTES, 'UTF-8') ?></h3>
+                <code style="font-size:.75rem;color:var(--text-muted);"><?= htmlspecialchars($ticket['ticket_number'], ENT_QUOTES, 'UTF-8') ?></code>
+            </div>
+            <div style="padding:1rem 1.25rem;display:flex;flex-direction:column;gap:.75rem;" id="msgThread">
+                <?php foreach ($messages as $msg): ?>
+                <?php $isSA = $msg['sender_type'] === 'superadmin'; ?>
+                <div style="display:flex;gap:.75rem;<?= $isSA ? 'justify-content:flex-end;' : '' ?>">
+                    <?php if (!$isSA): ?>
+                    <div style="width:32px;height:32px;border-radius:50%;background:#e0e7ff;display:flex;align-items:center;justify-content:center;font-size:.7rem;font-weight:700;color:#4338ca;flex-shrink:0;">B</div>
+                    <?php endif; ?>
+                    <div style="max-width:75%;background:<?= $isSA ? '#eef2ff' : '#f8fafc' ?>;border:1px solid <?= $isSA ? '#c7d2fe' : 'var(--border)' ?>;border-radius:<?= $isSA ? '1rem 1rem 0 1rem' : '1rem 1rem 1rem 0' ?>;padding:.75rem 1rem;">
+                        <p style="margin:0 0 .4rem;font-size:.7rem;color:var(--text-muted);">
+                            <?= $isSA ? 'Soporte es21plus' : 'Empresa' ?>
+                            · <?= date('d/m/Y H:i', strtotime($msg['created_at'])) ?>
+                        </p>
+                        <p style="margin:0;font-size:.85rem;white-space:pre-wrap;color:var(--text-primary);"><?= htmlspecialchars($msg['message'], ENT_QUOTES, 'UTF-8') ?></p>
+                    </div>
+                    <?php if ($isSA): ?>
+                    <div style="width:32px;height:32px;border-radius:50%;background:#6366f1;display:flex;align-items:center;justify-content:center;font-size:.7rem;font-weight:700;color:#fff;flex-shrink:0;">SA</div>
+                    <?php endif; ?>
+                </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+
+        <?php if (!in_array($ticket['status'], ['closed'], true)): ?>
+        <div class="sa-form-card">
+            <form method="POST">
+                <input type="hidden" name="_action" value="reply">
+                <div class="form-field" style="margin-bottom:.75rem;">
+                    <label class="field-label">Tu respuesta</label>
+                    <textarea name="message" class="field-input" rows="4" required
+                        placeholder="Escribe tu respuesta…" style="resize:vertical;"></textarea>
+                </div>
+                <button type="submit" class="btn btn-primary">Enviar respuesta</button>
+            </form>
+        </div>
+        <?php else: ?>
+        <p style="color:var(--text-muted);font-size:.84rem;padding:.5rem 0;">Este ticket está cerrado.</p>
+        <?php endif; ?>
+    </div>
+
+    <!-- Panel lateral: cambiar estado -->
+    <div>
+        <div class="sa-form-card">
+            <h2 style="font-size:.9rem;margin-bottom:1rem;">Gestionar ticket</h2>
+            <form method="POST">
+                <input type="hidden" name="_action" value="update_status">
+                <div class="form-field" style="margin-bottom:.75rem;">
+                    <label class="field-label" style="font-size:.78rem;">Estado</label>
+                    <select name="status" class="field-input" style="font-size:.82rem;">
+                        <?php foreach (['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resuelto','closed'=>'Cerrado'] as $k=>$v): ?>
+                            <option value="<?= $k ?>" <?= $ticket['status'] === $k ? 'selected' : '' ?>><?= $v ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="form-field" style="margin-bottom:1rem;">
+                    <label class="field-label" style="font-size:.78rem;">Prioridad</label>
+                    <select name="priority" class="field-input" style="font-size:.82rem;">
+                        <?php foreach (['urgent'=>'Urgente','high'=>'Alta','normal'=>'Normal','low'=>'Baja'] as $k=>$v): ?>
+                            <option value="<?= $k ?>" <?= $ticket['priority'] === $k ? 'selected' : '' ?>><?= $v ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <button type="submit" class="btn btn-secondary" style="width:100%;font-size:.82rem;">Actualizar</button>
+            </form>
+
+            <?php if ($ticket['closed_at']): ?>
+            <p style="margin-top:.75rem;font-size:.75rem;color:var(--text-muted);">
+                Cerrado: <?= date('d/m/Y H:i', strtotime($ticket['closed_at'])) ?>
+            </p>
+            <?php endif; ?>
+        </div>
+    </div>
+</div>
+<?php
+$content = ob_get_clean();
+require __DIR__ . '/../views/layout.php';

--- a/src/superadmin/views/layout.php
+++ b/src/superadmin/views/layout.php
@@ -229,9 +229,23 @@
                     <span class="sa-badge-count"><?= (int)$mensajesSinLeer ?></span>
                 <?php endif; ?>
             </a>
+            <a href="<?= $base ?? './' ?>tickets.php" class="<?= ($activeMenu ?? '') === 'tickets' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 01-2 2H7l-4 4V5a2 2 0 012-2h14a2 2 0 012 2z"/></svg>
+                Tickets
+            </a>
             <a href="<?= $base ?? './' ?>announcements.php" class="<?= ($activeMenu ?? '') === 'announcements' ? 'active' : '' ?>">
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M22 17H2a3 3 0 000 6h20a3 3 0 000-6z"/><path d="M6 17V3a2 2 0 012-2h8a2 2 0 012 2v14"/></svg>
                 Anuncios
+            </a>
+
+            <div class="sa-nav-section">Finanzas</div>
+            <a href="<?= $base ?? './' ?>billing.php" class="<?= ($activeMenu ?? '') === 'billing' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="4" width="22" height="16" rx="2" ry="2"/><line x1="1" y1="10" x2="23" y2="10"/></svg>
+                Facturación
+            </a>
+            <a href="<?= $base ?? './' ?>reports.php" class="<?= ($activeMenu ?? '') === 'reports' ? 'active' : '' ?>">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
+                Reportes
             </a>
 
             <div class="sa-nav-section">Auditoría</div>


### PR DESCRIPTION
## Summary

- **Block 1 – Support Tickets**: `support_tickets`, `ticket_messages`, `ticket_attachments` tables with TK-YYYY-NNNNN numbering. Superadmin chat UI at `/superadmin/tickets/view.php`. Business panel at `/soporte/mis-tickets.php`, `/soporte/crear-ticket.php`, `/soporte/ticket.php`. Email + bell notifications on ticket events.

- **Block 2 – Billing**: `plan_prices` (seeded with free/basic/pro features) + `invoices` tables. FAC-YYYY-NNNNN invoice numbering. Full CRUD at `/superadmin/billing`. PDF download via FPDF. Plan prices editable at `/superadmin/settings/plans`. `BusinessMiddleware` now loads `$_SESSION['plan_features']` from `plan_prices` with 5-min cache.

- **Block 3 – Reports**: `CsvExporter` (UTF-8 BOM) + `PdfGenerator` (FPDF). `ReportsController` provides businesses/billing/activity/tickets data. `/superadmin/reports` UI with 4 export panels (CSV + PDF where applicable). `/superadmin/reports/export.php` unified endpoint.

- **Sidebar updated**: Tickets, Facturación, Reportes links added to superadmin layout. Soporte link added to business panel sidebar.

## Test plan

- [ ] Superadmin: open `/superadmin/tickets.php` — table renders with filters
- [ ] Business panel: open `/soporte/crear-ticket.php` → submit → redirects to thread view
- [ ] Superadmin: open `/superadmin/tickets/view.php?id=1` — reply + update status
- [ ] Superadmin: open `/superadmin/billing.php` — KPI cards visible
- [ ] Create invoice at `/superadmin/billing/create.php` — number FAC-YYYY-00001 assigned
- [ ] Download PDF at `/superadmin/billing/pdf.php?id=1` — PDF renders
- [ ] Open `/superadmin/settings/plans.php` — edit prices, save
- [ ] Open `/superadmin/reports.php` — click CSV on Negocios — file downloads with BOM
- [ ] Click PDF on Facturación — PDF table renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)