### PR TITLE
fix(sidebar): highlight Pedidos nav on nuevo_pedido.php

### DIFF
--- a/src/includes/_sidebar.php
+++ b/src/includes/_sidebar.php
@@ -59,7 +59,7 @@ $sidebarBasePath ??= '';
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
                 <span class="nav-label">Proveedores</span>
             </a>
-            <a href="<?= $sidebarBasePath ?>pedidos.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'pedidos.php' ? 'active' : '' ?>">
+            <a href="<?= $sidebarBasePath ?>pedidos.php" class="nav-item <?= in_array(basename($_SERVER['PHP_SELF']), ['pedidos.php', 'nuevo_pedido.php']) ? 'active' : '' ?>">
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
                 <span class="nav-label">Pedidos</span>
             </a>


### PR DESCRIPTION
## Problema

El link «Pedidos» del sidebar no resaltaba al navegar a \
uevo_pedido.php\.
Inconsistente con «Productos» que ya usaba \in_array()\ para cubrir subpáginas.

## Cambio

\_sidebar.php\ — condición \ctive\ de Pedidos pasa de comparación simple a \in_array()\:

\\\php
// antes
basename(\['PHP_SELF']) === 'pedidos.php'

// después
in_array(basename(\['PHP_SELF']), ['pedidos.php', 'nuevo_pedido.php'])
\\\

🤖 Generated with [Claude Code](https://claude.com/claude-code)