### PR TITLE
fix(api/usuarios): validate CSRF token on POST, PUT and PATCH

### DIFF
--- a/src/api/usuarios.php
+++ b/src/api/usuarios.php
@@ -27,6 +27,7 @@ header('Content-Type: application/json; charset=utf-8');
 require_once __DIR__ . '/../includes/AppException.php';
 require_once __DIR__ . '/../includes/Database.php';
 require_once __DIR__ . '/../includes/Usuario.php';
+require_once __DIR__ . '/../includes/csrf.php';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -93,6 +94,10 @@ try {
         // ── POST: crear usuario ───────────────────────────────────────────────
         case 'POST':
             $body = json_decode(file_get_contents('php://input'), true) ?? [];
+            $csrfToken = $body['csrf_token'] ?? '';
+            if (!validateCsrfToken('gestionar_usuarios', $csrfToken)) {
+                jsonResponse(false, null, 'Token CSRF inválido.', 403);
+            }
 
             $username        = trim($body['username']        ?? '');
             $password        = $body['password']             ?? '';
@@ -115,6 +120,10 @@ try {
             }
 
             $body = json_decode(file_get_contents('php://input'), true) ?? [];
+            $csrfToken = $body['csrf_token'] ?? '';
+            if (!validateCsrfToken('gestionar_usuarios', $csrfToken)) {
+                jsonResponse(false, null, 'Token CSRF inválido.', 403);
+            }
 
             $username       = trim($body['username']        ?? '');
             $nombreCompleto = trim($body['nombre_completo'] ?? '');
@@ -133,6 +142,12 @@ try {
         case 'PATCH':
             if ($id === null) {
                 jsonResponse(false, null, 'Parámetro id requerido.', 400);
+            }
+
+            $body = json_decode(file_get_contents('php://input'), true) ?? [];
+            $csrfToken = $body['csrf_token'] ?? '';
+            if (!validateCsrfToken('gestionar_usuarios', $csrfToken)) {
+                jsonResponse(false, null, 'Token CSRF inválido.', 403);
             }
 
             if ($accion === 'toggle') {


### PR DESCRIPTION
## Problema

`src/api/usuarios.php` aceptaba `csrf_token` en el body JSON pero nunca lo validaba — cualquier sitio podía hacer llamadas de escritura en nombre de un admin autenticado.

## Cambios

- `require_once csrf.php` añadido tras los otros requires
- **POST**: valida `gestionar_usuarios` antes de leer cualquier campo del body
- **PUT**: ídem, tras comprobar que `$id !== null`
- **PATCH**: ídem, antes de distinguir entre `toggle` y `reset-password`

Todos responden `403 Token CSRF inválido.` si la validación falla.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)