### PR TITLE
fix(security): add CSRF protection to 5 POST forms

### DIFF
--- a/src/nuevo_pedido.php
+++ b/src/nuevo_pedido.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/Proveedor.php';
 require_once __DIR__ . '/includes/Pedido.php';
+require_once __DIR__ . '/includes/csrf.php';
 
 // Solo admin puede crear pedidos
 if (!isAdmin()) {
@@ -59,6 +60,10 @@ if (empty($lineasIniciales)) {
 // ── Manejar POST ──────────────────────────────────────────────────────────────
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
+        if (!validateCsrfToken('crear_pedido', $_POST['csrf_token'] ?? '')) {
+            throw new AppException('Token CSRF inválido.', 403);
+        }
+
         $datos = [
             'proveedor_id' => filter_input(INPUT_POST, 'proveedor_id', FILTER_VALIDATE_INT) ?: null,
             'notas'        => trim($_POST['notas'] ?? '') ?: null,
@@ -239,6 +244,7 @@ try { $stockBajoCount = count($productoModel->filtrarStockBajo()); } catch (\Thr
         <div class="card">
             <div class="card-body">
                 <form method="POST" id="formPedido">
+                    <input type="hidden" name="csrf_token" value="<?= generateCsrfToken('crear_pedido') ?>">
 
                     <!-- Proveedor -->
                     <div class="form-field" style="margin-bottom:1rem;">

--- a/src/pedidos.php
+++ b/src/pedidos.php
@@ -12,6 +12,7 @@ require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/Proveedor.php';
 require_once __DIR__ . '/includes/Pedido.php';
+require_once __DIR__ . '/includes/csrf.php';
 
 $pedidoModel    = new Pedido();
 $stockBajoCount = 0;
@@ -25,6 +26,10 @@ unset($_SESSION['flash_success'], $_SESSION['flash_error']);
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $accion = $_POST['accion'] ?? '';
     try {
+        if (!validateCsrfToken('cambiar_estado_pedido', $_POST['csrf_token'] ?? '')) {
+            throw new AppException('Token CSRF inválido.', 403);
+        }
+
         if ($accion === 'cambiar_estado') {
             $pedidoId   = (int) ($_POST['pedido_id'] ?? 0);
             $nuevoEstado = trim($_POST['nuevo_estado'] ?? '');
@@ -350,6 +355,7 @@ $esAdmin = isAdmin();
                             <td class="td-actions" style="white-space:nowrap;">
                                 <?php if ($esAdmin && $ped['estado'] === 'borrador'): ?>
                                 <form method="POST" style="display:inline;">
+                                    <input type="hidden" name="csrf_token"   value="<?= generateCsrfToken('cambiar_estado_pedido') ?>">
                                     <input type="hidden" name="accion"       value="cambiar_estado">
                                     <input type="hidden" name="pedido_id"    value="<?= (int)$ped['id'] ?>">
                                     <input type="hidden" name="nuevo_estado" value="enviado">
@@ -359,6 +365,7 @@ $esAdmin = isAdmin();
                                     </button>
                                 </form>
                                 <form method="POST" style="display:inline;">
+                                    <input type="hidden" name="csrf_token"   value="<?= generateCsrfToken('cambiar_estado_pedido') ?>">
                                     <input type="hidden" name="accion"       value="cambiar_estado">
                                     <input type="hidden" name="pedido_id"    value="<?= (int)$ped['id'] ?>">
                                     <input type="hidden" name="nuevo_estado" value="cancelado">
@@ -370,6 +377,7 @@ $esAdmin = isAdmin();
                                 <?php endif; ?>
                                 <?php if ($esAdmin && $ped['estado'] === 'enviado'): ?>
                                 <form method="POST" style="display:inline;">
+                                    <input type="hidden" name="csrf_token"   value="<?= generateCsrfToken('cambiar_estado_pedido') ?>">
                                     <input type="hidden" name="accion"       value="cambiar_estado">
                                     <input type="hidden" name="pedido_id"    value="<?= (int)$ped['id'] ?>">
                                     <input type="hidden" name="nuevo_estado" value="recibido">
@@ -379,6 +387,7 @@ $esAdmin = isAdmin();
                                     </button>
                                 </form>
                                 <form method="POST" style="display:inline;">
+                                    <input type="hidden" name="csrf_token"   value="<?= generateCsrfToken('cambiar_estado_pedido') ?>">
                                     <input type="hidden" name="accion"       value="cambiar_estado">
                                     <input type="hidden" name="pedido_id"    value="<?= (int)$ped['id'] ?>">
                                     <input type="hidden" name="nuevo_estado" value="cancelado">

--- a/src/perfil.php
+++ b/src/perfil.php
@@ -19,6 +19,7 @@ require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Auditoria.php';
 require_once __DIR__ . '/includes/Usuario.php';
 require_once __DIR__ . '/includes/Producto.php';
+require_once __DIR__ . '/includes/csrf.php';
 
 $flashSuccess = $_SESSION['flash_success'] ?? '';
 $flashError   = $_SESSION['flash_error']   ?? '';
@@ -51,6 +52,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if ($accionPost === 'perfil') {
         // ── Actualizar nombre y email ─────────────────────────────────────────
         try {
+            if (!validateCsrfToken('actualizar_perfil', $_POST['csrf_token'] ?? '')) {
+                throw new AppException('Token CSRF inválido.', 403);
+            }
+
             $nombreCompleto = trim($_POST['nombre_completo'] ?? '');
             $email          = trim($_POST['email']           ?? '');
 
@@ -76,6 +81,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     } elseif ($accionPost === 'password') {
         // ── Cambiar contraseña ────────────────────────────────────────────────
         try {
+            if (!validateCsrfToken('cambiar_password_perfil', $_POST['csrf_token'] ?? '')) {
+                throw new AppException('Token CSRF inválido.', 403);
+            }
+
             $passwordActual   = $_POST['password_actual']    ?? '';
             $passwordNueva    = $_POST['password_nueva']     ?? '';
             $passwordConfirma = $_POST['password_confirmar'] ?? '';
@@ -351,6 +360,7 @@ $rolLabel     = match ($rolSesion) {
 
                     <form method="POST" novalidate>
                         <input type="hidden" name="accion" value="perfil">
+                        <input type="hidden" name="csrf_token" value="<?= generateCsrfToken('actualizar_perfil') ?>">
 
                         <div class="form-field" style="margin-bottom:1rem;">
                             <label class="field-label" for="nombre_completo">
@@ -389,6 +399,7 @@ $rolLabel     = match ($rolSesion) {
                 <div class="card-body">
                     <form method="POST" id="formPassword" novalidate>
                         <input type="hidden" name="accion" value="password">
+                        <input type="hidden" name="csrf_token" value="<?= generateCsrfToken('cambiar_password_perfil') ?>">
 
                         <div class="form-field" style="margin-bottom:1rem;">
                             <label class="field-label" for="password_actual">

--- a/src/proveedores.php
+++ b/src/proveedores.php
@@ -11,6 +11,7 @@ require_once __DIR__ . '/includes/AppException.php';
 require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/Proveedor.php';
+require_once __DIR__ . '/includes/csrf.php';
 
 if (!isAdmin()) {
     header('Location: index.php');
@@ -34,6 +35,11 @@ unset($_SESSION['flash_success'], $_SESSION['flash_error']);
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     try {
         $postAccion = $_POST['accion'] ?? '';
+
+        $csrfAccion = $postAccion === 'desactivar' ? 'desactivar_proveedor' : 'guardar_proveedor';
+        if (!validateCsrfToken($csrfAccion, $_POST['csrf_token'] ?? '')) {
+            throw new AppException('Token CSRF inválido.', 403);
+        }
 
         if ($postAccion === 'crear') {
             $datos = [
@@ -317,6 +323,7 @@ if ($provSelId) {
                     </div>
                     <div class="card-body">
                         <form method="POST">
+                            <input type="hidden" name="csrf_token" value="<?= generateCsrfToken('guardar_proveedor') ?>">
                             <input type="hidden" name="accion" value="<?= $editProv ? 'editar' : 'crear' ?>">
                             <?php if ($editProv): ?>
                                 <input type="hidden" name="id" value="<?= (int)$editProv['id'] ?>">
@@ -439,6 +446,7 @@ if ($provSelId) {
                                         </a>
                                         <?php if ((int)$prov['activo'] === 1): ?>
                                         <form method="POST" style="display:inline;">
+                                            <input type="hidden" name="csrf_token" value="<?= generateCsrfToken('desactivar_proveedor') ?>">
                                             <input type="hidden" name="accion" value="desactivar">
                                             <input type="hidden" name="id" value="<?= (int)$prov['id'] ?>">
                                             <button type="submit" class="action-btn action-btn-red" title="Desactivar proveedor"

--- a/src/usuarios.php
+++ b/src/usuarios.php
@@ -18,6 +18,7 @@ require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Usuario.php';
 require_once __DIR__ . '/includes/auth_check.php';
 require_once __DIR__ . '/middleware/RoleMiddleware.php';
+require_once __DIR__ . '/includes/csrf.php';
 
 // Solo administradores pueden gestionar usuarios
 RoleMiddleware::requireAdmin();
@@ -39,6 +40,9 @@ try {
 // Iniciales del usuario de sesión para el avatar — compatible con sesiones locales y multi-tenant
 $nombreSesion = $_SESSION['user_name'] ?? $_SESSION['usuario_nombre'] ?? 'Usuario';
 $iniciales    = mb_strtoupper(mb_substr($nombreSesion, 0, 2)) ?: 'U';
+
+// Token CSRF para las operaciones AJAX del formulario de usuarios
+$csrfTokenUsuarios = generateCsrfToken('gestionar_usuarios');
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -380,6 +384,8 @@ $iniciales    = mb_strtoupper(mb_substr($nombreSesion, 0, 2)) ?: 'U';
 
         <form id="formUsuario" novalidate>
             <input type="hidden" id="usuarioId" name="id" value="">
+            <input type="hidden" id="csrfTokenUsuarios" name="csrf_token"
+                   value="<?= htmlspecialchars($csrfTokenUsuarios, ENT_QUOTES, 'UTF-8') ?>">
 
             <div class="form-field" style="margin-bottom:1rem;">
                 <label class="field-label" for="inputUsername">Username <span style="color:#ef4444;">*</span></label>
@@ -515,7 +521,8 @@ document.getElementById('formUsuario').addEventListener('submit', async function
     const rol           = document.getElementById('inputRol').value;
     const password      = document.getElementById('inputPassword').value;
 
-    const body = { username, nombre_completo: nombreCompleto, email, rol };
+    const csrfToken = document.getElementById('csrfTokenUsuarios').value;
+    const body = { username, nombre_completo: nombreCompleto, email, rol, csrf_token: csrfToken };
     if (!modoEdicion) body.password = password;
 
     const url    = modoEdicion ? `api/usuarios.php?id=${id}` : 'api/usuarios.php';
@@ -562,8 +569,13 @@ async function toggleUsuario(id, activo, btn) {
 
     btn.disabled = true;
 
+    const csrfToken = document.getElementById('csrfTokenUsuarios').value;
     try {
-        const res  = await fetch(`api/usuarios.php?id=${id}&accion=toggle`, { method: 'PATCH' });
+        const res  = await fetch(`api/usuarios.php?id=${id}&accion=toggle`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ csrf_token: csrfToken }),
+        });
         const json = await res.json();
 
         if (!json.success) {
@@ -588,8 +600,13 @@ async function toggleUsuario(id, activo, btn) {
 async function resetPassword(id, username) {
     if (!confirm(`¿Resetear la contraseña de "${username}"? Se generará una contraseña aleatoria.`)) return;
 
+    const csrfToken = document.getElementById('csrfTokenUsuarios').value;
     try {
-        const res  = await fetch(`api/usuarios.php?id=${id}&accion=reset-password`, { method: 'PATCH' });
+        const res  = await fetch(`api/usuarios.php?id=${id}&accion=reset-password`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ csrf_token: csrfToken }),
+        });
         const json = await res.json();
 
         if (!json.success) {


### PR DESCRIPTION
## Descripción

Formularios POST sin protección CSRF en 5 páginas — vector de ataque para Cross-Site Request Forgery.

## Cambios

| Archivo | Acción/token | Formularios protegidos |
|---|---|---|
| `nuevo_pedido.php` | `crear_pedido` | 1 form |
| `pedidos.php` | `cambiar_estado_pedido` | 4 inline forms |
| `proveedores.php` | `guardar_proveedor` + `desactivar_proveedor` | 2 forms |
| `perfil.php` | `actualizar_perfil` + `cambiar_password_perfil` | 2 forms |
| `usuarios.php` | `gestionar_usuarios` | modal form + 3 fetch() AJAX |

## Implementación

- `require_once csrf.php` al inicio de cada archivo (antes del handler POST)
- `generateCsrfToken('accion')` en cada `<input type="hidden" name="csrf_token">`
- `validateCsrfToken()` antes de cualquier operación DB — lanza `AppException(403)` si falla
- `usuarios.php`: token generado en PHP, pasado en body JSON de cada `fetch()` (POST/PUT/PATCH)

## Helper CSRF

Usa `src/includes/csrf.php` existente (`generateCsrfToken` / `validateCsrfToken`). Sin dependencias nuevas.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)