### PR TITLE
feat(security): complete CSRF on empleados POST/PUT + perfil_empresa

### DIFF
--- a/src/api/empleados.php
+++ b/src/api/empleados.php
@@ -96,6 +96,11 @@ try {
         case 'POST':
             $body = json_decode(file_get_contents('php://input'), true) ?? [];
 
+            $csrfToken = $body['csrf_token'] ?? '';
+            if (!validateCsrfToken('gestionar_empleados', $csrfToken)) {
+                jsonOut(false, null, 'Token CSRF inválido.', 403);
+            }
+
             $name  = trim($body['name']  ?? '');
             $email = trim($body['email'] ?? '');
             $role  = $body['role']  ?? 'employee';
@@ -129,6 +134,12 @@ try {
             fetchEmployee($pdo, $id, $businessId);
 
             $body  = json_decode(file_get_contents('php://input'), true) ?? [];
+
+            $csrfToken = $body['csrf_token'] ?? '';
+            if (!validateCsrfToken('gestionar_empleados', $csrfToken)) {
+                jsonOut(false, null, 'Token CSRF inválido.', 403);
+            }
+
             $name  = trim($body['name']  ?? '');
             $email = trim($body['email'] ?? '');
             $role  = $body['role'] ?? 'employee';

--- a/src/api/perfil_empresa_info.php
+++ b/src/api/perfil_empresa_info.php
@@ -14,6 +14,7 @@ header('Content-Type: application/json; charset=utf-8');
 
 require_once __DIR__ . '/../includes/Database.php';
 require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/csrf.php';
 
 if (empty($_SESSION['business_id']) || empty($_SESSION['user_id']) || ($_SESSION['user_role'] ?? '') !== 'admin') {
     http_response_code(401);
@@ -25,6 +26,14 @@ $businessId = (int)$_SESSION['business_id'];
 
 try {
     $data  = json_decode(file_get_contents('php://input'), true) ?? $_POST;
+
+    $csrfToken = $data['csrf_token'] ?? '';
+    if (!validateCsrfToken('perfil_empresa', $csrfToken)) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Token CSRF inválido.']);
+        exit;
+    }
+
     $pdo   = Database::getInstance();
 
     $name    = trim($data['name'] ?? '');

--- a/src/api/perfil_empresa_logo.php
+++ b/src/api/perfil_empresa_logo.php
@@ -15,6 +15,7 @@ header('Content-Type: application/json; charset=utf-8');
 
 require_once __DIR__ . '/../includes/Database.php';
 require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../core/Settings.php';
 
 if (empty($_SESSION['business_id']) || empty($_SESSION['user_id']) || ($_SESSION['user_role'] ?? '') !== 'admin') {
@@ -28,12 +29,22 @@ $businessId = (int)$_SESSION['business_id'];
 try {
     $pdo = Database::getInstance();
 
-    // ── Eliminar logo ───────────────────────────────────────────
-    $isDelete = false;
-    if ($_SERVER['CONTENT_TYPE'] && str_contains($_SERVER['CONTENT_TYPE'], 'application/json')) {
-        $body     = json_decode(file_get_contents('php://input'), true) ?? [];
-        $isDelete = ($body['action'] ?? '') === 'delete';
+    // ── Leer body una sola vez y validar CSRF ───────────────────
+    $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
+    $jsonBody    = [];
+    if (str_contains($contentType, 'application/json')) {
+        $jsonBody = json_decode(file_get_contents('php://input'), true) ?? [];
     }
+    // FormData envía el token en $_POST; JSON lo envía en el body
+    $csrfToken = $_POST['csrf_token'] ?? $jsonBody['csrf_token'] ?? '';
+    if (!validateCsrfToken('perfil_empresa', $csrfToken)) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Token CSRF inválido.']);
+        exit;
+    }
+
+    // ── Eliminar logo ───────────────────────────────────────────
+    $isDelete = ($jsonBody['action'] ?? '') === 'delete';
 
     if ($isDelete) {
         $row = $pdo->prepare('SELECT logo_path FROM businesses WHERE id = ?');

--- a/src/api/perfil_empresa_password.php
+++ b/src/api/perfil_empresa_password.php
@@ -14,6 +14,7 @@ header('Content-Type: application/json; charset=utf-8');
 
 require_once __DIR__ . '/../includes/Database.php';
 require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/csrf.php';
 
 if (empty($_SESSION['business_id']) || empty($_SESSION['user_id'])) {
     http_response_code(401);
@@ -25,6 +26,14 @@ $employeeId = (int)$_SESSION['user_id'];
 
 try {
     $data    = json_decode(file_get_contents('php://input'), true) ?? $_POST;
+
+    $csrfToken = $data['csrf_token'] ?? '';
+    if (!validateCsrfToken('perfil_empresa', $csrfToken)) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Token CSRF inválido.']);
+        exit;
+    }
+
     $current = $data['current_password'] ?? '';
     $new     = $data['new_password']     ?? '';
 

--- a/src/api/perfil_empresa_theme.php
+++ b/src/api/perfil_empresa_theme.php
@@ -14,6 +14,7 @@ header('Content-Type: application/json; charset=utf-8');
 
 require_once __DIR__ . '/../includes/Database.php';
 require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/csrf.php';
 
 if (empty($_SESSION['business_id']) || empty($_SESSION['user_id']) || ($_SESSION['user_role'] ?? '') !== 'admin') {
     http_response_code(401);
@@ -25,6 +26,14 @@ $businessId = (int)$_SESSION['business_id'];
 
 try {
     $data  = json_decode(file_get_contents('php://input'), true) ?? $_POST;
+
+    $csrfToken = $data['csrf_token'] ?? '';
+    if (!validateCsrfToken('perfil_empresa', $csrfToken)) {
+        http_response_code(403);
+        echo json_encode(['success' => false, 'message' => 'Token CSRF inválido.']);
+        exit;
+    }
+
     $color = trim($data['theme_color'] ?? '');
 
     if (!preg_match('/^#[0-9A-Fa-f]{6}$/', $color)) {

--- a/src/empleados.php
+++ b/src/empleados.php
@@ -349,9 +349,10 @@ document.getElementById('formEmpleado').addEventListener('submit', async functio
 
     const id    = document.getElementById('empleadoId').value;
     const body  = {
-        name:     document.getElementById('inputNombre').value.trim(),
-        email:    document.getElementById('inputEmail').value.trim(),
-        role:     document.getElementById('inputRol').value,
+        name:       document.getElementById('inputNombre').value.trim(),
+        email:      document.getElementById('inputEmail').value.trim(),
+        role:       document.getElementById('inputRol').value,
+        csrf_token: document.getElementById('csrfTokenEmpleados').value,
     };
     if (!modoEdicion) body.password = document.getElementById('inputPassword').value;
 

--- a/src/perfil_empresa.php
+++ b/src/perfil_empresa.php
@@ -22,6 +22,7 @@ if (($_SESSION['user_role'] ?? '') !== 'admin') {
 }
 
 require_once __DIR__ . '/includes/Database.php';
+require_once __DIR__ . '/includes/csrf.php';
 require_once __DIR__ . '/includes/Producto.php';
 
 $businessId = (int)$_SESSION['business_id'];
@@ -43,6 +44,7 @@ if (!$business) {
 $themeColor  = $business['theme_color'] ?? '#4F46E5';
 $logoPath    = $business['logo_path']   ?? '';
 $maxUploadMb = 5;
+$csrfPerfil  = generateCsrfToken('perfil_empresa');
 try {
     require_once __DIR__ . '/core/Settings.php';
     $maxUploadMb = (int)\Settings::get('max_file_upload_mb', '5');
@@ -60,6 +62,8 @@ try {
 <body class="layout">
 
 <?php require_once __DIR__ . '/includes/_sidebar.php'; ?>
+
+<input type="hidden" id="csrfPerfil" value="<?= htmlspecialchars($csrfPerfil, ENT_QUOTES, 'UTF-8') ?>">
 
 <div class="sidebar-overlay" id="sidebarOverlay"></div>
 
@@ -239,7 +243,7 @@ async function apiPost(url, body, isFormData = false) {
         opts.body = body;
     } else {
         opts.headers = { 'Content-Type': 'application/json' };
-        opts.body    = JSON.stringify(body);
+        opts.body    = JSON.stringify({ ...body, csrf_token: document.getElementById('csrfPerfil').value });
     }
     const res  = await fetch(url, opts);
     return res.json();
@@ -280,6 +284,7 @@ async function uploadLogo() {
 
     const fd = new FormData();
     fd.append('logo', input.files[0]);
+    fd.append('csrf_token', document.getElementById('csrfPerfil').value);
 
     try {
         const json = await apiPost('api/perfil_empresa_logo.php', fd, true);


### PR DESCRIPTION
## Problema

Cobertura CSRF incompleta en dos áreas:

1. **empleados**: el fix anterior (#49) solo cubrió PATCH. Los endpoints POST (crear) y PUT (editar) seguían sin validación.
2. **perfil_empresa**: los 4 endpoints (info, password, theme, logo) aceptaban peticiones sin token.

## Cambios

### P1 — empleados
- **\empleados.php\**: añade \csrf_token\ al objeto \ody\ del submit handler (POST/PUT)
- **\pi/empleados.php\**: valida token en cases POST y PUT inmediatamente tras leer el body

### P2 — perfil_empresa
- **\perfil_empresa.php\**: require \csrf.php\, genera \\\, hidden input \#csrfPerfil\, \piPost()\ spread \csrf_token\ en todos los bodies JSON, \uploadLogo()\ append al FormData
- **\pi/perfil_empresa_info.php\**: require \csrf.php\ + validate
- **\pi/perfil_empresa_password.php\**: require \csrf.php\ + validate
- **\pi/perfil_empresa_theme.php\**: require \csrf.php\ + validate
- **\pi/perfil_empresa_logo.php\**: require \csrf.php\, lee \php://input\ una sola vez, token desde \\\ (multipart upload) o \\\ (JSON delete), valida antes de bifurcar

🤖 Generated with [Claude Code](https://claude.com/claude-code)