### PR TITLE
feat(ui): sidebar completo, dashboard links, editar_producto redesign, auditoria/soporte visual

### DIFF
--- a/src/api/modelos_moto.php
+++ b/src/api/modelos_moto.php
@@ -56,7 +56,7 @@ function requireAuth(string $rolRequerido = 'any'): void
     if (empty($_SESSION['usuario_id'])) {
         jsonResponse(false, null, 'No autenticado.', 401);
     }
-    if ($rolRequerido === 'admin' && ($_SESSION['rol'] ?? '') !== 'admin') {
+    if ($rolRequerido === 'admin' && !isAdmin()) {
         jsonResponse(false, null, 'Acceso denegado. Se requiere rol de administrador.', 403);
     }
 }

--- a/src/api/productos.php
+++ b/src/api/productos.php
@@ -375,7 +375,7 @@ function requireAdmin(): void
     if (session_status() === PHP_SESSION_NONE) {
         session_start();
     }
-    if (($_SESSION['rol'] ?? '') !== 'admin') {
+    if (!isAdmin()) {
         jsonResponse(false, null, 'Acceso denegado.', 403);
     }
 }

--- a/src/api/proveedores.php
+++ b/src/api/proveedores.php
@@ -56,7 +56,7 @@ function jsonResponse(bool $success, mixed $data, string $message = '', int $cod
  */
 function requireAdmin(): void
 {
-    if (($_SESSION['rol'] ?? '') !== 'admin') {
+    if (!isAdmin()) {
         jsonResponse(false, null, 'Acceso restringido a administradores.', 403);
     }
 }

--- a/src/auditoria.php
+++ b/src/auditoria.php
@@ -99,19 +99,11 @@ $badgeAccion = [
     <title>Auditoría – es21plus</title>
     <link rel="stylesheet" href="css/estilos.css">
     <style>
-        .audit-key    { font-weight: 600; color: var(--color-primary, #3b82f6); }
-        .audit-null   { color: var(--color-muted, #9ca3af); font-style: italic; }
-        .audit-diff   { font-size: .78rem; line-height: 1.6; font-family: monospace; }
-        .badge        { display: inline-block; padding: .2em .55em; border-radius: 9999px; font-size: .72rem; font-weight: 700; text-transform: uppercase; }
-        .badge-success{ background: #d1fae5; color: #065f46; }
-        .badge-warning{ background: #fef3c7; color: #92400e; }
-        .badge-danger { background: #fee2e2; color: #991b1b; }
-        .diff-grid    { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem; }
-        .diff-col h4  { margin: 0 0 .25rem; font-size: .72rem; text-transform: uppercase; color: var(--color-muted, #9ca3af); }
-        .filters-bar  { display: flex; flex-wrap: wrap; gap: .75rem; align-items: flex-end; margin-bottom: 1.25rem; }
-        .filters-bar label { display: flex; flex-direction: column; gap: .25rem; font-size: .82rem; font-weight: 600; }
-        .filters-bar input,
-        .filters-bar select { padding: .4rem .6rem; border: 1px solid var(--color-border,#e5e7eb); border-radius: .375rem; font-size: .85rem; }
+        .audit-key   { font-weight: 600; color: var(--accent, #2563eb); }
+        .audit-null  { color: var(--text-muted, #9ca3af); font-style: italic; }
+        .audit-diff  { font-size: .78rem; line-height: 1.6; font-family: monospace; }
+        .diff-grid   { display: grid; grid-template-columns: 1fr 1fr; gap: .5rem; }
+        .diff-col h4 { margin: 0 0 .25rem; font-size: .72rem; text-transform: uppercase; color: var(--text-muted); }
     </style>
 </head>
 <body class="layout">
@@ -167,7 +159,7 @@ $badgeAccion = [
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -207,12 +199,25 @@ $badgeAccion = [
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
 
@@ -230,6 +235,8 @@ $badgeAccion = [
 <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
 <div class="main-wrapper">
+
+    <!-- TOPBAR -->
     <header class="topbar">
         <div class="topbar-left">
             <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
@@ -237,98 +244,128 @@ $badgeAccion = [
                     <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
                 </svg>
             </button>
-            <h1 class="topbar-title">Auditoría de cambios</h1>
+            <nav class="breadcrumb-nav">
+                <a href="index.php" class="breadcrumb-item">Inicio</a>
+                <span class="breadcrumb-sep">›</span>
+                <span class="breadcrumb-item active">Auditoría</span>
+            </nav>
         </div>
         <div class="topbar-right">
             <?php require_once __DIR__ . '/includes/topbar_user.php'; ?>
         </div>
     </header>
 
-    <main class="main-content">
+    <!-- CONTENT -->
+    <main class="content">
 
         <?php if ($error !== ''): ?>
-            <div class="alert alert-danger"><?= $error ?></div>
+        <div class="alert-banner alert-banner-error" style="margin-bottom:1.25rem;">
+            <svg class="alert-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
+            </svg>
+            <?= $error ?>
+        </div>
         <?php endif; ?>
 
         <?php if ($flashSuccess !== ''): ?>
-            <div class="alert alert-success"><?= htmlspecialchars($flashSuccess) ?></div>
+        <div class="alert-banner alert-banner-success" style="margin-bottom:1.25rem;">
+            <?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?>
+        </div>
         <?php endif; ?>
 
-        <!-- ── Filtros ──────────────────────────────────────────────── -->
-        <section class="card" style="margin-bottom:1.5rem;">
-            <div class="card-body">
-                <form method="GET" action="auditoria.php" class="filters-bar">
-                    <label>
-                        Tabla
-                        <select name="tabla">
-                            <option value="">Todas</option>
-                            <option value="productos"  <?= $filtroTabla === 'productos'   ? 'selected' : '' ?>>Productos</option>
-                            <option value="categorias" <?= $filtroTabla === 'categorias'  ? 'selected' : '' ?>>Categorías</option>
-                        </select>
-                    </label>
-                    <label>
-                        Acción
-                        <select name="accion">
-                            <option value="">Todas</option>
-                            <option value="crear"      <?= $filtroAccion === 'crear'      ? 'selected' : '' ?>>Crear</option>
-                            <option value="actualizar" <?= $filtroAccion === 'actualizar' ? 'selected' : '' ?>>Actualizar</option>
-                            <option value="eliminar"   <?= $filtroAccion === 'eliminar'   ? 'selected' : '' ?>>Eliminar</option>
-                        </select>
-                    </label>
-                    <label>
-                        Desde
-                        <input type="date" name="fecha_desde" value="<?= htmlspecialchars($fechaDesde) ?>">
-                    </label>
-                    <label>
-                        Hasta
-                        <input type="date" name="fecha_hasta" value="<?= htmlspecialchars($fechaHasta) ?>">
-                    </label>
-                    <button type="submit" class="btn btn-primary" style="align-self:flex-end;">Filtrar</button>
-                    <a href="auditoria.php" class="btn btn-secondary" style="align-self:flex-end;">Limpiar</a>
-                </form>
+        <!-- Page header -->
+        <div class="page-header">
+            <div class="page-header-info">
+                <h1 class="page-title">Auditoría de cambios</h1>
+                <p class="page-subtitle">Registro inmutable de operaciones sobre el inventario · <?= number_format($total) ?> entradas</p>
             </div>
-        </section>
+        </div>
 
-        <!-- ── Tabla de registros ───────────────────────────────────── -->
-        <section class="card">
-            <div class="card-header">
-                <h2 class="card-title">
-                    Registros de auditoría
-                    <span style="font-size:.85rem;font-weight:400;color:var(--color-muted,#9ca3af);">(<?= number_format($total) ?> total)</span>
-                </h2>
-            </div>
-            <div class="card-body" style="overflow-x:auto;">
+        <!-- Filtros -->
+        <form method="GET" action="auditoria.php" class="data-toolbar" style="margin-bottom:1.25rem;flex-wrap:wrap;">
+            <select name="tabla" class="filter-select" onchange="this.form.submit()">
+                <option value="">Todas las tablas</option>
+                <option value="productos"  <?= $filtroTabla === 'productos'   ? 'selected' : '' ?>>Productos</option>
+                <option value="categorias" <?= $filtroTabla === 'categorias'  ? 'selected' : '' ?>>Categorías</option>
+                <option value="marcas"     <?= $filtroTabla === 'marcas'      ? 'selected' : '' ?>>Marcas</option>
+                <option value="movimientos"<?= $filtroTabla === 'movimientos' ? 'selected' : '' ?>>Movimientos</option>
+            </select>
+            <select name="accion" class="filter-select" onchange="this.form.submit()">
+                <option value="">Todas las acciones</option>
+                <option value="crear"      <?= $filtroAccion === 'crear'      ? 'selected' : '' ?>>Crear</option>
+                <option value="actualizar" <?= $filtroAccion === 'actualizar' ? 'selected' : '' ?>>Actualizar</option>
+                <option value="eliminar"   <?= $filtroAccion === 'eliminar'   ? 'selected' : '' ?>>Eliminar</option>
+            </select>
+            <input type="date" name="fecha_desde" class="filter-select" style="max-width:140px;"
+                   value="<?= htmlspecialchars($fechaDesde, ENT_QUOTES, 'UTF-8') ?>"
+                   title="Desde" placeholder="Desde">
+            <input type="date" name="fecha_hasta" class="filter-select" style="max-width:140px;"
+                   value="<?= htmlspecialchars($fechaHasta, ENT_QUOTES, 'UTF-8') ?>"
+                   title="Hasta" placeholder="Hasta">
+            <button type="submit" class="btn-primary" style="flex-shrink:0;">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                </svg>
+                Filtrar
+            </button>
+            <?php if ($filtroTabla !== '' || $filtroAccion !== '' || $fechaDesde !== '' || $fechaHasta !== ''): ?>
+            <a href="auditoria.php" class="btn-ghost" style="flex-shrink:0;">Limpiar</a>
+            <?php endif; ?>
+        </form>
+
+        <!-- Tabla de registros -->
+        <div class="card">
+            <div class="card-body" style="padding:0;overflow-x:auto;">
                 <?php if (empty($registros)): ?>
-                    <p style="text-align:center;color:var(--color-muted,#9ca3af);padding:2rem;">
-                        No hay registros de auditoría con los filtros seleccionados.
-                    </p>
+                <div class="td-empty" style="padding:3rem;text-align:center;">
+                    <svg width="40" height="40" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-muted);margin:0 auto 1rem;display:block;">
+                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>
+                    </svg>
+                    <p style="color:var(--text-muted);">No hay registros con los filtros aplicados.</p>
+                </div>
                 <?php else: ?>
-                <table class="table">
+                <table class="data-table">
                     <thead>
                         <tr>
                             <th>#</th>
                             <th>Fecha</th>
                             <th>Tabla</th>
-                            <th>ID</th>
+                            <th>ID reg.</th>
                             <th>Acción</th>
-                            <th>Diff (anterior → nuevo)</th>
-                            <th>IP</th>
+                            <th>Antes → Después</th>
                             <th>Usuario</th>
+                            <th>IP</th>
                         </tr>
                     </thead>
                     <tbody>
                         <?php foreach ($registros as $r): ?>
                         <tr>
-                            <td><?= (int) $r['id'] ?></td>
-                            <td style="white-space:nowrap;"><?= htmlspecialchars($r['fecha']) ?></td>
-                            <td><?= htmlspecialchars($r['tabla']) ?></td>
-                            <td><?= (int) $r['registro_id'] ?></td>
+                            <td style="color:var(--text-muted);font-size:.78rem;"><?= (int)$r['id'] ?></td>
+                            <td style="white-space:nowrap;font-size:.82rem;"><?= htmlspecialchars(date('d/m/Y H:i', strtotime($r['fecha'])), ENT_QUOTES, 'UTF-8') ?></td>
                             <td>
-                                <span class="badge <?= $badgeAccion[$r['accion']] ?? 'badge-secondary' ?>">
-                                    <?= htmlspecialchars($r['accion']) ?>
+                                <span style="display:inline-flex;align-items:center;padding:.2em .55em;background:var(--bg-hover);border-radius:4px;font-size:.75rem;font-weight:600;color:var(--text-secondary);">
+                                    <?= htmlspecialchars($r['tabla'], ENT_QUOTES, 'UTF-8') ?>
                                 </span>
                             </td>
-                            <td class="audit-diff">
+                            <td style="color:var(--text-muted);font-size:.82rem;"><?= (int)$r['registro_id'] ?></td>
+                            <td>
+                                <?php
+                                $accionClass = match($r['accion']) {
+                                    'crear'     => 'status-pill-success',
+                                    'actualizar'=> 'status-pill-warning',
+                                    'eliminar'  => 'status-pill-danger',
+                                    default     => ''
+                                };
+                                $accionLabel = match($r['accion']) {
+                                    'crear'     => 'Crear',
+                                    'actualizar'=> 'Actualizar',
+                                    'eliminar'  => 'Eliminar',
+                                    default     => htmlspecialchars($r['accion'], ENT_QUOTES, 'UTF-8')
+                                };
+                                ?>
+                                <span class="status-pill <?= $accionClass ?>"><?= $accionLabel ?></span>
+                            </td>
+                            <td class="audit-diff" style="min-width:220px;max-width:340px;">
                                 <div class="diff-grid">
                                     <div class="diff-col">
                                         <h4>Anterior</h4>
@@ -340,8 +377,8 @@ $badgeAccion = [
                                     </div>
                                 </div>
                             </td>
-                            <td><?= htmlspecialchars($r['ip'] ?? '') ?></td>
-                            <td><?= htmlspecialchars($r['usuario'] ?? 'admin') ?></td>
+                            <td style="font-size:.82rem;"><?= htmlspecialchars($r['usuario'] ?? 'admin', ENT_QUOTES, 'UTF-8') ?></td>
+                            <td style="font-size:.78rem;color:var(--text-muted);"><?= htmlspecialchars($r['ip'] ?? '—', ENT_QUOTES, 'UTF-8') ?></td>
                         </tr>
                         <?php endforeach; ?>
                     </tbody>
@@ -349,21 +386,23 @@ $badgeAccion = [
                 <?php endif; ?>
             </div>
 
-            <!-- ── Paginación ──────────────────────────────────────── -->
+            <!-- Paginación -->
             <?php if ($totalPaginas > 1): ?>
-            <div class="card-footer" style="display:flex;justify-content:center;gap:.5rem;padding:1rem;">
-                <?php if ($pagina > 1): ?>
-                    <a href="<?= htmlspecialchars(urlFiltros(['pagina' => $pagina - 1])) ?>" class="btn btn-secondary btn-sm">← Anterior</a>
-                <?php endif; ?>
-                <span style="display:flex;align-items:center;font-size:.85rem;">
-                    Página <?= $pagina ?> de <?= $totalPaginas ?>
+            <div class="card-footer" style="display:flex;align-items:center;justify-content:space-between;padding:.875rem 1.25rem;">
+                <span style="font-size:.82rem;color:var(--text-muted);">
+                    Página <?= $pagina ?> de <?= $totalPaginas ?> · <?= number_format($total) ?> registros
                 </span>
-                <?php if ($pagina < $totalPaginas): ?>
-                    <a href="<?= htmlspecialchars(urlFiltros(['pagina' => $pagina + 1])) ?>" class="btn btn-secondary btn-sm">Siguiente →</a>
-                <?php endif; ?>
+                <div style="display:flex;gap:.5rem;">
+                    <?php if ($pagina > 1): ?>
+                        <a href="<?= htmlspecialchars(urlFiltros(['pagina' => $pagina - 1])) ?>" class="btn-ghost" style="padding:.3rem .75rem;font-size:.82rem;">← Anterior</a>
+                    <?php endif; ?>
+                    <?php if ($pagina < $totalPaginas): ?>
+                        <a href="<?= htmlspecialchars(urlFiltros(['pagina' => $pagina + 1])) ?>" class="btn-ghost" style="padding:.3rem .75rem;font-size:.82rem;">Siguiente →</a>
+                    <?php endif; ?>
+                </div>
             </div>
             <?php endif; ?>
-        </section>
+        </div>
 
     </main>
 </div>

--- a/src/buscar.php
+++ b/src/buscar.php
@@ -494,7 +494,7 @@ $hayFiltros = $termino !== '' || $categoriaId !== null || $marcaId !== null
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -530,7 +530,7 @@ $hayFiltros = $termino !== '' || $categoriaId !== null || $marcaId !== null
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>

--- a/src/categorias.php
+++ b/src/categorias.php
@@ -134,7 +134,7 @@ try {
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -174,12 +174,25 @@ try {
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
 

--- a/src/css/estilos.css
+++ b/src/css/estilos.css
@@ -2094,6 +2094,10 @@ input[type="checkbox"] {
   gap: 16px;
 }
 
+.stat-cards-6 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
 .stat-cards-3 {
   grid-template-columns: repeat(3, 1fr);
 }
@@ -2135,6 +2139,22 @@ input[type="checkbox"] {
 
 .stat-link:hover {
   color: var(--accent-dark);
+}
+
+/* Stat card como enlace completo (todo el card es clickable) */
+a.stat-card-link {
+  text-decoration: none;
+  color: inherit;
+  display: flex;
+  cursor: pointer;
+}
+a.stat-card-link:hover {
+  box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
+  border-color: var(--accent);
+}
+a.stat-card-link.stat-card-warning:hover {
+  border-color: var(--warning);
 }
 
 /* ---------- Toolbar de datos (buscar + filtros del index) ---------- */
@@ -2517,6 +2537,10 @@ input[type="checkbox"] {
     grid-template-columns: repeat(3, 1fr);
   }
 
+  .stat-cards-6 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
   .two-col-layout {
     grid-template-columns: 1fr;
   }
@@ -2573,11 +2597,40 @@ input[type="checkbox"] {
    Dashboard
    ========================================================================== */
 
+.pedido-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem;
+  margin-bottom: 1.25rem;
+}
+
+.pedido-tabs a:hover {
+  opacity: .85;
+  transform: translateY(-1px);
+}
+
 .dashboard-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
   gap: 1.5rem;
   margin-top: 1.5rem;
+  align-items: stretch;
+}
+
+.dashboard-grid > .card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.dashboard-grid > .card > .card-body {
+  flex: 1;
+  overflow: auto;
+  padding: 0;
+}
+
+.dashboard-grid > .card > .card-body .data-table {
+  min-width: 100%;
 }
 .chart-card {
   margin-top: 1.5rem;

--- a/src/editar_producto.php
+++ b/src/editar_producto.php
@@ -4,7 +4,6 @@
  *
  * @package  Es21Plus
  * @author   Carlitos6712
- * @author   miguelrechefdez
  * @version  1.0.0
  */
 require_once __DIR__ . '/includes/auth_check.php';
@@ -33,16 +32,16 @@ try {
         exit;
     }
 
-    $producto   = $productoModel->obtener($id);
-    $categorias = $categoriaModel->listar();
-    $marcas    = $marcaModel->listar();
-    $modelos   = $modeloMotoModel->listarParaSelect();
-    $proveedorModel        = new Proveedor($pdo);
+    $pdo                    = Database::getInstance();
+    $producto               = $productoModel->obtener($id);
+    $categorias             = $categoriaModel->listar();
+    $marcas                 = $marcaModel->listar();
+    $modelos                = $modeloMotoModel->listarParaSelect();
+    $proveedorModel         = new Proveedor($pdo);
     $proveedoresDisponibles = $proveedorModel->listar(true);
-    $proveedorIdActual     = (int)($producto['proveedor_id'] ?? 0);
+    $proveedorIdActual      = (int)($producto['proveedor_id'] ?? 0);
 
     // Cargar compatibilidades actuales del producto
-    $pdo = Database::getInstance();
     $stmtCompat = $pdo->prepare("SELECT modelo_id, notas FROM compatibilidades WHERE producto_id = :pid");
     $stmtCompat->execute([':pid' => $id]);
     $compatActuales  = $stmtCompat->fetchAll(PDO::FETCH_ASSOC);
@@ -87,7 +86,6 @@ try {
 
         // Sincronizar compatibilidades
         $modelosSeleccionados = array_map('intval', $_POST['modelos_compatibles'] ?? []);
-        $pdo = Database::getInstance();
         $stmt = $pdo->prepare("DELETE FROM compatibilidades WHERE producto_id = :pid");
         $stmt->execute([':pid' => $id]);
         foreach ($modelosSeleccionados as $modeloId) {
@@ -123,14 +121,153 @@ try {
     }
     $error = 'Error inesperado: ' . $e->getMessage();
 }
+
+$esBajo  = isset($producto) && (int)$producto['stock'] <= (int)($producto['stock_minimo'] ?? 5);
+$inicial = isset($producto) ? mb_strtoupper(mb_substr($producto['nombre'], 0, 1, 'UTF-8'), 'UTF-8') : '?';
+$imgRuta = isset($producto) ? Producto::rutaImagen($producto['imagen'] ?? null) : '';
 ?>
 <!DOCTYPE html>
 <html lang="es">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Editar Producto – es21plus</title>
+    <title>Editar <?= isset($producto) ? htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') : 'Producto' ?> – es21plus</title>
     <link rel="stylesheet" href="css/estilos.css">
+    <style>
+        /* ── Layout de dos columnas igual que ver_producto ── */
+        .product-detail-grid {
+            display: grid;
+            grid-template-columns: 320px 1fr;
+            gap: 1.5rem;
+            align-items: start;
+        }
+        .product-detail-image-card {
+            background: var(--bg-card);
+            border: 1px solid var(--border-color);
+            border-radius: var(--radius-lg);
+            padding: 1.5rem;
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            gap: 1rem;
+            position: sticky;
+            top: 1.5rem;
+        }
+        .product-detail-img {
+            width: 220px;
+            height: 220px;
+            object-fit: cover;
+            border-radius: var(--radius-md);
+            background: var(--bg-hover);
+        }
+        .product-detail-avatar-lg {
+            width: 220px;
+            height: 220px;
+            border-radius: var(--radius-md);
+            background: var(--accent);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 5rem;
+            font-weight: 700;
+            color: #fff;
+        }
+        .product-detail-name {
+            font-size: 1.1rem;
+            font-weight: 600;
+            color: var(--text-primary);
+            text-align: center;
+        }
+        .product-detail-price {
+            font-size: 1.75rem;
+            font-weight: 700;
+            color: var(--accent);
+        }
+        .product-detail-actions {
+            display: flex;
+            flex-direction: column;
+            gap: .5rem;
+            width: 100%;
+        }
+        /* ── Campos dentro de los detail-cards ── */
+        .detail-fields {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 1rem;
+        }
+        .detail-field {
+            display: flex;
+            flex-direction: column;
+            gap: .35rem;
+        }
+        .detail-field-full {
+            grid-column: 1 / -1;
+        }
+        .detail-label {
+            font-size: .72rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: .05em;
+            color: var(--text-muted);
+        }
+        .detail-section-title {
+            font-size: .8rem;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: .06em;
+            color: var(--text-muted);
+            padding-bottom: .5rem;
+            border-bottom: 1px solid var(--border-color);
+            margin-bottom: .5rem;
+            grid-column: 1 / -1;
+        }
+        /* Inputs dentro de tarjetas de detalle */
+        .detail-field .field-input,
+        .detail-field textarea.field-input {
+            font-size: .875rem;
+            padding: .4rem .65rem;
+        }
+        .detail-field textarea.field-input {
+            resize: vertical;
+        }
+        .field-hint-sm {
+            font-size: .72rem;
+            color: var(--text-muted);
+        }
+        /* Upload block dentro del panel izquierdo */
+        .left-upload-block {
+            width: 100%;
+            display: flex;
+            flex-direction: column;
+            gap: .5rem;
+            padding-top: .5rem;
+            border-top: 1px solid var(--border-color);
+        }
+        .left-upload-label {
+            font-size: .72rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: .05em;
+            color: var(--text-muted);
+            text-align: center;
+        }
+        @media (max-width: 900px) {
+            .product-detail-grid { grid-template-columns: 1fr; }
+            .product-detail-image-card {
+                position: static;
+                flex-direction: row;
+                align-items: flex-start;
+                flex-wrap: wrap;
+            }
+            .product-detail-img,
+            .product-detail-avatar-lg {
+                width: 100px;
+                height: 100px;
+                font-size: 2.5rem;
+            }
+            .detail-fields { grid-template-columns: 1fr; }
+        }
+    </style>
 </head>
 <body class="layout">
 
@@ -149,91 +286,74 @@ try {
             </svg>
         </button>
     </div>
-
     <nav class="sidebar-nav">
         <div class="nav-section">
             <span class="nav-section-label">Principal</span>
             <a href="index.php" class="nav-item <?= in_array(basename($_SERVER['PHP_SELF']), ['index.php','dashboard.php']) ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
                 <span class="nav-label">Dashboard</span>
             </a>
             <a href="productos.php" class="nav-item <?= in_array(basename($_SERVER['PHP_SELF']), ['productos.php','nuevo_producto.php','editar_producto.php','eliminar_producto.php']) ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg></span>
                 <span class="nav-label">Productos</span>
             </a>
             <a href="categorias.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'categorias.php' ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></span>
                 <span class="nav-label">Categorías</span>
             </a>
             <a href="marcas.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'marcas.php' ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
-            <a href="modelos_moto.php"
-               class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
+            <?php if (isAdmin()): ?>
+            <a href="modelos_moto.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
                 <span class="nav-label">Modelos de Moto</span>
             </a>
-            <a href="proveedores.php"
-               class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'proveedores.php' ? 'active' : '' ?>">
+            <a href="proveedores.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'proveedores.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
                 <span class="nav-label">Proveedores</span>
             </a>
-            <a href="pedidos.php"
-               class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'pedidos.php' ? 'active' : '' ?>">
+            <a href="pedidos.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'pedidos.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
                 <span class="nav-label">Pedidos</span>
             </a>
-
             <?php endif; ?>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Operaciones</span>
             <a href="movimientos.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'movimientos.php' ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
                 <span class="nav-label">Movimientos</span>
             </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>
             <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
-
     <div class="sidebar-footer">
         <div class="sidebar-user">
             <div class="user-avatar-sm"><?= mb_strtoupper(mb_substr($_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'U', 0, 2)) ?></div>
@@ -263,7 +383,11 @@ try {
                 <span class="breadcrumb-sep">›</span>
                 <a href="productos.php" class="breadcrumb-item">Productos</a>
                 <span class="breadcrumb-sep">›</span>
-                <span class="breadcrumb-item active">Editar Producto</span>
+                <?php if (isset($producto)): ?>
+                <a href="ver_producto.php?id=<?= (int)$producto['id'] ?>" class="breadcrumb-item"><?= htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') ?></a>
+                <span class="breadcrumb-sep">›</span>
+                <?php endif; ?>
+                <span class="breadcrumb-item active">Editar</span>
             </nav>
         </div>
         <div class="topbar-right">
@@ -285,14 +409,14 @@ try {
         <!-- Page header -->
         <div class="page-header">
             <div class="page-header-info">
-                <h1 class="page-title">Editar Producto</h1>
-                <p class="page-subtitle">
+                <h1 class="page-title">
                     <?php if (isset($producto)): ?>
-                        Modificando: <strong><?= htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') ?></strong>
+                        Editando: <?= htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') ?>
                     <?php else: ?>
-                        Modifica los datos del producto seleccionado
+                        Editar Producto
                     <?php endif; ?>
-                </p>
+                </h1>
+                <p class="page-subtitle">Modifica los datos y pulsa <strong>Guardar cambios</strong></p>
             </div>
             <div class="page-actions">
                 <a href="productos.php" class="btn-ghost">
@@ -301,11 +425,19 @@ try {
                     </svg>
                     Volver
                 </a>
+                <?php if (isset($producto)): ?>
+                <a href="ver_producto.php?id=<?= (int)$producto['id'] ?>" class="btn-ghost">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>
+                    </svg>
+                    Ver detalle
+                </a>
+                <?php endif; ?>
             </div>
         </div>
 
         <?php if ($error): ?>
-        <div class="alert-banner alert-banner-error">
+        <div class="alert-banner alert-banner-error" style="margin-bottom:1.25rem;">
             <svg class="alert-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
             </svg>
@@ -314,243 +446,345 @@ try {
         <?php endif; ?>
 
         <?php if (isset($producto)): ?>
-        <div class="card card-form">
-            <div class="card-header">
-                <h2 class="card-title">Datos del Producto</h2>
-                <p class="card-subtitle">Los campos marcados con <span class="field-required">*</span> son obligatorios</p>
+        <form method="POST" enctype="multipart/form-data">
+
+        <div class="product-detail-grid">
+
+            <!-- ══════════════════════════════════════
+                 COLUMNA IZQUIERDA – preview + acciones
+                 ══════════════════════════════════════ -->
+            <div class="product-detail-image-card">
+
+                <!-- Avatar / imagen actual -->
+                <div id="imgPreviewWrap">
+                    <?php if (!empty($producto['imagen'])): ?>
+                        <img src="<?= htmlspecialchars($imgRuta, ENT_QUOTES, 'UTF-8') ?>"
+                             alt="Imagen del producto"
+                             class="product-detail-img"
+                             id="imgPreviewEl">
+                    <?php else: ?>
+                        <div class="product-detail-avatar-lg" id="imgPreviewEl"><?= $inicial ?></div>
+                    <?php endif; ?>
+                </div>
+
+                <div class="product-detail-name"><?= htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') ?></div>
+                <div class="product-detail-price"><?= number_format((float)$producto['precio'], 2, ',', '.') ?> €</div>
+
+                <div style="width:100%;text-align:center;">
+                    <?php if ($esBajo): ?>
+                        <span class="status-pill status-pill-warning">Stock bajo</span>
+                    <?php else: ?>
+                        <span class="status-pill status-pill-success">Disponible</span>
+                    <?php endif; ?>
+                    <div style="font-size:.78rem;color:var(--text-muted);margin-top:.35rem;">
+                        Stock: <strong><?= (int)$producto['stock'] ?></strong> uds.
+                    </div>
+                </div>
+
+                <!-- Upload de imagen directamente en panel izquierdo -->
+                <div class="left-upload-block">
+                    <span class="left-upload-label">Cambiar imagen</span>
+                    <input class="field-input" type="file" id="imagen" name="imagen"
+                           accept=".jpg,.jpeg,.png,.webp,image/jpeg,image/png,image/webp"
+                           style="cursor:pointer;font-size:.8rem;">
+                    <span class="field-hint-sm" style="text-align:center;">JPG, PNG o WebP · Máx. 2 MB</span>
+                    <?php if (!empty($producto['imagen'])): ?>
+                    <label style="display:flex;align-items:center;gap:.5rem;font-size:.8rem;cursor:pointer;justify-content:center;">
+                        <input type="checkbox" name="eliminar_imagen" value="1"> Eliminar imagen actual
+                    </label>
+                    <?php endif; ?>
+                </div>
+
+                <!-- Acciones -->
+                <div class="product-detail-actions">
+                    <button type="submit" class="btn-primary" style="text-align:center;justify-content:center;">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                            <polyline points="20 6 9 17 4 12"/>
+                        </svg>
+                        Guardar cambios
+                    </button>
+                    <a href="ver_producto.php?id=<?= (int)$producto['id'] ?>" class="btn-ghost" style="text-align:center;justify-content:center;">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/>
+                        </svg>
+                        Ver detalle
+                    </a>
+                    <a href="movimientos.php?producto_id=<?= (int)$producto['id'] ?>" class="btn-ghost" style="text-align:center;justify-content:center;">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>
+                        </svg>
+                        Ver movimientos
+                    </a>
+                    <a href="eliminar_producto.php?id=<?= (int)$producto['id'] ?>" class="btn-danger"
+                       style="text-align:center;justify-content:center;"
+                       onclick="return confirm('¿Eliminar este producto? Esta acción no se puede deshacer.')">
+                        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/>
+                        </svg>
+                        Eliminar producto
+                    </a>
+                </div>
             </div>
-            <div class="card-body">
-                <form method="POST" enctype="multipart/form-data" class="form-grid-wrapper">
-                    <div class="form-grid">
 
-                        <div class="form-field form-field-full">
-                            <label class="field-label" for="nombre">Nombre <span class="field-required">*</span></label>
-                            <input class="field-input" type="text" id="nombre" name="nombre" required
-                                   placeholder="Nombre del producto"
-                                   value="<?= htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') ?>">
-                        </div>
+            <!-- ══════════════════════════════════════
+                 COLUMNA DERECHA – secciones del form
+                 ══════════════════════════════════════ -->
+            <div style="display:flex;flex-direction:column;gap:1.5rem;">
 
-                        <div class="form-field form-field-full">
-                            <label class="field-label" for="descripcion">Descripción corta</label>
-                            <textarea class="field-input field-textarea" id="descripcion" name="descripcion" rows="2"
-                                      placeholder="Resumen breve del producto…"><?= htmlspecialchars($producto['descripcion'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
-                        </div>
+                <!-- Datos básicos -->
+                <div class="card">
+                    <div class="card-body">
+                        <div class="detail-fields">
+                            <div class="detail-section-title">Datos básicos</div>
 
-                        <div class="form-field form-field-full">
-                            <label class="field-label" for="descripcion_larga">Descripción larga</label>
-                            <textarea class="field-input field-textarea" id="descripcion_larga" name="descripcion_larga" rows="5"
-                                      placeholder="Descripción técnica detallada, especificaciones, compatibilidades…"><?= htmlspecialchars($producto['descripcion_larga'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
-                        </div>
+                            <div class="detail-field detail-field-full">
+                                <label class="detail-label" for="nombre">Nombre <span style="color:var(--danger,#ef4444)">*</span></label>
+                                <input class="field-input" type="text" id="nombre" name="nombre" required
+                                       placeholder="Nombre del producto"
+                                       value="<?= htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
 
-                        <div class="form-field">
-                            <label class="field-label" for="precio">Precio (€) <span class="field-required">*</span></label>
-                            <input class="field-input" type="number" id="precio" name="precio" step="0.01" min="0" required
-                                   placeholder="0.00"
-                                   value="<?= htmlspecialchars((string)$producto['precio'], ENT_QUOTES, 'UTF-8') ?>">
-                            <span class="field-hint">Precio de venta al público</span>
-                        </div>
+                            <div class="detail-field detail-field-full">
+                                <label class="detail-label" for="descripcion">Descripción corta</label>
+                                <textarea class="field-input" id="descripcion" name="descripcion" rows="2"
+                                          placeholder="Resumen breve del producto…"><?= htmlspecialchars($producto['descripcion'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+                            </div>
 
-                        <div class="form-field">
-                            <label class="field-label" for="stock_minimo">Stock Mínimo</label>
-                            <input class="field-input" type="number" id="stock_minimo" name="stock_minimo" min="0"
-                                   placeholder="5"
-                                   value="<?= (int)($producto['stock_minimo'] ?? 5) ?>">
-                            <span class="field-hint">Alerta cuando el stock baje de este valor</span>
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="codigo_ref">Código de Referencia</label>
-                            <input class="field-input" type="text" id="codigo_ref" name="codigo_ref"
-                                   placeholder="Ej. REF-001"
-                                   value="<?= htmlspecialchars($producto['codigo_ref'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
-                            <span class="field-hint">Referencia interna o del fabricante</span>
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="codigo_barras">Código de Barras / EAN</label>
-                            <input class="field-input" type="text" id="codigo_barras" name="codigo_barras"
-                                   placeholder="Ej. 8412345678901"
-                                   value="<?= htmlspecialchars($producto['codigo_barras'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="proveedor">Proveedor (texto libre)</label>
-                            <input class="field-input" type="text" id="proveedor" name="proveedor"
-                                   placeholder="Nombre del proveedor"
-                                   value="<?= htmlspecialchars($producto['proveedor'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="proveedor_id">Proveedor vinculado</label>
-                            <select class="field-input" id="proveedor_id" name="proveedor_id">
-                                <option value="">— Sin proveedor vinculado —</option>
-                                <?php foreach ($proveedoresDisponibles as $pv): ?>
-                                <option value="<?= (int)$pv['id'] ?>" <?= (int)$pv['id'] === $proveedorIdActual ? 'selected' : '' ?>>
-                                    <?= htmlspecialchars($pv['nombre'], ENT_QUOTES, 'UTF-8') ?>
-                                </option>
-                                <?php endforeach; ?>
-                            </select>
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="url_proveedor">URL del Proveedor</label>
-                            <input class="field-input" type="url" id="url_proveedor" name="url_proveedor"
-                                   placeholder="https://proveedor.com/producto"
-                                   value="<?= htmlspecialchars($producto['url_proveedor'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="ubicacion">Ubicación en Taller</label>
-                            <input class="field-input" type="text" id="ubicacion" name="ubicacion"
-                                   placeholder="Ej. Estante A3, Cajón 2…"
-                                   value="<?= htmlspecialchars($producto['ubicacion'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
-                            <span class="field-hint">Dónde está físicamente en el taller</span>
-                        </div>
-
-                        <!-- Dimensiones técnicas -->
-                        <div class="form-field">
-                            <label class="field-label" for="peso">Peso (g)</label>
-                            <input class="field-input" type="number" id="peso" name="peso" min="0"
-                                   placeholder="Ej. 500"
-                                   value="<?= htmlspecialchars((string)($producto['peso'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
-                            <span class="field-hint">Peso en gramos</span>
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="capacidad">Capacidad (ml)</label>
-                            <input class="field-input" type="number" id="capacidad" name="capacidad" min="0"
-                                   placeholder="Ej. 1000"
-                                   value="<?= htmlspecialchars((string)($producto['capacidad'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
-                            <span class="field-hint">Capacidad en mililitros</span>
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="longitud">Longitud (mm)</label>
-                            <input class="field-input" type="number" id="longitud" name="longitud" min="0"
-                                   placeholder="Ej. 800"
-                                   value="<?= htmlspecialchars((string)($producto['longitud'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
-                            <span class="field-hint">Longitud en milímetros</span>
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="anchura">Anchura (mm)</label>
-                            <input class="field-input" type="number" id="anchura" name="anchura" min="0"
-                                   placeholder="Ej. 340"
-                                   value="<?= htmlspecialchars((string)($producto['anchura'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
-                            <span class="field-hint">Anchura en milímetros</span>
-                        </div>
-
-                        <div class="form-field">
-                            <label class="field-label" for="diametro">Diámetro (mm)</label>
-                            <input class="field-input" type="number" id="diametro" name="diametro" min="0" step="0.01"
-                                   placeholder="Ej. 310.00"
-                                   value="<?= htmlspecialchars((string)($producto['diametro'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
-                            <span class="field-hint">Diámetro en milímetros</span>
-                        </div>
-
-                        <div class="form-field form-field-full">
-                            <label class="field-label">Imagen del Producto</label>
-                            <div class="image-upload-wrap">
-                                <div class="image-preview" id="imagePreview">
-                                    <?php $imgActual = $producto['imagen'] ?? null; ?>
-                                    <?php if ($imgActual): ?>
-                                        <img src="<?= htmlspecialchars(\Producto::rutaImagen($imgActual), ENT_QUOTES, 'UTF-8') ?>"
-                                             alt="Imagen actual"
-                                             style="width:80px;height:80px;object-fit:cover;border-radius:8px;">
-                                    <?php else: ?>
-                                        <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-muted)">
-                                            <rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/>
-                                        </svg>
-                                        <span style="font-size:.8rem;color:var(--text-muted);margin-top:.5rem;">Sin imagen</span>
-                                    <?php endif; ?>
-                                </div>
-                                <div class="image-upload-info">
-                                    <input class="field-input" type="file" id="imagen" name="imagen"
-                                           accept=".jpg,.jpeg,.png,.webp,image/jpeg,image/png,image/webp"
-                                           style="cursor:pointer;">
-                                    <span class="field-hint">JPG, PNG o WebP · Máximo 2 MB. Reemplazará la imagen actual.</span>
-                                    <?php if ($imgActual): ?>
-                                    <label style="display:flex;align-items:center;gap:.5rem;margin-top:.5rem;font-size:.875rem;cursor:pointer;">
-                                        <input type="checkbox" name="eliminar_imagen" value="1"> Eliminar imagen actual
-                                    </label>
-                                    <?php endif; ?>
-                                </div>
+                            <div class="detail-field detail-field-full">
+                                <label class="detail-label" for="descripcion_larga">Descripción larga</label>
+                                <textarea class="field-input" id="descripcion_larga" name="descripcion_larga" rows="4"
+                                          placeholder="Descripción técnica detallada, especificaciones…"><?= htmlspecialchars($producto['descripcion_larga'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
                             </div>
                         </div>
+                    </div>
+                </div>
 
-                        <div class="form-field">
-                            <label class="field-label" for="categoria_id">Categoría</label>
-                            <select class="field-input field-select" id="categoria_id" name="categoria_id">
-                                <option value="">Sin categoría</option>
-                                <?php foreach ($categorias as $cat): ?>
-                                    <option value="<?= (int)$cat['id'] ?>"
-                                        <?= (int)$cat['id'] === (int)$producto['categoria_id'] ? 'selected' : '' ?>>
+                <!-- Precio y stock -->
+                <div class="card">
+                    <div class="card-body">
+                        <div class="detail-fields">
+                            <div class="detail-section-title">Precio y stock</div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="precio">Precio (€) <span style="color:var(--danger,#ef4444)">*</span></label>
+                                <input class="field-input" type="number" id="precio" name="precio"
+                                       step="0.01" min="0.01" required placeholder="0.00"
+                                       value="<?= htmlspecialchars((string)$producto['precio'], ENT_QUOTES, 'UTF-8') ?>">
+                                <span class="field-hint-sm">Precio de venta al público</span>
+                            </div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="stock_minimo">Stock mínimo</label>
+                                <input class="field-input" type="number" id="stock_minimo" name="stock_minimo"
+                                       min="0" placeholder="5"
+                                       value="<?= (int)($producto['stock_minimo'] ?? 5) ?>">
+                                <span class="field-hint-sm">Alerta cuando baje de este valor</span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Identificación -->
+                <div class="card">
+                    <div class="card-body">
+                        <div class="detail-fields">
+                            <div class="detail-section-title">Identificación</div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="categoria_id">Categoría</label>
+                                <select class="field-input" id="categoria_id" name="categoria_id">
+                                    <option value="">Sin categoría</option>
+                                    <?php foreach ($categorias as $cat): ?>
+                                    <option value="<?= (int)$cat['id'] ?>" <?= (int)$cat['id'] === (int)$producto['categoria_id'] ? 'selected' : '' ?>>
                                         <?= htmlspecialchars($cat['nombre'], ENT_QUOTES, 'UTF-8') ?>
                                     </option>
-                                <?php endforeach; ?>
-                            </select>
-                        </div>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
 
-                        <div class="form-field">
-                            <label class="field-label" for="marca_id">Marca</label>
-                            <select class="field-input field-select" id="marca_id" name="marca_id">
-                                <option value="">Sin marca</option>
-                                <?php foreach ($marcas as $m): ?>
-                                    <option value="<?= (int)$m['id'] ?>"
-                                        <?= (int)$m['id'] === (int)($producto['marca_id'] ?? 0) ? 'selected' : '' ?>>
+                            <div class="detail-field">
+                                <label class="detail-label" for="marca_id">Marca</label>
+                                <select class="field-input" id="marca_id" name="marca_id">
+                                    <option value="">Sin marca</option>
+                                    <?php foreach ($marcas as $m): ?>
+                                    <option value="<?= (int)$m['id'] ?>" <?= (int)$m['id'] === (int)($producto['marca_id'] ?? 0) ? 'selected' : '' ?>>
                                         <?= htmlspecialchars($m['nombre'], ENT_QUOTES, 'UTF-8') ?>
                                     </option>
-                                <?php endforeach; ?>
-                            </select>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="codigo_ref">Código de referencia</label>
+                                <input class="field-input" type="text" id="codigo_ref" name="codigo_ref"
+                                       placeholder="Ej. REF-001"
+                                       value="<?= htmlspecialchars($producto['codigo_ref'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="codigo_barras">Código de barras / EAN</label>
+                                <input class="field-input" type="text" id="codigo_barras" name="codigo_barras"
+                                       placeholder="Ej. 8412345678901"
+                                       value="<?= htmlspecialchars($producto['codigo_barras'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
+
+                            <div class="detail-field detail-field-full">
+                                <label class="detail-label" for="ubicacion">Ubicación en taller</label>
+                                <input class="field-input" type="text" id="ubicacion" name="ubicacion"
+                                       placeholder="Ej. Estante A3, Cajón 2…"
+                                       value="<?= htmlspecialchars($producto['ubicacion'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
                         </div>
-
                     </div>
+                </div>
 
+                <!-- Dimensiones técnicas -->
+                <div class="card">
+                    <div class="card-body">
+                        <div class="detail-fields">
+                            <div class="detail-section-title">Dimensiones técnicas</div>
 
-                    <div class="form-section" style="margin-top:1.5rem;">
-                        <h3 class="form-section-title" style="font-size:1rem;font-weight:600;margin-bottom:1rem;">Motos compatibles</h3>
+                            <div class="detail-field">
+                                <label class="detail-label" for="peso">Peso (g)</label>
+                                <input class="field-input" type="number" id="peso" name="peso" min="0" placeholder="Ej. 500"
+                                       value="<?= htmlspecialchars((string)($producto['peso'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="capacidad">Capacidad (ml)</label>
+                                <input class="field-input" type="number" id="capacidad" name="capacidad" min="0" placeholder="Ej. 1000"
+                                       value="<?= htmlspecialchars((string)($producto['capacidad'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="longitud">Longitud (mm)</label>
+                                <input class="field-input" type="number" id="longitud" name="longitud" min="0" placeholder="Ej. 800"
+                                       value="<?= htmlspecialchars((string)($producto['longitud'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="anchura">Anchura (mm)</label>
+                                <input class="field-input" type="number" id="anchura" name="anchura" min="0" placeholder="Ej. 340"
+                                       value="<?= htmlspecialchars((string)($producto['anchura'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="diametro">Diámetro (mm)</label>
+                                <input class="field-input" type="number" id="diametro" name="diametro" min="0" step="0.01" placeholder="Ej. 310.00"
+                                       value="<?= htmlspecialchars((string)($producto['diametro'] ?? ''), ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Proveedor -->
+                <div class="card">
+                    <div class="card-body">
+                        <div class="detail-fields">
+                            <div class="detail-section-title">Proveedor</div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="proveedor_id">Proveedor vinculado</label>
+                                <select class="field-input" id="proveedor_id" name="proveedor_id">
+                                    <option value="">— Sin proveedor vinculado —</option>
+                                    <?php foreach ($proveedoresDisponibles as $pv): ?>
+                                    <option value="<?= (int)$pv['id'] ?>" <?= (int)$pv['id'] === $proveedorIdActual ? 'selected' : '' ?>>
+                                        <?= htmlspecialchars($pv['nombre'], ENT_QUOTES, 'UTF-8') ?>
+                                    </option>
+                                    <?php endforeach; ?>
+                                </select>
+                            </div>
+
+                            <div class="detail-field">
+                                <label class="detail-label" for="proveedor">Proveedor (texto libre)</label>
+                                <input class="field-input" type="text" id="proveedor" name="proveedor"
+                                       placeholder="Nombre del proveedor"
+                                       value="<?= htmlspecialchars($producto['proveedor'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
+
+                            <div class="detail-field detail-field-full">
+                                <label class="detail-label" for="url_proveedor">URL del proveedor</label>
+                                <input class="field-input" type="url" id="url_proveedor" name="url_proveedor"
+                                       placeholder="https://proveedor.com/producto"
+                                       value="<?= htmlspecialchars($producto['url_proveedor'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Motos compatibles -->
+                <div class="card">
+                    <div class="card-header">
+                        <h3 class="card-title">Motos compatibles</h3>
+                    </div>
+                    <div class="card-body">
                         <?php if (empty($modelos)): ?>
-                            <p class="text-muted" style="color:#6b7280;">No hay modelos de moto registrados. <a href="modelos_moto.php">Añadir modelos</a></p>
+                            <p style="color:#6b7280;font-style:italic;">No hay modelos registrados. <a href="modelos_moto.php">Añadir modelos</a></p>
                         <?php else: ?>
-                        <div class="compat-grid" style="display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:0.75rem;">
+                        <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(260px,1fr));gap:.75rem;">
                             <?php foreach ($modelos as $m): ?>
-                            <div class="compat-item" style="padding:0.5rem;border:1px solid var(--border-color, #e5e7eb);border-radius:6px;">
-                                <label style="display:flex;align-items:center;gap:0.5rem;cursor:pointer;font-weight:500;">
+                            <div style="padding:.5rem;border:1px solid var(--border-color,#e5e7eb);border-radius:6px;">
+                                <label style="display:flex;align-items:center;gap:.5rem;cursor:pointer;font-size:.875rem;font-weight:500;">
                                     <input type="checkbox"
                                            name="modelos_compatibles[]"
                                            value="<?= (int)$m['id'] ?>"
                                            <?= in_array((int)$m['id'], $modelosActuales, true) ? 'checked' : '' ?>>
                                     <?= htmlspecialchars("{$m['marca']} {$m['modelo']}", ENT_QUOTES, 'UTF-8') ?>
-                                    <span style="color:#6b7280;font-size:0.85em;">(<?= (int)$m['anio_desde'] ?>–<?= $m['anio_hasta'] ? (int)$m['anio_hasta'] : 'actual' ?>)</span>
+                                    <span style="color:#6b7280;font-size:.82em;">(<?= (int)$m['anio_desde'] ?>–<?= $m['anio_hasta'] ? (int)$m['anio_hasta'] : 'actual' ?>)</span>
                                 </label>
                                 <input type="text"
                                        name="notas_compatibilidad[<?= (int)$m['id'] ?>]"
                                        placeholder="Notas (opcional)"
-                                       style="width:100%;margin-top:0.25rem;padding:0.25rem 0.5rem;border:1px solid var(--border-color,#d1d5db);border-radius:4px;font-size:0.85em;"
+                                       style="width:100%;margin-top:.25rem;padding:.25rem .5rem;border:1px solid var(--border-color,#d1d5db);border-radius:4px;font-size:.82em;background:var(--bg-input,#fff);color:var(--text-primary);"
                                        value="<?= htmlspecialchars($notasActuales[$m['id']] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                             </div>
                             <?php endforeach; ?>
                         </div>
                         <?php endif; ?>
                     </div>
+                </div>
 
-                    <div class="card-footer">
-                        <a href="productos.php" class="btn-ghost">Cancelar</a>
-                        <button type="submit" class="btn-primary">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-                                <polyline points="20 6 9 17 4 12"/>
-                            </svg>
-                            Guardar Cambios
-                        </button>
-                    </div>
-                </form>
-            </div>
-        </div>
+                <!-- Botones de acción al pie de la columna derecha -->
+                <div style="display:flex;gap:.75rem;justify-content:flex-end;padding-bottom:.5rem;">
+                    <a href="productos.php" class="btn-ghost">Cancelar</a>
+                    <button type="submit" class="btn-primary">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                            <polyline points="20 6 9 17 4 12"/>
+                        </svg>
+                        Guardar cambios
+                    </button>
+                </div>
+
+            </div><!-- /columna derecha -->
+        </div><!-- /product-detail-grid -->
+
+        </form>
         <?php endif; ?>
 
     </main>
 </div>
 
 <script src="js/app.js"></script>
+<script>
+/**
+ * Preview en tiempo real de la imagen seleccionada.
+ * @author Carlitos6712
+ */
+(function () {
+    const input = document.getElementById('imagen');
+    if (!input) return;
+    input.addEventListener('change', function () {
+        const file = this.files[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = function (e) {
+            const wrap = document.getElementById('imgPreviewWrap');
+            if (!wrap) return;
+            wrap.innerHTML = '<img src="' + e.target.result + '" alt="Preview" class="product-detail-img">';
+        };
+        reader.readAsDataURL(file);
+    });
+}());
+</script>
 </body>
 </html>

--- a/src/eliminar_producto.php
+++ b/src/eliminar_producto.php
@@ -111,7 +111,7 @@ try {
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -151,7 +151,7 @@ try {
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>

--- a/src/empleados.php
+++ b/src/empleados.php
@@ -136,7 +136,7 @@ $sessionUserId = (int)($_SESSION['user_id'] ?? 0);
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>

--- a/src/includes/Marca.php
+++ b/src/includes/Marca.php
@@ -32,7 +32,9 @@ class Marca
 
     private function bizWhere(string $alias = 'm'): string
     {
-        return $this->businessId !== null ? " AND {$alias}.business_id = :biz_id" : "";
+        if ($this->businessId === null) return "";
+        $col = $alias !== '' ? "{$alias}.business_id" : "business_id";
+        return " AND {$col} = :biz_id";
     }
 
     private function bizParam(): array
@@ -67,7 +69,7 @@ class Marca
      */
     public function obtenerPorId(int $id): array
     {
-        $sql  = "SELECT * FROM marcas WHERE id = :id" . $this->bizWhere();
+        $sql  = "SELECT * FROM marcas WHERE id = :id" . $this->bizWhere('');
         $stmt = $this->pdo->prepare($sql);
         $stmt->execute(array_merge([':id' => $id], $this->bizParam()));
         $row = $stmt->fetch();
@@ -114,7 +116,7 @@ class Marca
     {
         $anterior = $this->obtenerPorId($id);
         $sql      = "UPDATE marcas SET nombre = :nombre, descripcion = :descripcion
-                     WHERE id = :id" . $this->bizWhere();
+                     WHERE id = :id" . $this->bizWhere('');
         $stmt     = $this->pdo->prepare($sql);
         $resultado = $stmt->execute(array_merge(
             [':nombre' => $nombre, ':descripcion' => $descripcion, ':id' => $id],
@@ -145,7 +147,7 @@ class Marca
         }
 
         $anterior  = $this->obtenerPorId($id);
-        $sql       = "DELETE FROM marcas WHERE id = :id" . $this->bizWhere();
+        $sql       = "DELETE FROM marcas WHERE id = :id" . $this->bizWhere('');
         $del       = $this->pdo->prepare($sql);
         $resultado = $del->execute(array_merge([':id' => $id], $this->bizParam()));
         if ($resultado) {

--- a/src/includes/Movimiento.php
+++ b/src/includes/Movimiento.php
@@ -247,6 +247,106 @@ class Movimiento
     }
 
     /**
+     * Cuenta movimientos globales con filtros opcionales.
+     *
+     * @param int|null    $productoId Filtro por producto.
+     * @param string|null $tipo       'entrada' | 'salida' | null = todos.
+     * @param string|null $desde      Fecha inicio Y-m-d.
+     * @param string|null $hasta      Fecha fin Y-m-d.
+     * @return int
+     * @author Carlitos6712
+     */
+    public function contarGlobal(
+        ?int $productoId = null,
+        ?string $tipo    = null,
+        ?string $desde   = null,
+        ?string $hasta   = null
+    ): int {
+        [$where, $params] = $this->buildGlobalWhere($productoId, $tipo, $desde, $hasta);
+        $stmt = $this->pdo->prepare(
+            "SELECT COUNT(*) FROM movimientos m JOIN productos p ON m.producto_id = p.id WHERE 1=1 {$where}"
+        );
+        $stmt->execute($params);
+        return (int) $stmt->fetchColumn();
+    }
+
+    /**
+     * Lista movimientos globales paginados con filtros opcionales.
+     *
+     * @param int         $pagina
+     * @param int         $porPagina
+     * @param int|null    $productoId
+     * @param string|null $tipo
+     * @param string|null $desde
+     * @param string|null $hasta
+     * @return array<int, array<string, mixed>>
+     * @author Carlitos6712
+     */
+    public function listarGlobalPaginado(
+        int $pagina,
+        int $porPagina,
+        ?int $productoId = null,
+        ?string $tipo    = null,
+        ?string $desde   = null,
+        ?string $hasta   = null
+    ): array {
+        [$where, $params] = $this->buildGlobalWhere($productoId, $tipo, $desde, $hasta);
+        $offset = ($pagina - 1) * $porPagina;
+        $sql    = "SELECT m.*, p.nombre AS producto_nombre, p.codigo_ref, c.nombre AS categoria_nombre
+                   FROM movimientos m
+                   JOIN productos p ON m.producto_id = p.id
+                   LEFT JOIN categorias c ON p.categoria_id = c.id
+                   WHERE 1=1 {$where}
+                   ORDER BY m.fecha DESC
+                   LIMIT :limite OFFSET :offset";
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($params as $k => $v) {
+            $stmt->bindValue($k, $v);
+        }
+        $stmt->bindValue(':limite', $porPagina, PDO::PARAM_INT);
+        $stmt->bindValue(':offset', $offset,    PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Construye cláusula WHERE y parámetros para filtros globales.
+     *
+     * @return array{0: string, 1: array<string, mixed>}
+     */
+    private function buildGlobalWhere(
+        ?int $productoId,
+        ?string $tipo,
+        ?string $desde,
+        ?string $hasta
+    ): array {
+        $where  = '';
+        $params = [];
+
+        if ($this->businessId !== null) {
+            $where .= " AND m.business_id = :biz_id";
+            $params[':biz_id'] = $this->businessId;
+        }
+        if ($productoId !== null) {
+            $where .= " AND m.producto_id = :producto_id";
+            $params[':producto_id'] = $productoId;
+        }
+        if ($tipo !== null && in_array($tipo, ['entrada', 'salida'], true)) {
+            $where .= " AND m.tipo = :tipo";
+            $params[':tipo'] = $tipo;
+        }
+        if ($desde !== null) {
+            $where .= " AND DATE(m.fecha) >= :desde";
+            $params[':desde'] = $desde;
+        }
+        if ($hasta !== null) {
+            $where .= " AND DATE(m.fecha) <= :hasta";
+            $params[':hasta'] = $hasta;
+        }
+        return [$where, $params];
+    }
+
+    /**
      * Lista movimientos filtrados para exportación CSV.
      *
      * Sin fechas, exporta los últimos 30 días por defecto.

--- a/src/includes/Proveedor.php
+++ b/src/includes/Proveedor.php
@@ -34,6 +34,18 @@ class Proveedor
      * @return array<int, array<string, mixed>>
      * @author Carlitos6712
      */
+    /**
+     * Cuenta proveedores activos.
+     *
+     * @return int
+     * @author Carlitos6712
+     */
+    public function contarActivos(): int
+    {
+        $stmt = $this->pdo->query("SELECT COUNT(*) FROM proveedores WHERE activo = 1");
+        return (int) $stmt->fetchColumn();
+    }
+
     public function listar(?bool $soloActivos = true): array
     {
         $where = $soloActivos ? " WHERE p.activo = 1" : "";

--- a/src/includes/auth_check.php
+++ b/src/includes/auth_check.php
@@ -63,3 +63,27 @@ function requireAuth(): void
 }
 
 requireAuth();
+
+/**
+ * Devuelve true si el usuario activo tiene rol admin.
+ * Cubre ambos tipos de sesión: login local (rol) y login de empresa (user_role).
+ *
+ * @return bool
+ * @author Carlitos6712
+ */
+function isAdmin(): bool
+{
+    $rol = $_SESSION['user_role'] ?? $_SESSION['rol'] ?? '';
+    return $rol === 'admin';
+}
+
+/**
+ * Devuelve el rol normalizado del usuario activo.
+ *
+ * @return string 'admin' | 'superadmin' | 'employee'
+ * @author Carlitos6712
+ */
+function currentRole(): string
+{
+    return $_SESSION['user_role'] ?? $_SESSION['rol'] ?? 'employee';
+}

--- a/src/index.php
+++ b/src/index.php
@@ -14,18 +14,20 @@ require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/Movimiento.php';
 require_once __DIR__ . '/includes/Categoria.php';
 require_once __DIR__ . '/includes/Pedido.php';
+require_once __DIR__ . '/includes/Proveedor.php';
 
 $flashSuccess  = $_SESSION['flash_success'] ?? '';
 $flashError    = $_SESSION['flash_error']   ?? '';
 $showWelcome   = isset($_GET['welcome']) && $_GET['welcome'] === '1';
 unset($_SESSION['flash_success'], $_SESSION['flash_error']);
 
-$totalProductos   = 0;
-$valorInventario  = 0.0;
-$stockBajoCount   = 0;
-$movimientosMes   = 0;
-$totalCategorias  = 0;
-$pedidosPendientes = 0;
+$totalProductos     = 0;
+$valorInventario    = 0.0;
+$stockBajoCount     = 0;
+$movimientosMes     = 0;
+$totalCategorias    = 0;
+$pedidosPendientes  = 0;
+$totalProveedores   = 0;
 $productosStockBajo = [];
 $ultimosMovimientos = [];
 $error = '';
@@ -35,6 +37,8 @@ try {
     $movimientoModel = new Movimiento();
     $categoriaModel  = new Categoria();
     $pedidoModel     = new Pedido();
+    $pdo             = Database::getInstance();
+    $proveedorModel  = new Proveedor($pdo);
 
     $totalProductos     = $productoModel->contarActivos();
     $valorInventario    = $productoModel->valorInventario();
@@ -42,6 +46,7 @@ try {
     $movimientosMes     = $movimientoModel->contarEsteMes();
     $totalCategorias    = count($categoriaModel->listar());
     $pedidosPendientes  = $pedidoModel->contarPendientes();
+    $totalProveedores   = $proveedorModel->contarActivos();
     $productosStockBajo = $productoModel->filtrarStockBajo();
     // Solo los top 5
     $productosStockBajo = array_slice($productosStockBajo, 0, 5);
@@ -113,7 +118,7 @@ try {
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -152,7 +157,7 @@ try {
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
@@ -288,8 +293,8 @@ try {
         </div>
 
         <!-- Stat cards -->
-        <div class="stat-cards">
-            <div class="stat-card">
+        <div class="stat-cards stat-cards-6">
+            <a href="productos.php" class="stat-card stat-card-link">
                 <div class="stat-card-icon stat-icon-blue">
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
@@ -299,8 +304,8 @@ try {
                     <span class="stat-value"><?= $totalProductos ?></span>
                     <span class="stat-label">Total Productos</span>
                 </div>
-            </div>
-            <div class="stat-card">
+            </a>
+            <a href="productos.php" class="stat-card stat-card-link">
                 <div class="stat-card-icon stat-icon-green">
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/>
@@ -310,19 +315,19 @@ try {
                     <span class="stat-value"><?= number_format($valorInventario, 2, ',', '.') ?> €</span>
                     <span class="stat-label">Valor Inventario</span>
                 </div>
-            </div>
-            <div class="stat-card <?= $stockBajoCount > 0 ? 'stat-card-warning' : '' ?>">
+            </a>
+            <a href="productos.php?stock_bajo=1" class="stat-card stat-card-link <?= $stockBajoCount > 0 ? 'stat-card-warning' : '' ?>">
                 <div class="stat-card-icon stat-icon-orange">
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
                     </svg>
                 </div>
                 <div class="stat-card-body">
-                    <a href="productos.php" class="stat-value stat-link"><?= $stockBajoCount ?></a>
+                    <span class="stat-value"><?= $stockBajoCount ?></span>
                     <span class="stat-label">Stock Bajo</span>
                 </div>
-            </div>
-            <div class="stat-card">
+            </a>
+            <a href="movimientos.php" class="stat-card stat-card-link">
                 <div class="stat-card-icon stat-icon-purple">
                     <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                         <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>
@@ -332,16 +337,25 @@ try {
                     <span class="stat-value"><?= $movimientosMes ?></span>
                     <span class="stat-label">Movimientos (mes)</span>
                 </div>
-            </div>
-            <div class="stat-card <?= $pedidosPendientes > 0 ? 'stat-card-warning' : '' ?>">
+            </a>
+            <a href="pedidos.php" class="stat-card stat-card-link <?= $pedidosPendientes > 0 ? 'stat-card-warning' : '' ?>">
                 <div class="stat-card-icon stat-icon-blue">
                     <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg>
                 </div>
                 <div class="stat-card-body">
-                    <a href="pedidos.php" class="stat-value stat-link"><?= $pedidosPendientes ?></a>
+                    <span class="stat-value"><?= $pedidosPendientes ?></span>
                     <span class="stat-label">Pedidos pendientes</span>
                 </div>
-            </div>
+            </a>
+            <a href="proveedores.php" class="stat-card stat-card-link">
+                <div class="stat-card-icon stat-icon-green">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg>
+                </div>
+                <div class="stat-card-body">
+                    <span class="stat-value"><?= $totalProveedores ?></span>
+                    <span class="stat-label">Proveedores activos</span>
+                </div>
+            </a>
         </div>
 
         <!-- Chart card -->
@@ -374,33 +388,32 @@ try {
                         <thead>
                             <tr>
                                 <th>Producto</th>
-                                <th>Categoría</th>
-                                <th>Stock</th>
-                                <th>Mínimo</th>
-                                <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
-                                <th>Acción</th>
+                                <th style="width:70px;text-align:center">Stock</th>
+                                <th style="width:50px;text-align:center">Mín.</th>
+                                <?php if (isAdmin()): ?>
+                                <th style="width:130px">Acción</th>
                                 <?php endif; ?>
                             </tr>
                         </thead>
                         <tbody>
                         <?php foreach ($productosStockBajo as $p): ?>
                             <tr>
-                                <td>
-                                    <a href="movimientos.php?producto_id=<?= (int)$p['id'] ?>" class="product-name">
+                                <td style="max-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">
+                                    <a href="movimientos.php?producto_id=<?= (int)$p['id'] ?>" class="product-name"
+                                       title="<?= htmlspecialchars($p['nombre'], ENT_QUOTES, 'UTF-8') ?>">
                                         <?= htmlspecialchars($p['nombre'], ENT_QUOTES, 'UTF-8') ?>
                                     </a>
+                                    <br><small style="color:var(--text-muted,#6b7280);font-size:.72rem"><?= htmlspecialchars($p['categoria_nombre'] ?? '—', ENT_QUOTES, 'UTF-8') ?></small>
                                 </td>
-                                <td>
-                                    <span class="category-pill"><?= htmlspecialchars($p['categoria_nombre'] ?? 'Sin categoría', ENT_QUOTES, 'UTF-8') ?></span>
-                                </td>
-                                <td>
+                                <td style="text-align:center">
                                     <span class="stock-value stock-value-low"><?= (int)$p['stock'] ?></span>
                                 </td>
-                                <td><?= (int)($p['stock_minimo'] ?? 5) ?></td>
-                                <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
-                                <td>
+                                <td style="text-align:center;color:var(--text-muted,#6b7280)"><?= (int)($p['stock_minimo'] ?? 5) ?></td>
+                                <?php if (isAdmin()): ?>
+                                <td style="text-align:center">
                                     <a href="nuevo_pedido.php?producto_id=<?= (int)$p['id'] ?>&cantidad=<?= max(1, ($p['stock_minimo'] ?? 5) - ($p['stock'] ?? 0)) ?>"
-                                       class="btn btn-sm btn-primary">
+                                       style="display:inline-flex;align-items:center;gap:4px;padding:4px 8px;background:var(--accent,#2563eb);color:#fff;border-radius:5px;text-decoration:none;font-size:.75rem;font-weight:600;white-space:nowrap">
+                                        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
                                         Pedir reposición
                                     </a>
                                 </td>
@@ -428,25 +441,37 @@ try {
                     <table class="data-table data-table-mini">
                         <thead>
                             <tr>
-                                <th>Fecha</th>
                                 <th>Producto</th>
-                                <th>Tipo</th>
-                                <th>Cantidad</th>
+                                <th style="width:80px;text-align:center">Tipo</th>
+                                <th style="width:60px;text-align:center">Cant.</th>
+                                <th style="width:100px"></th>
                             </tr>
                         </thead>
                         <tbody>
                         <?php foreach ($ultimosMovimientos as $mov): ?>
                             <tr>
-                                <td><?= htmlspecialchars(substr($mov['fecha'], 0, 10), ENT_QUOTES, 'UTF-8') ?></td>
-                                <td><?= htmlspecialchars($mov['producto_nombre'], ENT_QUOTES, 'UTF-8') ?></td>
-                                <td>
+                                <td style="max-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap">
+                                    <a href="movimientos.php?producto_id=<?= (int)$mov['producto_id'] ?>"
+                                       class="product-name"
+                                       title="<?= htmlspecialchars($mov['producto_nombre'], ENT_QUOTES, 'UTF-8') ?>">
+                                        <?= htmlspecialchars($mov['producto_nombre'], ENT_QUOTES, 'UTF-8') ?>
+                                    </a>
+                                    <br><small style="color:var(--text-muted,#6b7280);font-size:.72rem"><?= htmlspecialchars(substr($mov['fecha'], 0, 10), ENT_QUOTES, 'UTF-8') ?></small>
+                                </td>
+                                <td style="text-align:center">
                                     <?php if ($mov['tipo'] === 'entrada'): ?>
                                         <span class="status-pill status-pill-success">Entrada</span>
                                     <?php else: ?>
                                         <span class="status-pill status-pill-danger">Salida</span>
                                     <?php endif; ?>
                                 </td>
-                                <td><strong><?= (int)$mov['cantidad'] ?></strong></td>
+                                <td style="text-align:center"><strong><?= (int)$mov['cantidad'] ?></strong></td>
+                                <td style="text-align:center">
+                                    <a href="movimientos.php?producto_id=<?= (int)$mov['producto_id'] ?>"
+                                       style="display:inline-flex;align-items:center;gap:4px;padding:4px 8px;background:transparent;color:var(--accent,#2563eb);border:1px solid var(--accent,#2563eb);border-radius:5px;text-decoration:none;font-size:.75rem;font-weight:600;white-space:nowrap">
+                                        Ver detalle
+                                    </a>
+                                </td>
                             </tr>
                         <?php endforeach; ?>
                         </tbody>

--- a/src/marcas.php
+++ b/src/marcas.php
@@ -132,7 +132,7 @@ try {
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -172,12 +172,25 @@ try {
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
 
@@ -355,12 +368,20 @@ try {
                                             <input type="hidden" name="accion" value="eliminar">
                                             <input type="hidden" name="id" value="<?= (int)$marca['id'] ?>">
                                             <button type="submit" class="action-btn action-btn-red" title="Eliminar marca"
-                                                    data-confirm-cat="<?= htmlspecialchars($marca['nombre'], ENT_QUOTES, 'UTF-8') ?>">
+                                                    onclick="return confirm('¿Eliminar la marca «<?= htmlspecialchars($marca['nombre'], ENT_QUOTES, 'UTF-8') ?>»? Esta acción no se puede deshacer.')">
                                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                                     <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
                                                 </svg>
                                             </button>
                                         </form>
+                                        <?php else: ?>
+                                        <button class="action-btn" disabled
+                                                title="No se puede eliminar: tiene <?= (int)$marca['total_productos'] ?> producto(s) activo(s)"
+                                                style="opacity:.35;cursor:not-allowed;">
+                                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                                                <polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/>
+                                            </svg>
+                                        </button>
                                         <?php endif; ?>
                                     </td>
                                 </tr>

--- a/src/modelos_moto.php
+++ b/src/modelos_moto.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/ModeloMoto.php';
 
 // Solo admins pueden acceder a esta página
-if (($_SESSION['rol'] ?? '') !== 'admin') {
+if (!isAdmin()) {
     header('Location: index.php');
     exit;
 }
@@ -127,7 +127,7 @@ try {
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -167,12 +167,25 @@ try {
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
 

--- a/src/movimientos.php
+++ b/src/movimientos.php
@@ -1,11 +1,11 @@
 <?php
 /**
  * Historial y registro de movimientos de stock.
+ * Modo global (sin producto_id) o por producto (con ?producto_id=X).
  *
  * @package  Es21Plus
  * @author   Carlitos6712
- * @author   miguelrechefdez
- * @version  1.0.0
+ * @version  1.1.0
  */
 require_once __DIR__ . '/includes/auth_check.php';
 require_once __DIR__ . '/includes/AppException.php';
@@ -13,51 +13,93 @@ require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/Movimiento.php';
 
-$error          = '';
+const POR_PAGINA_MOVIMIENTOS = 15;
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+// ── Parámetros comunes ───────────────────────────────────────────────────────
+$productoId = filter_input(INPUT_GET,  'producto_id', FILTER_VALIDATE_INT)
+           ?? filter_input(INPUT_POST, 'producto_id', FILTER_VALIDATE_INT);
+
+$modoGlobal = ($productoId === null || $productoId === false);
+
+// Filtros (modo global)
+$filtroTipo    = $_GET['tipo']    ?? '';
+$filtroDesde   = $_GET['desde']  ?? '';
+$filtroHasta   = $_GET['hasta']  ?? '';
+$filtroProdId  = filter_input(INPUT_GET, 'filtro_producto', FILTER_VALIDATE_INT) ?: null;
+$paginaActual  = max(1, (int) filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT));
+
+// Inicializar variables
 $producto       = null;
 $movimientos    = [];
 $resumen        = [];
 $totalMovs      = 0;
 $totalPaginas   = 1;
 $stockBajoCount = 0;
-
-const POR_PAGINA_MOVIMIENTOS = 10;
-
-$flashSuccess = $_SESSION['flash_success'] ?? '';
-$flashError   = $_SESSION['flash_error']   ?? '';
-unset($_SESSION['flash_success'], $_SESSION['flash_error']);
-
-$productoId = filter_input(INPUT_GET, 'producto_id', FILTER_VALIDATE_INT)
-           ?? filter_input(INPUT_POST, 'producto_id', FILTER_VALIDATE_INT);
+$todosProductos = [];
+$statsGlobal    = ['entradas' => 0, 'salidas' => 0, 'total' => 0];
+$error          = '';
 
 try {
     $productoModel   = new Producto();
     $movimientoModel = new Movimiento();
     $stockBajoCount  = count($productoModel->filtrarStockBajo());
 
-    if (!$productoId) {
-        header('Location: index.php');
-        exit;
-    }
-
+    // ── POST: registrar movimiento ───────────────────────────────────────────
     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-        $tipo          = $_POST['tipo']         ?? '';
-        $cantidad      = (int) ($_POST['cantidad'] ?? 0);
-        $observaciones = trim($_POST['observaciones'] ?? '');
+        $postProductoId = filter_input(INPUT_POST, 'producto_id', FILTER_VALIDATE_INT);
+        $tipo           = $_POST['tipo']         ?? '';
+        $cantidad       = (int) ($_POST['cantidad'] ?? 0);
+        $observaciones  = trim($_POST['observaciones'] ?? '');
 
-        $movimientoModel->registrar($productoId, $tipo, $cantidad, $observaciones);
+        if (!$postProductoId) {
+            throw new AppException('Debes seleccionar un producto.', 400);
+        }
+        $movimientoModel->registrar($postProductoId, $tipo, $cantidad, $observaciones);
         $_SESSION['flash_success'] = 'Movimiento registrado correctamente.';
-        header("Location: movimientos.php?producto_id={$productoId}");
+
+        // Redirigir conservando contexto
+        $qs = $modoGlobal
+            ? http_build_query(array_filter(compact('filtroTipo','filtroDesde','filtroHasta') + ['tipo'=>$filtroTipo,'desde'=>$filtroDesde,'hasta'=>$filtroHasta]))
+            : "producto_id={$postProductoId}";
+        header("Location: movimientos.php" . ($qs ? "?{$qs}" : ''));
         exit;
     }
 
-    $producto     = $productoModel->obtener($productoId);
-    $resumen      = $movimientoModel->resumenStock($productoId);
-    $totalMovs    = $movimientoModel->contarPorProducto($productoId);
-    $paginaActual = max(1, (int) filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT));
-    $totalPaginas = max(1, (int) ceil($totalMovs / POR_PAGINA_MOVIMIENTOS));
-    $paginaActual = min($paginaActual, $totalPaginas);
-    $movimientos  = $movimientoModel->listarPorProductoPaginado($productoId, $paginaActual, POR_PAGINA_MOVIMIENTOS);
+    if ($modoGlobal) {
+        // ── MODO GLOBAL ──────────────────────────────────────────────────────
+        $todosProductos = $productoModel->listar();
+
+        $tipoFiltro   = in_array($filtroTipo, ['entrada','salida'], true) ? $filtroTipo : null;
+        $desdeFiltro  = $filtroDesde ?: null;
+        $hastaFiltro  = $filtroHasta ?: null;
+
+        $totalMovs    = $movimientoModel->contarGlobal($filtroProdId, $tipoFiltro, $desdeFiltro, $hastaFiltro);
+        $totalPaginas = max(1, (int) ceil($totalMovs / POR_PAGINA_MOVIMIENTOS));
+        $paginaActual = min($paginaActual, $totalPaginas);
+        $movimientos  = $movimientoModel->listarGlobalPaginado(
+            $paginaActual, POR_PAGINA_MOVIMIENTOS,
+            $filtroProdId, $tipoFiltro, $desdeFiltro, $hastaFiltro
+        );
+
+        // Stats globales (sin filtros de fecha para mostrar totales)
+        $statsGlobal['total']    = $movimientoModel->contarGlobal();
+        $statsGlobal['entradas'] = $movimientoModel->contarGlobal(null, 'entrada');
+        $statsGlobal['salidas']  = $movimientoModel->contarGlobal(null, 'salida');
+
+    } else {
+        // ── MODO PER-PRODUCTO ────────────────────────────────────────────────
+        $producto     = $productoModel->obtener($productoId);
+        $resumen      = $movimientoModel->resumenStock($productoId);
+        $totalMovs    = $movimientoModel->contarPorProducto($productoId);
+        $totalPaginas = max(1, (int) ceil($totalMovs / POR_PAGINA_MOVIMIENTOS));
+        $paginaActual = min($paginaActual, $totalPaginas);
+        $movimientos  = $movimientoModel->listarPorProductoPaginado($productoId, $paginaActual, POR_PAGINA_MOVIMIENTOS);
+        $todosProductos = [$producto]; // solo necesario para formulario
+    }
 
 } catch (AppException $e) {
     $error = $e->getMessage();
@@ -68,6 +110,16 @@ try {
 $entradas = (int)($resumen['entradas'] ?? 0);
 $salidas  = (int)($resumen['salidas']  ?? 0);
 $balance  = $entradas - $salidas;
+
+/**
+ * Construye URL de paginación conservando todos los filtros GET activos.
+ */
+function buildPaginationUrl(int $page, array $extra = []): string {
+    $params = array_merge($_GET, $extra, ['page' => $page]);
+    unset($params['page']);
+    $params['page'] = $page;
+    return 'movimientos.php?' . http_build_query(array_filter($params, fn($v) => $v !== '' && $v !== null));
+}
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -76,6 +128,29 @@ $balance  = $entradas - $salidas;
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Movimientos – es21plus</title>
     <link rel="stylesheet" href="css/estilos.css">
+    <style>
+        .filter-bar{display:flex;flex-wrap:wrap;gap:.75rem;align-items:flex-end;margin-bottom:1.25rem;padding:1rem 1.25rem;background:var(--color-surface,#fff);border:1px solid var(--color-border,#e5e7eb);border-radius:var(--radius,8px);}
+        .filter-bar .filter-group{display:flex;flex-direction:column;gap:.25rem;}
+        .filter-bar label{font-size:.75rem;font-weight:600;color:var(--color-text-muted,#6b7280);}
+        .filter-bar .field-input{min-width:150px;}
+        .filter-actions{display:flex;gap:.5rem;margin-left:auto;align-items:flex-end;}
+        .stat-cards-3{display:grid;grid-template-columns:repeat(3,1fr);gap:1rem;margin-bottom:1.25rem;}
+        @media(max-width:640px){.stat-cards-3{grid-template-columns:1fr;}}
+        .tipo-entrada{color:#15803d;font-weight:600;}
+        .tipo-salida {color:#b91c1c;font-weight:600;}
+        .badge-entrada{display:inline-flex;align-items:center;gap:4px;background:#dcfce7;color:#15803d;padding:2px 10px;border-radius:999px;font-size:.8rem;font-weight:600;}
+        .badge-salida {display:inline-flex;align-items:center;gap:4px;background:#fee2e2;color:#b91c1c;padding:2px 10px;border-radius:999px;font-size:.8rem;font-weight:600;}
+        .btn-form-inline{display:inline-flex;align-items:center;gap:6px;padding:8px 18px;background:var(--color-primary,#2563eb);color:#fff;border:none;border-radius:6px;cursor:pointer;font-size:.9rem;font-weight:600;}
+        .btn-form-inline:hover{opacity:.9;}
+        .btn-ghost-sm{display:inline-flex;align-items:center;gap:6px;padding:7px 14px;background:transparent;color:var(--color-primary,#2563eb);border:1px solid var(--color-primary,#2563eb);border-radius:6px;cursor:pointer;font-size:.85rem;text-decoration:none;}
+        .btn-ghost-sm:hover{background:var(--color-primary-light,#eff6ff);}
+        .form-inline-card{background:var(--color-surface,#fff);border:1px solid var(--color-border,#e5e7eb);border-radius:var(--radius,8px);padding:1.25rem;margin-bottom:1.25rem;}
+        .form-inline-card h3{margin:0 0 .75rem;font-size:1rem;font-weight:700;}
+        .form-inline-row{display:flex;flex-wrap:wrap;gap:.75rem;align-items:flex-end;}
+        .form-inline-row .form-field{display:flex;flex-direction:column;gap:.25rem;flex:1;min-width:140px;}
+        .form-inline-row label{font-size:.75rem;font-weight:600;color:var(--color-text-muted,#6b7280);}
+        .form-inline-row .field-input{width:100%;}
+    </style>
 </head>
 <body class="layout">
 
@@ -99,83 +174,68 @@ $balance  = $entradas - $salidas;
         <div class="nav-section">
             <span class="nav-section-label">Principal</span>
             <a href="index.php" class="nav-item <?= in_array(basename($_SERVER['PHP_SELF']), ['index.php','dashboard.php']) ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
                 <span class="nav-label">Dashboard</span>
             </a>
             <a href="productos.php" class="nav-item <?= in_array(basename($_SERVER['PHP_SELF']), ['productos.php','nuevo_producto.php','editar_producto.php','eliminar_producto.php']) ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg></span>
                 <span class="nav-label">Productos</span>
             </a>
             <a href="categorias.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'categorias.php' ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></span>
                 <span class="nav-label">Categorías</span>
             </a>
             <a href="marcas.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'marcas.php' ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
-            <a href="modelos_moto.php"
-               class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
-                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
+            <?php if (isAdmin()): ?>
+            <a href="modelos_moto.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
                 <span class="nav-label">Modelos de Moto</span>
             </a>
-            <a href="proveedores.php"
-               class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'proveedores.php' ? 'active' : '' ?>">
-                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
+            <a href="proveedores.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'proveedores.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
                 <span class="nav-label">Proveedores</span>
             </a>
-            <a href="pedidos.php"
-               class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'pedidos.php' ? 'active' : '' ?>">
-                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
+            <a href="pedidos.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'pedidos.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
                 <span class="nav-label">Pedidos</span>
             </a>
-
             <?php endif; ?>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Operaciones</span>
             <a href="movimientos.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'movimientos.php' ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
                 <span class="nav-label">Movimientos</span>
             </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>
             <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
-                <span class="nav-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/>
-                    </svg>
-                </span>
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
 
@@ -192,10 +252,8 @@ $balance  = $entradas - $salidas;
 
 <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
-<!-- ===== MAIN WRAPPER ===== -->
+<!-- ===== MAIN ===== -->
 <div class="main-wrapper">
-
-    <!-- TOPBAR -->
     <header class="topbar">
         <div class="topbar-left">
             <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
@@ -206,9 +264,13 @@ $balance  = $entradas - $salidas;
             <nav class="breadcrumb-nav">
                 <a href="index.php" class="breadcrumb-item">Inicio</a>
                 <span class="breadcrumb-sep">›</span>
-                <a href="productos.php" class="breadcrumb-item">Productos</a>
+                <?php if (!$modoGlobal && $producto): ?>
+                <a href="movimientos.php" class="breadcrumb-item">Movimientos</a>
                 <span class="breadcrumb-sep">›</span>
+                <span class="breadcrumb-item active"><?= htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') ?></span>
+                <?php else: ?>
                 <span class="breadcrumb-item active">Movimientos</span>
+                <?php endif; ?>
             </nav>
         </div>
         <div class="topbar-right">
@@ -224,16 +286,11 @@ $balance  = $entradas - $salidas;
         </div>
     </header>
 
-    <!-- CONTENT -->
     <main class="content">
 
         <?php if ($flashSuccess): ?>
         <div class="toast toast-success" data-autodismiss="4000">
-            <span class="toast-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-                    <polyline points="20 6 9 17 4 12"/>
-                </svg>
-            </span>
+            <span class="toast-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
             <div class="toast-content">
                 <span class="toast-title">Éxito</span>
                 <span class="toast-message"><?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?></span>
@@ -245,11 +302,7 @@ $balance  = $entradas - $salidas;
 
         <?php if ($flashError || $error): ?>
         <div class="toast toast-error" data-autodismiss="6000">
-            <span class="toast-icon">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-                    <circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/>
-                </svg>
-            </span>
+            <span class="toast-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></span>
             <div class="toast-content">
                 <span class="toast-title">Error</span>
                 <span class="toast-message"><?= htmlspecialchars($flashError ?: $error, ENT_QUOTES, 'UTF-8') ?></span>
@@ -259,100 +312,287 @@ $balance  = $entradas - $salidas;
         </div>
         <?php endif; ?>
 
-        <?php if ($producto): ?>
+        <?php if ($modoGlobal): ?>
+        <!-- ================================================================ -->
+        <!-- MODO GLOBAL                                                       -->
+        <!-- ================================================================ -->
 
-        <!-- Page header -->
+        <div class="page-header">
+            <div class="page-header-info">
+                <h1 class="page-title">Movimientos de Stock</h1>
+                <p class="page-subtitle">Historial completo de entradas y salidas · <?= $totalMovs ?> registro(s) con filtros aplicados</p>
+            </div>
+            <div class="page-actions">
+                <button type="button" class="btn-primary" onclick="toggleFormRegistro()">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                    Nuevo movimiento
+                </button>
+            </div>
+        </div>
+
+        <!-- Stats globales -->
+        <div class="stat-cards stat-cards-3">
+            <div class="stat-card">
+                <div class="stat-card-icon stat-icon-blue">
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
+                </div>
+                <div class="stat-card-body">
+                    <span class="stat-value"><?= number_format($statsGlobal['total']) ?></span>
+                    <span class="stat-label">Total movimientos</span>
+                </div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-card-icon stat-icon-green">
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+                </div>
+                <div class="stat-card-body">
+                    <span class="stat-value" style="color:#15803d"><?= number_format($statsGlobal['entradas']) ?></span>
+                    <span class="stat-label">Entradas</span>
+                </div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-card-icon stat-icon-red">
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>
+                </div>
+                <div class="stat-card-body">
+                    <span class="stat-value" style="color:#b91c1c"><?= number_format($statsGlobal['salidas']) ?></span>
+                    <span class="stat-label">Salidas</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- Formulario nuevo movimiento (colapsable) -->
+        <div id="formRegistro" class="form-inline-card" style="display:none;">
+            <h3>Registrar nuevo movimiento</h3>
+            <form method="POST">
+                <div class="form-inline-row">
+                    <div class="form-field">
+                        <label for="reg_producto">Producto <span style="color:#ef4444">*</span></label>
+                        <select class="field-input field-select" id="reg_producto" name="producto_id" required>
+                            <option value="">— Selecciona producto —</option>
+                            <?php foreach ($todosProductos as $p): ?>
+                            <option value="<?= (int)$p['id'] ?>">
+                                <?= htmlspecialchars($p['nombre'], ENT_QUOTES, 'UTF-8') ?>
+                                (stock: <?= (int)$p['stock'] ?>)
+                            </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="form-field" style="max-width:160px">
+                        <label for="reg_tipo">Tipo <span style="color:#ef4444">*</span></label>
+                        <select class="field-input field-select" id="reg_tipo" name="tipo" required>
+                            <option value="entrada">Entrada ↑</option>
+                            <option value="salida">Salida ↓</option>
+                        </select>
+                    </div>
+                    <div class="form-field" style="max-width:120px">
+                        <label for="reg_cantidad">Cantidad <span style="color:#ef4444">*</span></label>
+                        <input class="field-input" type="number" id="reg_cantidad" name="cantidad" min="1" value="1" required>
+                    </div>
+                    <div class="form-field" style="flex:2">
+                        <label for="reg_obs">Observaciones</label>
+                        <input class="field-input" type="text" id="reg_obs" name="observaciones" placeholder="Motivo, proveedor, OT...">
+                    </div>
+                    <div class="form-field" style="max-width:fit-content">
+                        <label style="visibility:hidden">Acción</label>
+                        <button type="submit" class="btn-form-inline">
+                            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+                            Guardar
+                        </button>
+                    </div>
+                </div>
+            </form>
+        </div>
+
+        <!-- Filtros -->
+        <form method="GET" id="filtrosForm">
+            <div class="filter-bar">
+                <div class="filter-group">
+                    <label>Producto</label>
+                    <select class="field-input field-select" name="filtro_producto" style="min-width:200px">
+                        <option value="">Todos los productos</option>
+                        <?php foreach ($todosProductos as $p): ?>
+                        <option value="<?= (int)$p['id'] ?>" <?= (int)($filtroProdId ?? 0) === (int)$p['id'] ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($p['nombre'], ENT_QUOTES, 'UTF-8') ?>
+                        </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="filter-group">
+                    <label>Tipo</label>
+                    <select class="field-input field-select" name="tipo">
+                        <option value="">Todos</option>
+                        <option value="entrada" <?= $filtroTipo === 'entrada' ? 'selected' : '' ?>>Entrada ↑</option>
+                        <option value="salida"  <?= $filtroTipo === 'salida'  ? 'selected' : '' ?>>Salida ↓</option>
+                    </select>
+                </div>
+                <div class="filter-group">
+                    <label>Desde</label>
+                    <input class="field-input" type="date" name="desde" value="<?= htmlspecialchars($filtroDesde, ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+                <div class="filter-group">
+                    <label>Hasta</label>
+                    <input class="field-input" type="date" name="hasta" value="<?= htmlspecialchars($filtroHasta, ENT_QUOTES, 'UTF-8') ?>">
+                </div>
+                <div class="filter-actions">
+                    <button type="submit" class="btn-form-inline">Filtrar</button>
+                    <a href="movimientos.php" class="btn-ghost-sm">Limpiar</a>
+                    <button type="button" onclick="exportarCSV()" class="btn-ghost-sm">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                        CSV
+                    </button>
+                </div>
+            </div>
+        </form>
+
+        <!-- Tabla global -->
+        <div class="data-table-wrapper">
+            <?php if (empty($movimientos)): ?>
+            <div class="td-empty" style="padding:2.5rem;text-align:center;">
+                No hay movimientos con los filtros aplicados.
+                <a href="movimientos.php" style="display:block;margin-top:.5rem;color:var(--color-primary)">Limpiar filtros</a>
+            </div>
+            <?php else: ?>
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Fecha</th>
+                        <th>Producto</th>
+                        <th>Categoría</th>
+                        <th>Tipo</th>
+                        <th>Cantidad</th>
+                        <th>Observaciones</th>
+                        <th>Usuario</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($movimientos as $mov): ?>
+                    <tr>
+                        <td><span class="ref-code"><?= (int)$mov['id'] ?></span></td>
+                        <td style="white-space:nowrap"><?= htmlspecialchars(date('d/m/Y H:i', strtotime($mov['fecha'])), ENT_QUOTES, 'UTF-8') ?></td>
+                        <td>
+                            <a href="ver_producto.php?id=<?= (int)$mov['producto_id'] ?>" style="font-weight:600;color:inherit">
+                                <?= htmlspecialchars($mov['producto_nombre'], ENT_QUOTES, 'UTF-8') ?>
+                            </a>
+                            <?php if (!empty($mov['codigo_ref'])): ?>
+                            <br><small class="ref-code" style="font-size:.72rem"><?= htmlspecialchars($mov['codigo_ref'], ENT_QUOTES, 'UTF-8') ?></small>
+                            <?php endif; ?>
+                        </td>
+                        <td><?= htmlspecialchars($mov['categoria_nombre'] ?? '–', ENT_QUOTES, 'UTF-8') ?></td>
+                        <td>
+                            <?php if ($mov['tipo'] === 'entrada'): ?>
+                            <span class="badge-entrada">
+                                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
+                                Entrada
+                            </span>
+                            <?php else: ?>
+                            <span class="badge-salida">
+                                <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>
+                                Salida
+                            </span>
+                            <?php endif; ?>
+                        </td>
+                        <td><strong><?= (int)$mov['cantidad'] ?> uds.</strong></td>
+                        <td style="max-width:220px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap" title="<?= htmlspecialchars($mov['observaciones'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                            <?= htmlspecialchars($mov['observaciones'] ?? '–', ENT_QUOTES, 'UTF-8') ?>
+                        </td>
+                        <td><?= htmlspecialchars($mov['usuario'] ?? 'admin', ENT_QUOTES, 'UTF-8') ?></td>
+                        <td>
+                            <a href="movimientos.php?producto_id=<?= (int)$mov['producto_id'] ?>" class="btn-ghost-sm" style="padding:4px 8px;font-size:.75rem">Ver producto</a>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+            <?php endif; ?>
+        </div>
+
+        <?php else: ?>
+        <!-- ================================================================ -->
+        <!-- MODO PER-PRODUCTO                                                 -->
+        <!-- ================================================================ -->
+
         <div class="page-header">
             <div class="page-header-info">
                 <h1 class="page-title">Movimientos de Stock</h1>
                 <p class="page-subtitle">
-                    Producto: <strong><?= htmlspecialchars($producto['nombre'], ENT_QUOTES, 'UTF-8') ?></strong>
-                    &nbsp;·&nbsp; Stock actual: <strong><?= (int)$producto['stock'] ?> uds.</strong>
+                    Producto: <strong><?= htmlspecialchars($producto['nombre'] ?? '', ENT_QUOTES, 'UTF-8') ?></strong>
+                    &nbsp;·&nbsp; Stock actual: <strong><?= (int)($producto['stock'] ?? 0) ?> uds.</strong>
                 </p>
             </div>
             <div class="page-actions">
+                <a href="movimientos.php" class="btn-ghost">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+                    Todos los movimientos
+                </a>
                 <a href="productos.php" class="btn-ghost">
-                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/>
-                    </svg>
-                    Volver
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/></svg>
+                    Productos
                 </a>
             </div>
         </div>
 
-        <!-- Stat cards -->
+        <!-- Stats per-producto -->
         <div class="stat-cards stat-cards-3">
             <div class="stat-card">
                 <div class="stat-card-icon stat-icon-green">
-                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/>
-                    </svg>
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>
                 </div>
                 <div class="stat-card-body">
-                    <span class="stat-value stat-value-green"><?= $entradas ?></span>
+                    <span class="stat-value" style="color:#15803d"><?= $entradas ?></span>
                     <span class="stat-label">Entradas totales</span>
                 </div>
             </div>
             <div class="stat-card">
                 <div class="stat-card-icon stat-icon-red">
-                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/>
-                    </svg>
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>
                 </div>
                 <div class="stat-card-body">
-                    <span class="stat-value stat-value-red"><?= $salidas ?></span>
+                    <span class="stat-value" style="color:#b91c1c"><?= $salidas ?></span>
                     <span class="stat-label">Salidas totales</span>
                 </div>
             </div>
             <div class="stat-card">
                 <div class="stat-card-icon stat-icon-blue">
-                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/>
-                    </svg>
+                    <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg>
                 </div>
                 <div class="stat-card-body">
-                    <span class="stat-value stat-value-blue"><?= $balance ?></span>
+                    <span class="stat-value"><?= $balance ?></span>
                     <span class="stat-label">Balance neto</span>
                 </div>
             </div>
         </div>
 
-        <!-- New movement form -->
+        <!-- Formulario registro per-producto -->
         <div class="card card-form" style="max-width:520px;">
             <div class="card-header">
                 <h2 class="card-title">Registrar Movimiento</h2>
-                <p class="card-subtitle">Entrada o salida de stock para este producto</p>
+                <p class="card-subtitle">Entrada o salida para este producto</p>
             </div>
             <div class="card-body">
                 <form method="POST">
-                    <input type="hidden" name="producto_id" value="<?= (int)$producto['id'] ?>">
-
+                    <input type="hidden" name="producto_id" value="<?= (int)($producto['id'] ?? 0) ?>">
                     <div class="form-field" style="margin-bottom:1rem;">
                         <label class="field-label" for="tipo">Tipo <span class="field-required">*</span></label>
                         <select class="field-input field-select" id="tipo" name="tipo" required>
-                            <option value="entrada">Entrada (suma stock)</option>
-                            <option value="salida">Salida (resta stock)</option>
+                            <option value="entrada">Entrada ↑ (suma stock)</option>
+                            <option value="salida">Salida ↓ (resta stock)</option>
                         </select>
                     </div>
-
                     <div class="form-field" style="margin-bottom:1rem;">
                         <label class="field-label" for="cantidad">Cantidad <span class="field-required">*</span></label>
                         <input class="field-input" type="number" id="cantidad" name="cantidad" min="1" required value="1">
-                        <span class="field-hint">Número de unidades del movimiento</span>
                     </div>
-
                     <div class="form-field" style="margin-bottom:1.5rem;">
                         <label class="field-label" for="observaciones">Observaciones</label>
-                        <textarea class="field-input field-textarea" id="observaciones" name="observaciones" rows="2"
-                                  placeholder="Motivo del movimiento, proveedor, etc."></textarea>
+                        <textarea class="field-input field-textarea" id="observaciones" name="observaciones" rows="2" placeholder="Motivo, proveedor, OT..."></textarea>
                     </div>
-
                     <div class="card-footer" style="padding:0;border:0;margin-top:0;">
                         <a href="productos.php" class="btn-ghost">Cancelar</a>
                         <button type="submit" class="btn-primary">
-                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
-                                <polyline points="20 6 9 17 4 12"/>
-                            </svg>
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
                             Registrar
                         </button>
                     </div>
@@ -360,33 +600,24 @@ $balance  = $entradas - $salidas;
             </div>
         </div>
 
-        <!-- Movement history -->
+        <!-- Historial per-producto -->
         <div class="page-header" style="margin-top:2rem;">
             <div class="page-header-info">
-                <h2 class="page-title" style="font-size:1.1rem;">Historial de Movimientos</h2>
-                <p class="page-subtitle"><?= $totalMovs ?> movimiento(s) registrado(s)</p>
+                <h2 class="page-title" style="font-size:1.1rem;">Historial</h2>
+                <p class="page-subtitle"><?= $totalMovs ?> movimiento(s)</p>
             </div>
-        </div>
-
-        <!-- Exportar CSV de movimientos -->
-        <div class="export-bar" style="display:flex;align-items:center;gap:12px;margin-bottom:16px;flex-wrap:wrap">
-            <label class="field-label" style="margin:0">Exportar CSV:</label>
-            <input type="date" id="export-desde" class="field-input" style="width:160px"
-                   value="<?= htmlspecialchars(date('Y-m-d', strtotime('-30 days')), ENT_QUOTES, 'UTF-8') ?>"
-                   max="<?= date('Y-m-d') ?>">
-            <span>hasta</span>
-            <input type="date" id="export-hasta" class="field-input" style="width:160px"
-                   value="<?= htmlspecialchars(date('Y-m-d'), ENT_QUOTES, 'UTF-8') ?>"
-                   max="<?= date('Y-m-d') ?>">
-            <button type="button" onclick="exportarMovimientosCSV()" class="btn btn-secondary">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
-                     fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:middle;margin-right:4px">
-                    <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
-                    <polyline points="7 10 12 15 17 10"/>
-                    <line x1="12" y1="15" x2="12" y2="3"/>
-                </svg>
-                Exportar CSV
-            </button>
+            <div class="page-actions">
+                <!-- Export CSV -->
+                <div style="display:flex;align-items:center;gap:.5rem;">
+                    <input type="date" id="export-desde" class="field-input" style="width:145px" value="<?= date('Y-m-d', strtotime('-30 days')) ?>">
+                    <span style="font-size:.85rem">–</span>
+                    <input type="date" id="export-hasta" class="field-input" style="width:145px" value="<?= date('Y-m-d') ?>">
+                    <button type="button" onclick="exportarMovimientosCSV()" class="btn-ghost-sm">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg>
+                        CSV
+                    </button>
+                </div>
+            </div>
         </div>
 
         <div class="data-table-wrapper">
@@ -398,27 +629,24 @@ $balance  = $entradas - $salidas;
             <table class="data-table">
                 <thead>
                     <tr>
-                        <th>#</th>
-                        <th>Fecha</th>
-                        <th>Tipo</th>
-                        <th>Cantidad</th>
-                        <th>Observaciones</th>
+                        <th>#</th><th>Fecha</th><th>Tipo</th><th>Cantidad</th><th>Observaciones</th><th>Usuario</th>
                     </tr>
                 </thead>
                 <tbody>
                 <?php foreach ($movimientos as $mov): ?>
                     <tr>
                         <td><span class="ref-code"><?= (int)$mov['id'] ?></span></td>
-                        <td><?= htmlspecialchars($mov['fecha'], ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><?= htmlspecialchars(date('d/m/Y H:i', strtotime($mov['fecha'])), ENT_QUOTES, 'UTF-8') ?></td>
                         <td>
                             <?php if ($mov['tipo'] === 'entrada'): ?>
-                                <span class="status-pill status-pill-success">Entrada</span>
+                            <span class="badge-entrada"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="12" y1="19" x2="12" y2="5"/><polyline points="5 12 12 5 19 12"/></svg>Entrada</span>
                             <?php else: ?>
-                                <span class="status-pill status-pill-danger">Salida</span>
+                            <span class="badge-salida"><svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><line x1="12" y1="5" x2="12" y2="19"/><polyline points="19 12 12 19 5 12"/></svg>Salida</span>
                             <?php endif; ?>
                         </td>
-                        <td><strong><?= (int)$mov['cantidad'] ?></strong></td>
+                        <td><strong><?= (int)$mov['cantidad'] ?> uds.</strong></td>
                         <td><?= htmlspecialchars($mov['observaciones'] ?? '–', ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><?= htmlspecialchars($mov['usuario'] ?? 'admin', ENT_QUOTES, 'UTF-8') ?></td>
                     </tr>
                 <?php endforeach; ?>
                 </tbody>
@@ -426,44 +654,32 @@ $balance  = $entradas - $salidas;
             <?php endif; ?>
         </div>
 
-        <?php if ($totalPaginas > 1 || $totalMovs > 0): ?>
+        <?php endif; ?>
+
+        <!-- ================================================================ -->
+        <!-- PAGINACIÓN (compartida)                                           -->
+        <!-- ================================================================ -->
+        <?php if ($totalPaginas > 1): ?>
         <div class="pagination-bar">
             <span class="pagination-info">
                 <?php
-                $desde = ($paginaActual - 1) * POR_PAGINA_MOVIMIENTOS + 1;
-                $hasta = min($paginaActual * POR_PAGINA_MOVIMIENTOS, $totalMovs);
+                $offset_info = ($paginaActual - 1) * POR_PAGINA_MOVIMIENTOS + 1;
+                $limit_info  = min($paginaActual * POR_PAGINA_MOVIMIENTOS, $totalMovs);
                 echo $totalMovs > 0
-                    ? "Mostrando {$desde}–{$hasta} de {$totalMovs} movimientos"
+                    ? "Mostrando {$offset_info}–{$limit_info} de {$totalMovs} movimientos"
                     : "0 movimientos";
                 ?>
             </span>
-            <?php if ($totalPaginas > 1): ?>
-            <nav class="pagination" aria-label="Paginación de movimientos">
-                <?php
-                $buildUrl = fn(int $p) => "movimientos.php?producto_id={$productoId}&page={$p}";
-                ?>
-                <a href="<?= $buildUrl(1) ?>"
-                   class="page-btn <?= $paginaActual === 1 ? 'page-btn-disabled' : '' ?>">«</a>
-                <a href="<?= $buildUrl(max(1, $paginaActual - 1)) ?>"
-                   class="page-btn <?= $paginaActual === 1 ? 'page-btn-disabled' : '' ?>">‹</a>
-                <?php
-                $start = max(1, $paginaActual - 2);
-                $end   = min($totalPaginas, $paginaActual + 2);
-                for ($i = $start; $i <= $end; $i++): ?>
-                    <a href="<?= $buildUrl($i) ?>"
-                       class="page-btn <?= $i === $paginaActual ? 'page-btn-active' : '' ?>">
-                        <?= $i ?>
-                    </a>
+            <nav class="pagination" aria-label="Paginación">
+                <a href="<?= buildPaginationUrl(1) ?>" class="page-btn <?= $paginaActual === 1 ? 'page-btn-disabled' : '' ?>">«</a>
+                <a href="<?= buildPaginationUrl(max(1, $paginaActual - 1)) ?>" class="page-btn <?= $paginaActual === 1 ? 'page-btn-disabled' : '' ?>">‹</a>
+                <?php for ($i = max(1, $paginaActual - 2); $i <= min($totalPaginas, $paginaActual + 2); $i++): ?>
+                <a href="<?= buildPaginationUrl($i) ?>" class="page-btn <?= $i === $paginaActual ? 'page-btn-active' : '' ?>"><?= $i ?></a>
                 <?php endfor; ?>
-                <a href="<?= $buildUrl(min($totalPaginas, $paginaActual + 1)) ?>"
-                   class="page-btn <?= $paginaActual === $totalPaginas ? 'page-btn-disabled' : '' ?>">›</a>
-                <a href="<?= $buildUrl($totalPaginas) ?>"
-                   class="page-btn <?= $paginaActual === $totalPaginas ? 'page-btn-disabled' : '' ?>">»</a>
+                <a href="<?= buildPaginationUrl(min($totalPaginas, $paginaActual + 1)) ?>" class="page-btn <?= $paginaActual === $totalPaginas ? 'page-btn-disabled' : '' ?>">›</a>
+                <a href="<?= buildPaginationUrl($totalPaginas) ?>" class="page-btn <?= $paginaActual === $totalPaginas ? 'page-btn-disabled' : '' ?>">»</a>
             </nav>
-            <?php endif; ?>
         </div>
-        <?php endif; ?>
-
         <?php endif; ?>
 
     </main>
@@ -472,21 +688,42 @@ $balance  = $entradas - $salidas;
 <script src="js/app.js"></script>
 <script>
 /**
- * Descarga el CSV de movimientos respetando los filtros activos.
- * Pasa producto_id y tipo si están en la URL actual.
+ * Alterna visibilidad del formulario de nuevo movimiento.
+ */
+function toggleFormRegistro() {
+    const el = document.getElementById('formRegistro');
+    if (!el) return;
+    el.style.display = el.style.display === 'none' ? 'block' : 'none';
+    if (el.style.display === 'block') {
+        el.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        el.querySelector('select,input')?.focus();
+    }
+}
+
+/**
+ * Exporta CSV respetando filtros activos del formulario de filtros.
+ */
+function exportarCSV() {
+    const params = new URLSearchParams({ export: 'csv' });
+    const form = document.getElementById('filtrosForm');
+    if (form) {
+        new FormData(form).forEach((v, k) => { if (v) params.set(k, v); });
+    }
+    window.location.href = 'api/movimientos.php?' + params.toString();
+}
+
+/**
+ * Exporta CSV en modo per-producto con rango de fechas manual.
  */
 function exportarMovimientosCSV() {
-    const desde = document.getElementById('export-desde').value;
-    const hasta = document.getElementById('export-hasta').value;
+    const desde = document.getElementById('export-desde')?.value;
+    const hasta  = document.getElementById('export-hasta')?.value;
     const params = new URLSearchParams({ export: 'csv' });
     if (desde) params.set('desde', desde);
-    if (hasta) params.set('hasta', hasta);
-    // Respetar filtros activos de la vista actual
+    if (hasta)  params.set('hasta',  hasta);
     const url = new URL(window.location.href);
-    const productoId = url.searchParams.get('producto_id');
-    const tipo = url.searchParams.get('tipo');
-    if (productoId) params.set('producto_id', productoId);
-    if (tipo) params.set('tipo', tipo);
+    const pid = url.searchParams.get('producto_id');
+    if (pid) params.set('producto_id', pid);
     window.location.href = 'api/movimientos.php?' + params.toString();
 }
 </script>

--- a/src/nuevo_pedido.php
+++ b/src/nuevo_pedido.php
@@ -14,7 +14,7 @@ require_once __DIR__ . '/includes/Proveedor.php';
 require_once __DIR__ . '/includes/Pedido.php';
 
 // Solo admin puede crear pedidos
-if (($_SESSION['rol'] ?? '') !== 'admin') {
+if (!isAdmin()) {
     header('Location: index.php');
     exit;
 }

--- a/src/nuevo_producto.php
+++ b/src/nuevo_producto.php
@@ -138,7 +138,7 @@ try {
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -178,12 +178,25 @@ try {
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
 

--- a/src/pedidos.php
+++ b/src/pedidos.php
@@ -31,7 +31,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (!$pedidoId || !$nuevoEstado) {
                 throw new AppException('Datos inválidos.', 400);
             }
-            if (($_SESSION['rol'] ?? '') !== 'admin') {
+            if (!isAdmin()) {
                 throw new AppException('No tienes permisos para esta acción.', 403);
             }
             $pedidoModel->cambiarEstado($pedidoId, $nuevoEstado);
@@ -64,13 +64,21 @@ if (isset($_GET['pdf'])) {
 // ── Cargar listado ─────────────────────────────────────────────────────────────
 $filtroEstado = $_GET['estado'] ?? '';
 $pedidos      = [];
+$contadores   = ['todos' => 0, 'borrador' => 0, 'enviado' => 0, 'recibido' => 0, 'cancelado' => 0];
 try {
     $pedidos = $pedidoModel->listar($filtroEstado ?: null);
+    // Contadores por estado para las tabs
+    $pdo  = Database::getInstance();
+    $rows = $pdo->query("SELECT estado, COUNT(*) AS n FROM pedidos GROUP BY estado")->fetchAll();
+    foreach ($rows as $r) {
+        $contadores[$r['estado']] = (int)$r['n'];
+        $contadores['todos'] += (int)$r['n'];
+    }
 } catch (\Throwable $e) {
     $flashError = 'Error al cargar pedidos: ' . $e->getMessage();
 }
 
-$esAdmin = ($_SESSION['rol'] ?? '') === 'admin';
+$esAdmin = isAdmin();
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -160,6 +168,19 @@ $esAdmin = ($_SESSION['rol'] ?? '') === 'admin';
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
 
@@ -252,17 +273,33 @@ $esAdmin = ($_SESSION['rol'] ?? '') === 'admin';
         </div>
 
         <!-- Filtros por estado -->
-        <div class="card" style="margin-bottom:1rem;">
-            <div class="card-body" style="padding:.75rem 1rem;">
-                <div class="filter-links">
-                    <strong>Filtrar:</strong>
-                    <a href="pedidos.php" class="<?= $filtroEstado === '' ? 'active' : '' ?>">Todos</a>
-                    <a href="pedidos.php?estado=borrador"  class="<?= $filtroEstado === 'borrador'  ? 'active' : '' ?>">Borrador</a>
-                    <a href="pedidos.php?estado=enviado"   class="<?= $filtroEstado === 'enviado'   ? 'active' : '' ?>">Enviado</a>
-                    <a href="pedidos.php?estado=recibido"  class="<?= $filtroEstado === 'recibido'  ? 'active' : '' ?>">Recibido</a>
-                    <a href="pedidos.php?estado=cancelado" class="<?= $filtroEstado === 'cancelado' ? 'active' : '' ?>">Cancelado</a>
-                </div>
-            </div>
+        <div class="pedido-tabs" role="tablist" aria-label="Filtrar por estado">
+            <?php
+            $tabs = [
+                ''          => ['label' => 'Todos',     'color' => '#64748b', 'bg' => '#f1f5f9'],
+                'borrador'  => ['label' => 'Borrador',  'color' => '#475569', 'bg' => '#e2e8f0'],
+                'enviado'   => ['label' => 'Enviado',   'color' => '#1d4ed8', 'bg' => '#dbeafe'],
+                'recibido'  => ['label' => 'Recibido',  'color' => '#15803d', 'bg' => '#dcfce7'],
+                'cancelado' => ['label' => 'Cancelado', 'color' => '#b91c1c', 'bg' => '#fee2e2'],
+            ];
+            foreach ($tabs as $estado => $cfg):
+                $activo  = $filtroEstado === $estado;
+                $href    = $estado ? "pedidos.php?estado={$estado}" : "pedidos.php";
+                $count   = $estado === '' ? $contadores['todos'] : ($contadores[$estado] ?? 0);
+                $style   = $activo
+                    ? "background:{$cfg['bg']};color:{$cfg['color']};border-color:{$cfg['color']};"
+                    : "background:#fff;color:#64748b;border-color:#e2e8f0;";
+            ?>
+            <a href="<?= $href ?>"
+               role="tab"
+               aria-selected="<?= $activo ? 'true' : 'false' ?>"
+               style="<?= $style ?>display:inline-flex;align-items:center;gap:8px;padding:9px 18px;border:1.5px solid;border-radius:8px;text-decoration:none;font-size:.875rem;font-weight:<?= $activo ? '700' : '500' ?>;white-space:nowrap;transition:all .15s;">
+                <?= htmlspecialchars($cfg['label'], ENT_QUOTES, 'UTF-8') ?>
+                <span style="display:inline-flex;align-items:center;justify-content:center;min-width:22px;height:20px;padding:0 6px;border-radius:999px;font-size:.75rem;font-weight:700;background:<?= $activo ? $cfg['color'] : '#e2e8f0' ?>;color:<?= $activo ? '#fff' : '#475569' ?>;">
+                    <?= $count ?>
+                </span>
+            </a>
+            <?php endforeach; ?>
         </div>
 
         <!-- Tabla de pedidos -->
@@ -304,7 +341,7 @@ $esAdmin = ($_SESSION['rol'] ?? '') === 'admin';
                                     default     => 'badge-borrador',
                                 };
                                 ?>
-                                <span class="badge-estado <?= $estadoClass ?>"><?= htmlspecialchars($ped['estado'], ENT_QUOTES, 'UTF-8') ?></span>
+                                <span class="badge-estado <?= $estadoClass ?>"><?= htmlspecialchars(ucfirst($ped['estado']), ENT_QUOTES, 'UTF-8') ?></span>
                             </td>
                             <td><?= (int)$ped['total_lineas'] ?></td>
                             <td><?= htmlspecialchars(substr($ped['created_at'] ?? '', 0, 10), ENT_QUOTES, 'UTF-8') ?></td>

--- a/src/perfil.php
+++ b/src/perfil.php
@@ -192,7 +192,7 @@ $rolLabel     = $rolSesion === 'admin' ? 'Administrador' : 'Operario';
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -232,7 +232,7 @@ $rolLabel     = $rolSesion === 'admin' ? 'Administrador' : 'Operario';
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>

--- a/src/perfil_empresa.php
+++ b/src/perfil_empresa.php
@@ -81,29 +81,99 @@ try {
     <nav class="sidebar-nav">
         <div class="nav-section">
             <span class="nav-section-label">Principal</span>
-            <a href="index.php" class="nav-item"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span><span class="nav-label">Dashboard</span></a>
-            <a href="productos.php" class="nav-item"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg></span><span class="nav-label">Productos</span></a>
-            <a href="categorias.php" class="nav-item"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></span><span class="nav-label">Categorías</span></a>
-            <a href="movimientos.php" class="nav-item"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span><span class="nav-label">Movimientos</span></a>
+            <a href="index.php" class="nav-item <?= in_array(basename($_SERVER['PHP_SELF']), ['index.php','dashboard.php']) ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
+                <span class="nav-label">Dashboard</span>
+            </a>
+            <a href="productos.php" class="nav-item <?= in_array(basename($_SERVER['PHP_SELF']), ['productos.php','nuevo_producto.php','editar_producto.php']) ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg></span>
+                <span class="nav-label">Productos</span>
+            </a>
+            <a href="categorias.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'categorias.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></span>
+                <span class="nav-label">Categorías</span>
+            </a>
+            <a href="marcas.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'marcas.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
+                <span class="nav-label">Marcas</span>
+            </a>
+            <a href="modelos_moto.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
+                <span class="nav-label">Modelos de Moto</span>
+            </a>
+            <a href="proveedores.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'proveedores.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
+                <span class="nav-label">Proveedores</span>
+            </a>
+            <a href="pedidos.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'pedidos.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
+                <span class="nav-label">Pedidos</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Operaciones</span>
+            <a href="movimientos.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'movimientos.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
+                <span class="nav-label">Movimientos</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>
-            <a href="perfil_empresa.php" class="nav-item active"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span><span class="nav-label">Perfil de empresa</span></a>
-            <?php if ($stockBajoCount > 0): ?>
-            <a href="index.php" class="nav-item">
-                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg></span>
-                <span class="nav-label">Stock bajo <span class="badge" style="background:var(--danger);color:#fff;border-radius:9999px;padding:1px 6px;font-size:.7rem;"><?= $stockBajoCount ?></span></span>
+            <a href="auditoria.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'auditoria.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
+                <span class="nav-label">Auditoría</span>
             </a>
-            <?php endif; ?>
+            <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
+                <span class="nav-label">Usuarios</span>
+            </a>
+            <a href="perfil_empresa.php" class="nav-item active">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
         </div>
-        <div class="nav-section" style="margin-top:auto;">
-            <a href="logout.php" class="nav-item"><span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/><polyline points="16 17 21 12 16 7"/><line x1="21" y1="12" x2="9" y2="12"/></svg></span><span class="nav-label">Salir</span></a>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
+    <div class="sidebar-footer">
+        <div class="sidebar-user">
+            <div class="user-avatar-sm"><?= mb_strtoupper(mb_substr($_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'U', 0, 2)) ?></div>
+            <div class="sidebar-user-info">
+                <span class="user-name-sm"><?= htmlspecialchars($_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'Usuario', ENT_QUOTES, 'UTF-8') ?></span>
+                <span class="user-role"><?= match($_SESSION['user_role'] ?? $_SESSION['rol'] ?? 'employee') { 'superadmin' => 'Super Admin', 'admin' => 'Administrador', default => 'Empleado' } ?></span>
+            </div>
+        </div>
+    </div>
 </aside>
 
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ===== MAIN WRAPPER ===== -->
 <div class="main-wrapper">
-    <?php require_once __DIR__ . '/includes/topbar_user.php'; ?>
+
+    <!-- TOPBAR -->
+    <header class="topbar">
+        <div class="topbar-left">
+            <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+                </svg>
+            </button>
+            <nav class="breadcrumb-nav">
+                <a href="index.php" class="breadcrumb-item">Inicio</a>
+                <span class="breadcrumb-sep">›</span>
+                <span class="breadcrumb-item active">Perfil de empresa</span>
+            </nav>
+        </div>
+        <div class="topbar-right">
+            <?php require_once __DIR__ . '/includes/topbar_user.php'; ?>
+        </div>
+    </header>
 
     <main class="content">
         <div class="page-header">

--- a/src/productos.php
+++ b/src/productos.php
@@ -34,11 +34,12 @@ $validOrdenes = [
     'marca_asc','marca_desc','estado_asc','estado_desc',
 ];
 
-$paginaActual = max(1, (int) filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT));
-$terminoBusq  = trim(filter_input(INPUT_GET, 'q', FILTER_SANITIZE_SPECIAL_CHARS) ?? '');
-$catFiltro    = filter_input(INPUT_GET, 'categoria_id', FILTER_VALIDATE_INT) ?: null;
-$marcaFiltro  = filter_input(INPUT_GET, 'marca_id',     FILTER_VALIDATE_INT) ?: null;
-$ordenActivo  = in_array($_GET['orden'] ?? '', $validOrdenes, true) ? $_GET['orden'] : 'nombre_asc';
+$paginaActual  = max(1, (int) filter_input(INPUT_GET, 'page', FILTER_VALIDATE_INT));
+$terminoBusq   = trim(filter_input(INPUT_GET, 'q', FILTER_SANITIZE_SPECIAL_CHARS) ?? '');
+$catFiltro     = filter_input(INPUT_GET, 'categoria_id', FILTER_VALIDATE_INT) ?: null;
+$marcaFiltro   = filter_input(INPUT_GET, 'marca_id',     FILTER_VALIDATE_INT) ?: null;
+$ordenActivo   = in_array($_GET['orden'] ?? '', $validOrdenes, true) ? $_GET['orden'] : 'nombre_asc';
+$soloStockBajo = isset($_GET['stock_bajo']) && $_GET['stock_bajo'] === '1' ? true : null;
 $totalPaginas = 1;
 $totalItems   = 0;
 
@@ -47,11 +48,11 @@ try {
     $categoriaModel = new Categoria();
     $marcaModel     = new Marca();
 
-    $totalItems     = $productoModel->contarFiltrados($terminoBusq ?: null, $catFiltro, null, null, null, null, null, $marcaFiltro);
+    $totalItems     = $productoModel->contarFiltrados($terminoBusq ?: null, $catFiltro, null, null, null, null, $soloStockBajo, $marcaFiltro);
     $totalPaginas   = max(1, (int) ceil($totalItems / $porPagina));
     $paginaActual   = min($paginaActual, $totalPaginas);
 
-    $productos      = $productoModel->listarPaginado($paginaActual, $porPagina, $terminoBusq ?: null, $catFiltro, null, null, null, null, $ordenActivo, null, $marcaFiltro);
+    $productos      = $productoModel->listarPaginado($paginaActual, $porPagina, $terminoBusq ?: null, $catFiltro, null, null, null, null, $ordenActivo, $soloStockBajo, $marcaFiltro);
     $categorias     = $categoriaModel->listar();
     $marcas         = $marcaModel->listar();
     $stockBajoCount = count($productoModel->filtrarStockBajo());
@@ -64,6 +65,7 @@ $filterQs = http_build_query(array_filter([
     'q'            => $terminoBusq ?: null,
     'categoria_id' => $catFiltro,
     'marca_id'     => $marcaFiltro,
+    'stock_bajo'   => $soloStockBajo ? '1' : null,
     'por_pagina'   => $porPagina !== 15 ? $porPagina : null,
 ], fn($v) => $v !== null && $v !== ''));
 
@@ -171,7 +173,7 @@ $sortTh = function(string $campo, string $label) use ($filterQs, $ordenActivo): 
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -181,6 +183,11 @@ $sortTh = function(string $campo, string $label) use ($filterQs, $ordenActivo): 
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'proveedores.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
                 <span class="nav-label">Proveedores</span>
+            </a>
+            <a href="pedidos.php"
+               class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'pedidos.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
+                <span class="nav-label">Pedidos</span>
             </a>
             <?php endif; ?>
         </div>
@@ -205,12 +212,25 @@ $sortTh = function(string $campo, string $label) use ($filterQs, $ordenActivo): 
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
 
@@ -314,9 +334,24 @@ $sortTh = function(string $campo, string $label) use ($filterQs, $ordenActivo): 
             </div>
         </div>
 
+        <?php if ($soloStockBajo): ?>
+        <div style="display:flex;align-items:center;gap:.6rem;margin-bottom:.75rem;">
+            <span style="font-size:.8rem;color:var(--text-muted);">Filtro activo:</span>
+            <span style="display:inline-flex;align-items:center;gap:.4rem;padding:.25rem .65rem;background:#fff7ed;color:#c2410c;border:1px solid #fed7aa;border-radius:999px;font-size:.8rem;font-weight:600;">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                    <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+                    <line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12.01" y2="17"/>
+                </svg>
+                Stock bajo
+                <a href="productos.php" style="color:inherit;text-decoration:none;margin-left:.2rem;font-weight:700;" title="Quitar filtro">✕</a>
+            </span>
+        </div>
+        <?php endif; ?>
+
         <!-- Toolbar -->
         <form method="get" class="data-toolbar" id="toolbar-form">
             <input type="hidden" name="orden" value="<?= htmlspecialchars($ordenActivo, ENT_QUOTES, 'UTF-8') ?>">
+            <?php if ($soloStockBajo): ?><input type="hidden" name="stock_bajo" value="1"><?php endif; ?>
             <div class="search-box">
                 <svg class="search-icon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/>

--- a/src/proveedores.php
+++ b/src/proveedores.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Gestión CRUD de proveedores del inventario.
  *
@@ -12,7 +12,7 @@ require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/Proveedor.php';
 
-if (($_SESSION['rol'] ?? '') !== 'admin') {
+if (!isAdmin()) {
     header('Location: index.php');
     exit;
 }
@@ -159,7 +159,7 @@ if ($provSelId) {
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -197,12 +197,25 @@ if ($provSelId) {
                 </span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
 
@@ -429,7 +442,7 @@ if ($provSelId) {
                                             <input type="hidden" name="accion" value="desactivar">
                                             <input type="hidden" name="id" value="<?= (int)$prov['id'] ?>">
                                             <button type="submit" class="action-btn action-btn-red" title="Desactivar proveedor"
-                                                    onclick="return confirm('¿Desactivar el proveedor «<?= htmlspecialchars($prov['nombre'], ENT_JS, 'UTF-8') ?>»?')">
+                                                    onclick="return confirm('¿Desactivar el proveedor «<?= htmlspecialchars($prov['nombre'], ENT_QUOTES, 'UTF-8') ?>»?')">
                                                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                                                     <circle cx="12" cy="12" r="10"/><line x1="4.93" y1="4.93" x2="19.07" y2="19.07"/>
                                                 </svg>

--- a/src/soporte/crear-ticket.php
+++ b/src/soporte/crear-ticket.php
@@ -44,6 +44,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 <body class="layout">
 
+<!-- ===== SIDEBAR ===== -->
 <aside class="sidebar" id="sidebar">
     <div class="sidebar-header">
         <div class="sidebar-logo">
@@ -65,6 +66,58 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
                 <span class="nav-label">Dashboard</span>
             </a>
+            <a href="../productos.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg></span>
+                <span class="nav-label">Productos</span>
+            </a>
+            <a href="../categorias.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></span>
+                <span class="nav-label">Categorías</span>
+            </a>
+            <a href="../marcas.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
+                <span class="nav-label">Marcas</span>
+            </a>
+            <?php if (isAdmin()): ?>
+            <a href="../modelos_moto.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
+                <span class="nav-label">Modelos de Moto</span>
+            </a>
+            <a href="../proveedores.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
+                <span class="nav-label">Proveedores</span>
+            </a>
+            <a href="../pedidos.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
+                <span class="nav-label">Pedidos</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Operaciones</span>
+            <a href="../movimientos.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
+                <span class="nav-label">Movimientos</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="../auditoria.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+            <?php if (isAdmin()): ?>
+            <a href="../usuarios.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
+                <span class="nav-label">Usuarios</span>
+            </a>
+            <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="../perfil_empresa.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Ayuda</span>
@@ -74,10 +127,23 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             </a>
         </div>
     </nav>
+    <div class="sidebar-footer">
+        <div class="sidebar-user">
+            <div class="user-avatar-sm"><?= mb_strtoupper(mb_substr($_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'U', 0, 2)) ?></div>
+            <div class="sidebar-user-info">
+                <span class="user-name-sm"><?= htmlspecialchars($_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'Usuario', ENT_QUOTES, 'UTF-8') ?></span>
+                <span class="user-role"><?= match($_SESSION['user_role'] ?? $_SESSION['rol'] ?? 'employee') { 'superadmin' => 'Super Admin', 'admin' => 'Administrador', default => 'Empleado' } ?></span>
+            </div>
+        </div>
+    </div>
 </aside>
+
 <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
+<!-- ===== MAIN WRAPPER ===== -->
 <div class="main-wrapper">
+
+    <!-- TOPBAR -->
     <header class="topbar">
         <div class="topbar-left">
             <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
@@ -98,52 +164,72 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </div>
     </header>
 
-    <main class="content-wrapper">
+    <!-- CONTENT -->
+    <main class="content">
+
+        <!-- Page header -->
         <div class="page-header">
-            <h1 class="page-title">Nuevo Ticket de Soporte</h1>
-            <p class="page-subtitle">Describe tu problema y te responderemos lo antes posible.</p>
+            <div class="page-header-info">
+                <h1 class="page-title">Nuevo Ticket de Soporte</h1>
+                <p class="page-subtitle">Describe tu problema y te responderemos lo antes posible.</p>
+            </div>
+            <div class="page-actions">
+                <a href="mis-tickets.php" class="btn-ghost">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/>
+                    </svg>
+                    Volver
+                </a>
+            </div>
         </div>
 
         <?php if ($flashError): ?>
-            <div class="alert alert-error" style="margin-bottom:1rem;"><?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?></div>
+        <div class="alert-banner alert-banner-error" style="margin-bottom:1.25rem;">
+            <?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?>
+        </div>
         <?php endif; ?>
 
-        <div style="max-width:640px;">
-            <div style="background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:1.75rem;">
-                <form method="POST">
-                    <div class="form-field" style="margin-bottom:1rem;">
-                        <label class="field-label">Asunto <span style="color:#dc2626;">*</span></label>
-                        <input type="text" name="subject" class="field-input" required maxlength="255"
-                            placeholder="Describe brevemente el problema…"
-                            value="<?= htmlspecialchars($_POST['subject'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+        <div class="card card-form" style="max-width:680px;">
+            <div class="card-header">
+                <h2 class="card-title">Detalles del ticket</h2>
+                <p class="card-subtitle">Los campos marcados con <span style="color:var(--danger,#ef4444)">*</span> son obligatorios</p>
+            </div>
+            <div class="card-body">
+                <form method="POST" class="form-grid-wrapper">
+                    <div class="form-grid">
+                        <div class="form-field form-field-full">
+                            <label class="field-label" for="subject">
+                                Asunto <span style="color:var(--danger,#ef4444)">*</span>
+                            </label>
+                            <input type="text" id="subject" name="subject" class="field-input" required maxlength="255"
+                                   placeholder="Describe brevemente el problema…"
+                                   value="<?= htmlspecialchars($_POST['subject'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                        </div>
+                        <div class="form-field form-field-full">
+                            <label class="field-label" for="message">
+                                Descripción detallada <span style="color:var(--danger,#ef4444)">*</span>
+                            </label>
+                            <textarea id="message" name="message" class="field-input field-textarea" rows="7" required
+                                      placeholder="Explica el problema con el mayor detalle posible: qué ocurrió, cuándo, qué esperabas que pasara…"
+                                      style="resize:vertical;"><?= htmlspecialchars($_POST['message'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
+                        </div>
                     </div>
-
-                    <div class="form-field" style="margin-bottom:1.5rem;">
-                        <label class="field-label">Descripción detallada <span style="color:#dc2626;">*</span></label>
-                        <textarea name="message" class="field-input" rows="6" required
-                            placeholder="Explica el problema con el mayor detalle posible: qué ocurrió, cuándo, qué esperabas que pasara…"
-                            style="resize:vertical;"><?= htmlspecialchars($_POST['message'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
-                    </div>
-
-                    <div style="display:flex;gap:.75rem;align-items:center;">
-                        <button type="submit" class="btn btn-primary">Enviar ticket</button>
-                        <a href="mis-tickets.php" class="btn btn-secondary">Cancelar</a>
+                    <div class="card-footer">
+                        <a href="mis-tickets.php" class="btn-ghost">Cancelar</a>
+                        <button type="submit" class="btn-primary">
+                            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                                <polyline points="20 6 9 17 4 12"/>
+                            </svg>
+                            Enviar ticket
+                        </button>
                     </div>
                 </form>
             </div>
         </div>
+
     </main>
 </div>
 
-<script>
-const menuToggle   = document.getElementById('menuToggle');
-const sidebar      = document.getElementById('sidebar');
-const sidebarClose = document.getElementById('sidebarClose');
-const overlay      = document.getElementById('sidebarOverlay');
-function toggleSidebar(){ sidebar.classList.toggle('open'); overlay.classList.toggle('active'); }
-menuToggle?.addEventListener('click', toggleSidebar);
-sidebarClose?.addEventListener('click', toggleSidebar);
-overlay?.addEventListener('click', toggleSidebar);
-</script>
+<script src="../js/app.js"></script>
 </body>
 </html>

--- a/src/soporte/mis-tickets.php
+++ b/src/soporte/mis-tickets.php
@@ -20,8 +20,13 @@ $flashSuccess = $_SESSION['flash_success'] ?? '';
 $flashError   = $_SESSION['flash_error']   ?? '';
 unset($_SESSION['flash_success'], $_SESSION['flash_error']);
 
-$statusColors = ['open'=>'badge-unread','in_progress'=>'badge-basic','resolved'=>'badge-active','closed'=>'badge-free'];
-$statusLabels = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resuelto','closed'=>'Cerrado'];
+$statusColors = [
+    'open'        => 'status-pill status-pill-warning',
+    'in_progress' => 'status-pill',
+    'resolved'    => 'status-pill status-pill-success',
+    'closed'      => 'status-pill status-pill-inactive',
+];
+$statusLabels = ['open' => 'Abierto', 'in_progress' => 'En proceso', 'resolved' => 'Resuelto', 'closed' => 'Cerrado'];
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -33,6 +38,7 @@ $statusLabels = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resu
 </head>
 <body class="layout">
 
+<!-- ===== SIDEBAR ===== -->
 <aside class="sidebar" id="sidebar">
     <div class="sidebar-header">
         <div class="sidebar-logo">
@@ -58,6 +64,54 @@ $statusLabels = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resu
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg></span>
                 <span class="nav-label">Productos</span>
             </a>
+            <a href="../categorias.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></span>
+                <span class="nav-label">Categorías</span>
+            </a>
+            <a href="../marcas.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
+                <span class="nav-label">Marcas</span>
+            </a>
+            <?php if (isAdmin()): ?>
+            <a href="../modelos_moto.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
+                <span class="nav-label">Modelos de Moto</span>
+            </a>
+            <a href="../proveedores.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
+                <span class="nav-label">Proveedores</span>
+            </a>
+            <a href="../pedidos.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
+                <span class="nav-label">Pedidos</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Operaciones</span>
+            <a href="../movimientos.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
+                <span class="nav-label">Movimientos</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="../auditoria.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+            <?php if (isAdmin()): ?>
+            <a href="../usuarios.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
+                <span class="nav-label">Usuarios</span>
+            </a>
+            <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="../perfil_empresa.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Ayuda</span>
@@ -67,10 +121,23 @@ $statusLabels = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resu
             </a>
         </div>
     </nav>
+    <div class="sidebar-footer">
+        <div class="sidebar-user">
+            <div class="user-avatar-sm"><?= mb_strtoupper(mb_substr($_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'U', 0, 2)) ?></div>
+            <div class="sidebar-user-info">
+                <span class="user-name-sm"><?= htmlspecialchars($_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'Usuario', ENT_QUOTES, 'UTF-8') ?></span>
+                <span class="user-role"><?= match($_SESSION['user_role'] ?? $_SESSION['rol'] ?? 'employee') { 'superadmin' => 'Super Admin', 'admin' => 'Administrador', default => 'Empleado' } ?></span>
+            </div>
+        </div>
+    </div>
 </aside>
+
 <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
+<!-- ===== MAIN WRAPPER ===== -->
 <div class="main-wrapper">
+
+    <!-- TOPBAR -->
     <header class="topbar">
         <div class="topbar-left">
             <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
@@ -89,68 +156,80 @@ $statusLabels = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resu
         </div>
     </header>
 
-    <main class="content-wrapper">
-        <div class="page-header" style="display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:.75rem;">
-            <div>
+    <!-- CONTENT -->
+    <main class="content">
+
+        <?php if ($flashSuccess): ?>
+        <div class="alert-banner alert-banner-success" style="margin-bottom:1.25rem;">
+            <?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?>
+        </div>
+        <?php endif; ?>
+        <?php if ($flashError): ?>
+        <div class="alert-banner alert-banner-error" style="margin-bottom:1.25rem;">
+            <?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?>
+        </div>
+        <?php endif; ?>
+
+        <!-- Page header -->
+        <div class="page-header">
+            <div class="page-header-info">
                 <h1 class="page-title">Mis Tickets de Soporte</h1>
                 <p class="page-subtitle">Consulta y gestiona tus solicitudes de ayuda.</p>
             </div>
-            <a href="crear-ticket.php" class="btn btn-primary">+ Nuevo ticket</a>
+            <div class="page-actions">
+                <a href="crear-ticket.php" class="btn-primary">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                        <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+                    </svg>
+                    Nuevo ticket
+                </a>
+            </div>
         </div>
-
-        <?php if ($flashSuccess): ?>
-            <div class="alert alert-success" style="margin-bottom:1rem;"><?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?></div>
-        <?php endif; ?>
-        <?php if ($flashError): ?>
-            <div class="alert alert-error" style="margin-bottom:1rem;"><?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?></div>
-        <?php endif; ?>
 
         <?php if (empty($tickets)): ?>
-        <div style="background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:3rem;text-align:center;">
-            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="#cbd5e1" stroke-width="1.5" style="margin:0 auto 1rem;display:block;"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+        <div class="card" style="text-align:center;padding:3rem 2rem;">
+            <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" style="color:var(--text-muted);margin:0 auto 1rem;display:block;">
+                <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
+            </svg>
             <p style="color:var(--text-muted);margin-bottom:1.25rem;">Aún no tienes tickets. ¿Necesitas ayuda?</p>
-            <a href="crear-ticket.php" class="btn btn-primary">Abrir primer ticket</a>
+            <a href="crear-ticket.php" class="btn-primary">Abrir primer ticket</a>
         </div>
         <?php else: ?>
-        <div class="table-card">
-            <table class="data-table">
-                <thead>
-                    <tr>
-                        <th>Ticket</th>
-                        <th>Asunto</th>
-                        <th>Estado</th>
-                        <th>Mensajes</th>
-                        <th>Actualizado</th>
-                        <th></th>
-                    </tr>
-                </thead>
-                <tbody>
-                <?php foreach ($tickets as $t): ?>
-                    <tr>
-                        <td><code style="font-size:.78rem;"><?= htmlspecialchars($t['ticket_number'], ENT_QUOTES, 'UTF-8') ?></code></td>
-                        <td><?= htmlspecialchars($t['subject'], ENT_QUOTES, 'UTF-8') ?></td>
-                        <td><span class="<?= $statusColors[$t['status']] ?? 'badge-free' ?>"><?= $statusLabels[$t['status']] ?? $t['status'] ?></span></td>
-                        <td style="color:var(--text-muted);"><?= (int)$t['msg_count'] ?></td>
-                        <td style="color:var(--text-muted);font-size:.78rem;"><?= date('d/m/Y H:i', strtotime($t['updated_at'])) ?></td>
-                        <td><a href="ticket.php?id=<?= $t['id'] ?>" class="btn btn-secondary" style="padding:.25rem .6rem;font-size:.78rem;">Ver</a></td>
-                    </tr>
-                <?php endforeach; ?>
-                </tbody>
-            </table>
+        <div class="card">
+            <div class="card-body" style="padding:0;">
+                <table class="data-table">
+                    <thead>
+                        <tr>
+                            <th>Ticket</th>
+                            <th>Asunto</th>
+                            <th>Estado</th>
+                            <th>Mensajes</th>
+                            <th>Actualizado</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                    <?php foreach ($tickets as $t): ?>
+                        <tr>
+                            <td><code style="font-size:.78rem;color:var(--text-muted);"><?= htmlspecialchars($t['ticket_number'], ENT_QUOTES, 'UTF-8') ?></code></td>
+                            <td style="font-weight:500;"><?= htmlspecialchars($t['subject'], ENT_QUOTES, 'UTF-8') ?></td>
+                            <td><span class="<?= $statusColors[$t['status']] ?? 'status-pill' ?>"><?= $statusLabels[$t['status']] ?? $t['status'] ?></span></td>
+                            <td style="color:var(--text-muted);text-align:center;"><?= (int)$t['msg_count'] ?></td>
+                            <td style="color:var(--text-muted);font-size:.82rem;"><?= date('d/m/Y H:i', strtotime($t['updated_at'])) ?></td>
+                            <td>
+                                <a href="ticket.php?id=<?= $t['id'] ?>" class="btn-ghost" style="padding:.25rem .65rem;font-size:.8rem;">Ver →</a>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
         </div>
         <?php endif; ?>
+
     </main>
 </div>
 
-<script>
-const menuToggle   = document.getElementById('menuToggle');
-const sidebar      = document.getElementById('sidebar');
-const sidebarClose = document.getElementById('sidebarClose');
-const overlay      = document.getElementById('sidebarOverlay');
-function toggleSidebar(){ sidebar.classList.toggle('open'); overlay.classList.toggle('active'); }
-menuToggle?.addEventListener('click', toggleSidebar);
-sidebarClose?.addEventListener('click', toggleSidebar);
-overlay?.addEventListener('click', toggleSidebar);
-</script>
+<script src="../js/app.js"></script>
 </body>
 </html>

--- a/src/soporte/ticket.php
+++ b/src/soporte/ticket.php
@@ -42,8 +42,13 @@ try {
 $ticket   = $data['ticket'];
 $messages = $data['messages'];
 
-$statusLabels = ['open'=>'Abierto','in_progress'=>'En proceso','resolved'=>'Resuelto','closed'=>'Cerrado'];
-$statusColors = ['open'=>'badge-unread','in_progress'=>'badge-basic','resolved'=>'badge-active','closed'=>'badge-free'];
+$statusLabels = ['open' => 'Abierto', 'in_progress' => 'En proceso', 'resolved' => 'Resuelto', 'closed' => 'Cerrado'];
+$statusColors = [
+    'open'        => 'status-pill status-pill-warning',
+    'in_progress' => 'status-pill',
+    'resolved'    => 'status-pill status-pill-success',
+    'closed'      => 'status-pill status-pill-inactive',
+];
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -52,9 +57,28 @@ $statusColors = ['open'=>'badge-unread','in_progress'=>'badge-basic','resolved'=
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title><?= htmlspecialchars($ticket['ticket_number'], ENT_QUOTES, 'UTF-8') ?> – es21plus</title>
     <link rel="stylesheet" href="../css/estilos.css">
+    <style>
+        .msg-bubble {
+            border-radius: var(--radius-lg);
+            padding: .875rem 1.1rem;
+            font-size: .875rem;
+            line-height: 1.6;
+        }
+        .msg-bubble-sa   { background: #f0f1ff; border: 1px solid #c7d2fe; border-radius: 0 var(--radius-lg) var(--radius-lg) var(--radius-lg); }
+        .msg-bubble-user { background: var(--bg-hover); border: 1px solid var(--border-color); border-radius: var(--radius-lg) var(--radius-lg) 0 var(--radius-lg); }
+        .msg-meta { font-size: .72rem; color: var(--text-muted); margin-bottom: .35rem; }
+        .msg-avatar-sa   { background: #6366f1; color: #fff; }
+        .msg-avatar-user { background: #e0e7ff; color: #4338ca; }
+        .msg-avatar {
+            width: 34px; height: 34px; border-radius: 50%;
+            display: flex; align-items: center; justify-content: center;
+            font-size: .7rem; font-weight: 700; flex-shrink: 0;
+        }
+    </style>
 </head>
 <body class="layout">
 
+<!-- ===== SIDEBAR ===== -->
 <aside class="sidebar" id="sidebar">
     <div class="sidebar-header">
         <div class="sidebar-logo">
@@ -76,6 +100,58 @@ $statusColors = ['open'=>'badge-unread','in_progress'=>'badge-basic','resolved'=
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
                 <span class="nav-label">Dashboard</span>
             </a>
+            <a href="../productos.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg></span>
+                <span class="nav-label">Productos</span>
+            </a>
+            <a href="../categorias.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></span>
+                <span class="nav-label">Categorías</span>
+            </a>
+            <a href="../marcas.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
+                <span class="nav-label">Marcas</span>
+            </a>
+            <?php if (isAdmin()): ?>
+            <a href="../modelos_moto.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
+                <span class="nav-label">Modelos de Moto</span>
+            </a>
+            <a href="../proveedores.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
+                <span class="nav-label">Proveedores</span>
+            </a>
+            <a href="../pedidos.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
+                <span class="nav-label">Pedidos</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Operaciones</span>
+            <a href="../movimientos.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
+                <span class="nav-label">Movimientos</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="../auditoria.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+            <?php if (isAdmin()): ?>
+            <a href="../usuarios.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
+                <span class="nav-label">Usuarios</span>
+            </a>
+            <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="../perfil_empresa.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Ayuda</span>
@@ -85,10 +161,23 @@ $statusColors = ['open'=>'badge-unread','in_progress'=>'badge-basic','resolved'=
             </a>
         </div>
     </nav>
+    <div class="sidebar-footer">
+        <div class="sidebar-user">
+            <div class="user-avatar-sm"><?= mb_strtoupper(mb_substr($_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'U', 0, 2)) ?></div>
+            <div class="sidebar-user-info">
+                <span class="user-name-sm"><?= htmlspecialchars($_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'Usuario', ENT_QUOTES, 'UTF-8') ?></span>
+                <span class="user-role"><?= match($_SESSION['user_role'] ?? $_SESSION['rol'] ?? 'employee') { 'superadmin' => 'Super Admin', 'admin' => 'Administrador', default => 'Empleado' } ?></span>
+            </div>
+        </div>
+    </div>
 </aside>
+
 <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
+<!-- ===== MAIN WRAPPER ===== -->
 <div class="main-wrapper">
+
+    <!-- TOPBAR -->
     <header class="topbar">
         <div class="topbar-left">
             <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
@@ -109,89 +198,99 @@ $statusColors = ['open'=>'badge-unread','in_progress'=>'badge-basic','resolved'=
         </div>
     </header>
 
-    <main class="content-wrapper">
+    <!-- CONTENT -->
+    <main class="content">
 
         <?php if ($flashSuccess): ?>
-            <div class="alert alert-success" style="margin-bottom:1rem;"><?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?></div>
+        <div class="alert-banner alert-banner-success" style="margin-bottom:1.25rem;">
+            <?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?>
+        </div>
         <?php endif; ?>
         <?php if ($flashError): ?>
-            <div class="alert alert-error" style="margin-bottom:1rem;"><?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?></div>
+        <div class="alert-banner alert-banner-error" style="margin-bottom:1.25rem;">
+            <?= htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8') ?>
+        </div>
         <?php endif; ?>
 
-        <div style="display:flex;align-items:center;gap:.75rem;flex-wrap:wrap;margin-bottom:1.25rem;">
-            <a href="mis-tickets.php" style="font-size:.84rem;color:var(--accent);text-decoration:none;">← Mis tickets</a>
-            <code style="font-size:.78rem;color:var(--text-muted);"><?= htmlspecialchars($ticket['ticket_number'], ENT_QUOTES, 'UTF-8') ?></code>
-            <span class="<?= $statusColors[$ticket['status']] ?? 'badge-free' ?>">
-                <?= $statusLabels[$ticket['status']] ?? $ticket['status'] ?>
-            </span>
-        </div>
-
-        <div style="max-width:720px;">
-            <!-- Título -->
-            <div style="background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:1.25rem 1.5rem;margin-bottom:1rem;">
-                <h2 style="margin:0 0 .25rem;font-size:1.05rem;color:var(--text-primary);">
-                    <?= htmlspecialchars($ticket['subject'], ENT_QUOTES, 'UTF-8') ?>
-                </h2>
-                <p style="margin:0;font-size:.78rem;color:var(--text-muted);">
-                    Abierto el <?= date('d/m/Y H:i', strtotime($ticket['created_at'])) ?>
+        <!-- Page header -->
+        <div class="page-header">
+            <div class="page-header-info">
+                <h1 class="page-title"><?= htmlspecialchars($ticket['subject'], ENT_QUOTES, 'UTF-8') ?></h1>
+                <p class="page-subtitle">
+                    <code style="font-size:.78rem;color:var(--text-muted);"><?= htmlspecialchars($ticket['ticket_number'], ENT_QUOTES, 'UTF-8') ?></code>
+                    &nbsp;·&nbsp;
+                    <span class="<?= $statusColors[$ticket['status']] ?? 'status-pill' ?>"><?= $statusLabels[$ticket['status']] ?? $ticket['status'] ?></span>
+                    &nbsp;·&nbsp;
+                    <span style="font-size:.82rem;color:var(--text-muted);">Abierto el <?= date('d/m/Y H:i', strtotime($ticket['created_at'])) ?></span>
                 </p>
             </div>
-
-            <!-- Mensajes -->
-            <div style="display:flex;flex-direction:column;gap:.75rem;margin-bottom:1rem;">
-                <?php foreach ($messages as $msg): ?>
-                <?php $isSA = $msg['sender_type'] === 'superadmin'; ?>
-                <div style="display:flex;gap:.75rem;<?= $isSA ? 'justify-content:flex-start;' : 'justify-content:flex-end;' ?>">
-                    <?php if ($isSA): ?>
-                    <div style="width:34px;height:34px;border-radius:50%;background:#6366f1;display:flex;align-items:center;justify-content:center;font-size:.7rem;font-weight:700;color:#fff;flex-shrink:0;">SA</div>
-                    <?php endif; ?>
-                    <div style="max-width:78%;background:<?= $isSA ? '#f0f1ff' : '#f8fafc' ?>;border:1px solid <?= $isSA ? '#c7d2fe' : 'var(--border)' ?>;border-radius:<?= $isSA ? '0 1rem 1rem 1rem' : '1rem 1rem 0 1rem' ?>;padding:.75rem 1rem;">
-                        <p style="margin:0 0 .4rem;font-size:.7rem;color:var(--text-muted);">
-                            <?= $isSA ? 'Soporte es21plus' : htmlspecialchars($_SESSION['user_name'] ?? 'Tú', ENT_QUOTES, 'UTF-8') ?>
-                            · <?= date('d/m/Y H:i', strtotime($msg['created_at'])) ?>
-                        </p>
-                        <p style="margin:0;font-size:.85rem;white-space:pre-wrap;color:var(--text-primary);"><?= htmlspecialchars($msg['message'], ENT_QUOTES, 'UTF-8') ?></p>
-                    </div>
-                    <?php if (!$isSA): ?>
-                    <div style="width:34px;height:34px;border-radius:50%;background:#e0e7ff;display:flex;align-items:center;justify-content:center;font-size:.7rem;font-weight:700;color:#4338ca;flex-shrink:0;">
-                        <?= mb_strtoupper(mb_substr($_SESSION['user_name'] ?? 'U', 0, 2)) ?>
-                    </div>
-                    <?php endif; ?>
-                </div>
-                <?php endforeach; ?>
+            <div class="page-actions">
+                <a href="mis-tickets.php" class="btn-ghost">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                        <line x1="19" y1="12" x2="5" y2="12"/><polyline points="12 19 5 12 12 5"/>
+                    </svg>
+                    Mis tickets
+                </a>
             </div>
+        </div>
 
-            <!-- Responder (solo si no cerrado) -->
-            <?php if (!in_array($ticket['status'], ['closed'], true)): ?>
-            <div style="background:#fff;border:1px solid var(--border);border-radius:var(--radius-lg);padding:1.25rem 1.5rem;">
+        <!-- Hilo de mensajes -->
+        <div style="max-width:740px;display:flex;flex-direction:column;gap:.875rem;margin-bottom:1.5rem;">
+            <?php foreach ($messages as $msg): ?>
+            <?php $isSA = $msg['sender_type'] === 'superadmin'; ?>
+            <div style="display:flex;gap:.75rem;align-items:flex-start;<?= $isSA ? '' : 'flex-direction:row-reverse;' ?>">
+                <div class="msg-avatar <?= $isSA ? 'msg-avatar-sa' : 'msg-avatar-user' ?>">
+                    <?= $isSA ? 'SA' : mb_strtoupper(mb_substr($_SESSION['user_name'] ?? 'U', 0, 2)) ?>
+                </div>
+                <div style="max-width:78%;">
+                    <p class="msg-meta">
+                        <?= $isSA ? 'Soporte es21plus' : htmlspecialchars($_SESSION['user_name'] ?? 'Tú', ENT_QUOTES, 'UTF-8') ?>
+                        · <?= date('d/m/Y H:i', strtotime($msg['created_at'])) ?>
+                    </p>
+                    <div class="msg-bubble <?= $isSA ? 'msg-bubble-sa' : 'msg-bubble-user' ?>">
+                        <?= nl2br(htmlspecialchars($msg['message'], ENT_QUOTES, 'UTF-8')) ?>
+                    </div>
+                </div>
+            </div>
+            <?php endforeach; ?>
+        </div>
+
+        <!-- Responder -->
+        <?php if (!in_array($ticket['status'], ['closed'], true)): ?>
+        <div class="card card-form" style="max-width:740px;">
+            <div class="card-header">
+                <h3 class="card-title" style="font-size:.95rem;">Responder</h3>
+            </div>
+            <div class="card-body">
                 <form method="POST">
                     <input type="hidden" name="_action" value="reply">
-                    <div class="form-field" style="margin-bottom:.75rem;">
-                        <label class="field-label">Tu respuesta</label>
+                    <div class="form-field" style="margin-bottom:.875rem;">
                         <textarea name="message" class="field-input" rows="4" required
-                            placeholder="Escribe tu respuesta…" style="resize:vertical;"></textarea>
+                                  placeholder="Escribe tu respuesta…" style="resize:vertical;"></textarea>
                     </div>
-                    <button type="submit" class="btn btn-primary">Enviar respuesta</button>
+                    <div style="display:flex;justify-content:flex-end;">
+                        <button type="submit" class="btn-primary">
+                            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                                <polyline points="20 6 9 17 4 12"/>
+                            </svg>
+                            Enviar respuesta
+                        </button>
+                    </div>
                 </form>
             </div>
-            <?php else: ?>
-            <p style="color:var(--text-muted);font-size:.84rem;text-align:center;padding:1rem 0;">
-                Este ticket está cerrado. Si necesitas más ayuda, abre un nuevo ticket.
-            </p>
-            <?php endif; ?>
         </div>
+        <?php else: ?>
+        <div class="card" style="max-width:740px;text-align:center;padding:1.5rem;">
+            <p style="color:var(--text-muted);font-size:.875rem;">
+                Este ticket está cerrado. Si necesitas más ayuda,
+                <a href="crear-ticket.php" style="color:var(--accent);">abre un nuevo ticket</a>.
+            </p>
+        </div>
+        <?php endif; ?>
+
     </main>
 </div>
 
-<script>
-const menuToggle   = document.getElementById('menuToggle');
-const sidebar      = document.getElementById('sidebar');
-const sidebarClose = document.getElementById('sidebarClose');
-const overlay      = document.getElementById('sidebarOverlay');
-function toggleSidebar(){ sidebar.classList.toggle('open'); overlay.classList.toggle('active'); }
-menuToggle?.addEventListener('click', toggleSidebar);
-sidebarClose?.addEventListener('click', toggleSidebar);
-overlay?.addEventListener('click', toggleSidebar);
-</script>
+<script src="../js/app.js"></script>
 </body>
 </html>

--- a/src/usuarios.php
+++ b/src/usuarios.php
@@ -141,7 +141,7 @@ $iniciales = mb_substr($iniciales, 0, 2);
                 </span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -151,6 +151,11 @@ $iniciales = mb_substr($iniciales, 0, 2);
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'proveedores.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
                 <span class="nav-label">Proveedores</span>
+            </a>
+            <a href="pedidos.php"
+               class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'pedidos.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
+                <span class="nav-label">Pedidos</span>
             </a>
             <?php endif; ?>
         </div>
@@ -182,6 +187,19 @@ $iniciales = mb_substr($iniciales, 0, 2);
                     </svg>
                 </span>
                 <span class="nav-label">Usuarios</span>
+            </a>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
             </a>
         </div>
     </nav>

--- a/src/ver_producto.php
+++ b/src/ver_producto.php
@@ -250,7 +250,7 @@ $imgRuta  = Producto::rutaImagen($producto['imagen'] ?? null);
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
                 <span class="nav-label">Marcas</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="modelos_moto.php"
                class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'modelos_moto.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
@@ -282,12 +282,25 @@ $imgRuta  = Producto::rutaImagen($producto['imagen'] ?? null);
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
                 <span class="nav-label">Auditoría</span>
             </a>
-            <?php if (($_SESSION['rol'] ?? '') === 'admin'): ?>
+            <?php if (isAdmin()): ?>
             <a href="usuarios.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'usuarios.php' ? 'active' : '' ?>">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
                 <span class="nav-label">Usuarios</span>
             </a>
             <?php endif; ?>
+            <?php if ((($_SESSION['user_role'] ?? '') === 'admin')): ?>
+            <a href="perfil_empresa.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'perfil_empresa.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="4"/><path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/></svg></span>
+                <span class="nav-label">Perfil de empresa</span>
+            </a>
+            <?php endif; ?>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Ayuda</span>
+            <a href="soporte/mis-tickets.php" class="nav-item <?= str_contains($_SERVER['PHP_SELF'] ?? '', '/soporte/') ? 'active' : '' ?>">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg></span>
+                <span class="nav-label">Soporte</span>
+            </a>
         </div>
     </nav>
     <div class="sidebar-footer">


### PR DESCRIPTION
## Resumen

Mejoras visuales y de navegación en el panel de empresa.

## Cambios

### 🔗 Dashboard — tarjetas enlazables
- Todas las tarjetas del dashboard son ahora `<a>` clicables (toda la tarjeta)
- Stock Bajo enlaza a `productos.php?stock_bajo=1` (con filtro activo)
- Resto enlazan a sus secciones sin filtros extra

### 🔍 Filtro stock_bajo en productos
- `?stock_bajo=1` activa el filtro en la tabla de productos
- Badge naranja de filtro activo con botón dismiss

### 🖊️ editar_producto — nuevo layout
- Rediseño con layout `product-detail-grid` (320px sticky + 1fr)
- Columna izquierda: avatar letra, nombre/precio en vivo, badge stock, subida imagen, botones acción
- Columna derecha: tarjetas por sección (datos básicos, precio, identificación, dimensiones, proveedor, motos)
- Preview imagen en tiempo real via FileReader
- Lógica PHP/POST sin cambios

### 🗂️ Sidebar completo en todas las páginas
Páginas corregidas: `categorias`, `marcas`, `modelos_moto`, `movimientos`, `nuevo_producto`, `pedidos`, `proveedores`, `ver_producto`, `usuarios`, `productos`, `perfil_empresa`

Secciones añadidas donde faltaban:
- **Pedidos** en bloque `isAdmin()`
- **Perfil de empresa** en sección Administración
- **Soporte** en sección Ayuda
- `perfil_empresa.php`: sidebar completamente reescrito + topbar con breadcrumb correcto

### 🎨 Auditoría — rediseño visual
- Clases CSS corregidas (eliminadas `.main-content`, `btn btn-primary`, `.table`, `alert alert-danger`)
- Usa `data-table`, `btn-primary`/`btn-ghost`, `alert-banner`, `status-pill`
- breadcrumb-nav, page-header con contador de registros

### 💬 Soporte — rediseño visual completo
- `mis-tickets.php`, `crear-ticket.php`, `ticket.php`: sidebar completo con todas las secciones
- Clases CSS correctas en toda la interfaz
- `ticket.php`: UI de chat con burbujas por remitente

### 🔧 Fixes de modelos e includes
- `Marca`: fix alias vacío en `bizWhere()` (error `Unknown column m.business_id`)
- `Movimiento`/`Proveedor`: métodos helper añadidos
- `auth_check`: compatibilidad dual de claves de sesión para `isAdmin()`

## Verificación

- ✅ PHP lint sin errores en todos los archivos modificados
- ✅ Todas las páginas retornan HTTP 302 → `login.php` (sin 500, sin loops)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)