### PR TITLE
feat(security): CSRF protection on empleados PATCH endpoints

### DIFF
--- a/src/api/empleados.php
+++ b/src/api/empleados.php
@@ -20,6 +20,7 @@ if (session_status() === PHP_SESSION_NONE) session_start();
 
 require_once __DIR__ . '/../includes/AppException.php';
 require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../core/Session.php';
 require_once __DIR__ . '/../middleware/RoleMiddleware.php';
 
@@ -150,6 +151,13 @@ try {
         // ── PATCH: toggle activo / reset password ─────────────────────────────
         case 'PATCH':
             if (!$id) throw new AppException('ID requerido.', 400);
+
+            $body      = json_decode(file_get_contents('php://input'), true) ?? [];
+            $csrfToken = $body['csrf_token'] ?? '';
+            if (!validateCsrfToken('gestionar_empleados', $csrfToken)) {
+                jsonOut(false, null, 'Token CSRF inválido.', 403);
+            }
+
             fetchEmployee($pdo, $id, $businessId);
 
             if ($accion === 'toggle') {

--- a/src/empleados.php
+++ b/src/empleados.php
@@ -16,6 +16,7 @@ if (session_status() === PHP_SESSION_NONE) session_start();
 require_once __DIR__ . '/includes/AppException.php';
 require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/auth_check.php';
+require_once __DIR__ . '/includes/csrf.php';
 require_once __DIR__ . '/middleware/RoleMiddleware.php';
 require_once __DIR__ . '/core/Session.php';
 
@@ -43,7 +44,8 @@ try {
     $error = 'Error al cargar los empleados.';
 }
 
-$sessionUserId = (int)($_SESSION['user_id'] ?? 0);
+$sessionUserId       = (int)($_SESSION['user_id'] ?? 0);
+$csrfTokenEmpleados  = generateCsrfToken('gestionar_empleados');
 ?>
 <!DOCTYPE html>
 <html lang="es">
@@ -86,6 +88,8 @@ $sessionUserId = (int)($_SESSION['user_id'] ?? 0);
 <body class="layout">
 
 <?php require_once __DIR__ . '/includes/_sidebar.php'; ?>
+
+<input type="hidden" id="csrfTokenEmpleados" value="<?= htmlspecialchars($csrfTokenEmpleados, ENT_QUOTES, 'UTF-8') ?>">
 
 <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
@@ -392,7 +396,11 @@ async function toggleEmpleado(id, activo, btn) {
     if (!confirm(`¿${activo ? 'Desactivar' : 'Activar'} este empleado?`)) return;
     btn.disabled = true;
     try {
-        const res  = await fetch(`api/empleados.php?id=${id}&accion=toggle`, { method: 'PATCH' });
+        const res  = await fetch(`api/empleados.php?id=${id}&accion=toggle`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ csrf_token: document.getElementById('csrfTokenEmpleados').value }),
+        });
         const json = await res.json();
         if (!json.success) {
             mostrarAlerta(json.message, 'danger');
@@ -415,7 +423,11 @@ async function toggleEmpleado(id, activo, btn) {
 async function resetPassword(id, name) {
     if (!confirm(`¿Resetear la contraseña de "${name}"? Se generará una contraseña aleatoria.`)) return;
     try {
-        const res  = await fetch(`api/empleados.php?id=${id}&accion=reset-password`, { method: 'PATCH' });
+        const res  = await fetch(`api/empleados.php?id=${id}&accion=reset-password`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ csrf_token: document.getElementById('csrfTokenEmpleados').value }),
+        });
         const json = await res.json();
         if (!json.success) {
             mostrarAlerta(json.message, 'danger');


### PR DESCRIPTION
## Problema

Los endpoints \PATCH api/empleados.php?accion=toggle\ y \PATCH api/empleados.php?accion=reset-password\ no tenían protección CSRF. Cualquier web maliciosa podía forzar al admin a activar/desactivar empleados o resetear contraseñas.

## Cambios

### \src/empleados.php\
- Añade \equire_once .../csrf.php\
- Genera \\ = generateCsrfToken('gestionar_empleados')\ antes del HTML
- Hidden input \#csrfTokenEmpleados\ en el body
- Ambas funciones JS (\	oggleEmpleado\, \esetPassword\) envían \csrf_token\ en el body JSON

### \src/api/empleados.php\
- Añade \equire_once .../csrf.php\
- Case PATCH: lee body, extrae y valida token con \alidateCsrfToken('gestionar_empleados', ...)\ antes de operar — retorna 403 si inválido

## Patrón de referencia
Mismo patrón ya existente en \src/usuarios.php\ + \src/api/usuarios.php\.

🤖 Generated with [Claude Code](https://claude.com/claude-code)