### PR TITLE
fix(usuarios): remove duplicate session_start() call

### DIFF
--- a/src/usuarios.php
+++ b/src/usuarios.php
@@ -11,8 +11,6 @@
  * @author   miguelrechefdez
  * @version  1.0.0
  */
-session_start();
-
 require_once __DIR__ . '/includes/AppException.php';
 require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Usuario.php';


### PR DESCRIPTION
## Problema

`usuarios.php` llamaba a `session_start()` en línea 14 de forma incondicional. `auth_check.php` (incluido justo después) ya gestiona la sesión con `session_status() === PHP_SESSION_NONE`.

La llamada duplicada provoca:
- `Warning: session_start(): Session already started` en PHP
- Comportamiento inesperado si hay headers ya enviados

## Cambio

Eliminada la línea `session_start();` de `src/usuarios.php`. Sin otro cambio.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)