### PR TITLE
feat(security): CSRF protection on modelos_moto DELETE endpoint

### DIFF
--- a/src/api/modelos_moto.php
+++ b/src/api/modelos_moto.php
@@ -24,6 +24,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 
 require_once __DIR__ . '/../includes/AppException.php';
 require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/ModeloMoto.php';
 require_once __DIR__ . '/../includes/auth_check.php';
 
@@ -151,6 +152,12 @@ function handlePost(ModeloMoto $modelo): void
  */
 function handleDelete(ModeloMoto $modelo): void
 {
+    $body      = json_decode(file_get_contents('php://input'), true) ?? [];
+    $csrfToken = $body['csrf_token'] ?? '';
+    if (!validateCsrfToken('gestionar_modelos', $csrfToken)) {
+        jsonResponse(false, null, 'Token CSRF inválido.', 403);
+    }
+
     $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
     if (!$id) {
         throw new AppException('Se requiere el parámetro id.', 400);

--- a/src/modelos_moto.php
+++ b/src/modelos_moto.php
@@ -10,6 +10,7 @@
 require_once __DIR__ . '/includes/auth_check.php';
 require_once __DIR__ . '/includes/AppException.php';
 require_once __DIR__ . '/includes/Database.php';
+require_once __DIR__ . '/includes/csrf.php';
 require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/ModeloMoto.php';
 
@@ -19,8 +20,9 @@ if (!isAdmin()) {
     exit;
 }
 
-$error          = '';
-$stockBajoCount = 0;
+$error            = '';
+$stockBajoCount   = 0;
+$csrfTokenModelos = generateCsrfToken('gestionar_modelos');
 
 $modeloMotoModel = new ModeloMoto();
 try { $stockBajoCount = count((new Producto())->filtrarStockBajo()); } catch (\Throwable $e) {}
@@ -77,6 +79,8 @@ try {
 <body class="layout">
 
 <?php require_once __DIR__ . '/includes/_sidebar.php'; ?>
+
+<input type="hidden" id="csrfTokenModelos" value="<?= htmlspecialchars($csrfTokenModelos, ENT_QUOTES, 'UTF-8') ?>">
 
 <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
@@ -275,7 +279,11 @@ try {
 function confirmarEliminar(id) {
     if (!confirm('¿Seguro que quieres eliminar este modelo de moto?')) return;
 
-    fetch('api/modelos_moto.php?id=' + id, { method: 'DELETE' })
+    fetch('api/modelos_moto.php?id=' + id, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ csrf_token: document.getElementById('csrfTokenModelos').value }),
+    })
         .then(function(r) { return r.json(); })
         .then(function(json) {
             if (json.success) {


### PR DESCRIPTION
## Problema

\DELETE api/modelos_moto.php?id=X\ no tenía protección CSRF. Cualquier web maliciosa podía forzar al admin a eliminar modelos de moto.

## Cambios

### \src/modelos_moto.php\
- Añade \equire_once .../csrf.php\
- Genera \\ = generateCsrfToken('gestionar_modelos')\ antes del HTML
- Hidden input \#csrfTokenModelos\ en el body
- Fetch DELETE envía \csrf_token\ en body JSON con header \Content-Type: application/json\

### \src/api/modelos_moto.php\
- Añade \equire_once .../csrf.php\
- \handleDelete()\: lee body, valida token con \alidateCsrfToken('gestionar_modelos', ...)\ — retorna 403 si inválido, antes de cualquier operación DB

## Patrón de referencia
Mismo patrón ya mergeado en \src/api/usuarios.php\ (PR #43) y \src/api/empleados.php\ (PR #49).

🤖 Generated with [Claude Code](https://claude.com/claude-code)