### PR TITLE
fix(api/usuarios): support multi-tenant session in requireAdmin()

### DIFF
--- a/src/api/usuarios.php
+++ b/src/api/usuarios.php
@@ -61,10 +61,17 @@ function jsonResponse(bool $success, mixed $data, string $message, int $status =
  */
 function requireAdmin(): void
 {
-    if (empty($_SESSION['usuario_id'])) {
+    // Sesión local (login directo)
+    $isLocalUser    = !empty($_SESSION['usuario_id']);
+    // Sesión multi-tenant (login de empresa)
+    $isBusinessUser = !empty($_SESSION['user_id']) && !empty($_SESSION['business_id']);
+
+    if (!$isLocalUser && !$isBusinessUser) {
         jsonResponse(false, null, 'No autenticado.', 401);
     }
-    if (!in_array($_SESSION['rol'] ?? '', ['admin', 'superadmin'], true)) {
+
+    $rol = $_SESSION['user_role'] ?? $_SESSION['rol'] ?? '';
+    if (!in_array($rol, ['admin', 'superadmin'], true)) {
         jsonResponse(false, null, 'Acceso denegado: se requiere rol admin.', 403);
     }
 }


### PR DESCRIPTION
## Problema

`requireAdmin()` sólo comprobaba `$_SESSION['usuario_id']` y `$_SESSION['rol']` (sesión de login local). Los usuarios de empresa (multi-tenant) usan `$_SESSION['user_id']`, `$_SESSION['business_id']` y `$_SESSION['user_role']`, por lo que recibían 401 en todos los endpoints de escritura.

## Cambio

Acepta cualquiera de las dos rutas de autenticación antes de verificar el rol:

```php
$isLocalUser    = !empty($_SESSION['usuario_id']);
$isBusinessUser = !empty($_SESSION['user_id']) && !empty($_SESSION['business_id']);
```

Rol unificado: `$_SESSION['user_role'] ?? $_SESSION['rol'] ?? ''`

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)