### PR TITLE
feat(security+ux): CSRF categorias/import + description + perfil info card

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -430,6 +430,11 @@ SET @col_cd = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEM
 SET @sql_cd = IF(@col_cd = 0, 'ALTER TABLE businesses ADD COLUMN custom_domain VARCHAR(255) NULL AFTER slug', 'SELECT 1');
 PREPARE stmt FROM @sql_cd; EXECUTE stmt; DEALLOCATE PREPARE stmt;
 
+-- Columna description en businesses
+SET @col_desc = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'businesses' AND COLUMN_NAME = 'description');
+SET @sql_desc = IF(@col_desc = 0, 'ALTER TABLE businesses ADD COLUMN description TEXT NULL AFTER address', 'SELECT 1');
+PREPARE stmt FROM @sql_desc; EXECUTE stmt; DEALLOCATE PREPARE stmt;
+
 -- Columna last_login en employees
 SET @col_ll = (SELECT COUNT(*) FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'employees' AND COLUMN_NAME = 'last_login');
 SET @sql_ll = IF(@col_ll = 0, 'ALTER TABLE employees ADD COLUMN last_login TIMESTAMP NULL DEFAULT NULL', 'SELECT 1');

--- a/src/api/perfil_empresa_info.php
+++ b/src/api/perfil_empresa_info.php
@@ -36,10 +36,11 @@ try {
 
     $pdo   = Database::getInstance();
 
-    $name    = trim($data['name'] ?? '');
-    $phone   = trim($data['phone'] ?? '');
-    $address = trim($data['address'] ?? '');
-    $email   = trim($data['contact_email'] ?? '');
+    $name        = trim($data['name']          ?? '');
+    $phone       = trim($data['phone']         ?? '');
+    $address     = trim($data['address']       ?? '');
+    $email       = trim($data['contact_email'] ?? '');
+    $description = trim($data['description']   ?? '');
 
     if (!$name) throw new AppException('El nombre es obligatorio.', 400);
     if ($email && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
@@ -47,8 +48,8 @@ try {
     }
 
     $pdo->prepare(
-        'UPDATE businesses SET name = ?, phone = ?, address = ?, contact_email = ? WHERE id = ?'
-    )->execute([$name, $phone ?: null, $address ?: null, $email ?: null, $businessId]);
+        'UPDATE businesses SET name = ?, phone = ?, address = ?, contact_email = ?, description = ? WHERE id = ?'
+    )->execute([$name, $phone ?: null, $address ?: null, $email ?: null, $description ?: null, $businessId]);
 
     $_SESSION['business_name'] = $name;
 

--- a/src/api/productos.php
+++ b/src/api/productos.php
@@ -30,6 +30,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 
 require_once __DIR__ . '/../includes/AppException.php';
 require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/Producto.php';
 
 /**
@@ -391,6 +392,12 @@ function requireAdmin(): void
 function handleImport(): void
 {
     requireAdmin();
+
+    $csrfToken = $_POST['csrf_token'] ?? '';
+    if (!validateCsrfToken('importar_productos', $csrfToken)) {
+        jsonResponse(false, null, 'Token CSRF inválido.', 403);
+    }
+
     require_once __DIR__ . '/../includes/ImportadorProductos.php';
 
     if (empty($_FILES['csv'])) {

--- a/src/categorias.php
+++ b/src/categorias.php
@@ -10,6 +10,7 @@
 require_once __DIR__ . '/includes/auth_check.php';
 require_once __DIR__ . '/includes/AppException.php';
 require_once __DIR__ . '/includes/Database.php';
+require_once __DIR__ . '/includes/csrf.php';
 require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/Categoria.php';
 
@@ -26,34 +27,40 @@ $flashSuccess = $_SESSION['flash_success'] ?? '';
 $flashError   = $_SESSION['flash_error']   ?? '';
 unset($_SESSION['flash_success'], $_SESSION['flash_error']);
 
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    try {
-        $postAccion = $_POST['accion'] ?? '';
+$csrfToken = generateCsrfToken('gestionar_categorias');
 
-        if ($postAccion === 'crear') {
-            $nombre      = trim($_POST['nombre']      ?? '');
-            $descripcion = trim($_POST['descripcion'] ?? '');
-            if ($nombre === '') throw new AppException('El nombre es obligatorio.', 400);
-            $categoriaModel->crear($nombre, $descripcion);
-            $_SESSION['flash_success'] = 'Categoría creada correctamente.';
-        } elseif ($postAccion === 'actualizar') {
-            $id          = (int) ($_POST['id'] ?? 0);
-            $nombre      = trim($_POST['nombre']      ?? '');
-            $descripcion = trim($_POST['descripcion'] ?? '');
-            if (!$id || $nombre === '') throw new AppException('Datos inválidos.', 400);
-            $categoriaModel->actualizar($id, $nombre, $descripcion);
-            $_SESSION['flash_success'] = 'Categoría actualizada correctamente.';
-        } elseif ($postAccion === 'eliminar') {
-            $id = (int) ($_POST['id'] ?? 0);
-            $categoriaModel->eliminar($id);
-            $_SESSION['flash_success'] = 'Categoría eliminada correctamente.';
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (!validateCsrfToken('gestionar_categorias', $_POST['csrf_token'] ?? '')) {
+        $flashError = 'Token de seguridad inválido. Recarga la página.';
+    } else {
+        try {
+            $postAccion = $_POST['accion'] ?? '';
+
+            if ($postAccion === 'crear') {
+                $nombre      = trim($_POST['nombre']      ?? '');
+                $descripcion = trim($_POST['descripcion'] ?? '');
+                if ($nombre === '') throw new AppException('El nombre es obligatorio.', 400);
+                $categoriaModel->crear($nombre, $descripcion);
+                $_SESSION['flash_success'] = 'Categoría creada correctamente.';
+            } elseif ($postAccion === 'actualizar') {
+                $id          = (int) ($_POST['id'] ?? 0);
+                $nombre      = trim($_POST['nombre']      ?? '');
+                $descripcion = trim($_POST['descripcion'] ?? '');
+                if (!$id || $nombre === '') throw new AppException('Datos inválidos.', 400);
+                $categoriaModel->actualizar($id, $nombre, $descripcion);
+                $_SESSION['flash_success'] = 'Categoría actualizada correctamente.';
+            } elseif ($postAccion === 'eliminar') {
+                $id = (int) ($_POST['id'] ?? 0);
+                $categoriaModel->eliminar($id);
+                $_SESSION['flash_success'] = 'Categoría eliminada correctamente.';
+            }
+            header('Location: categorias.php');
+            exit;
+        } catch (AppException $e) {
+            $error = $e->getMessage();
+        } catch (\Throwable $e) {
+            $error = 'Error inesperado: ' . $e->getMessage();
         }
-        header('Location: categorias.php');
-        exit;
-    } catch (AppException $e) {
-        $error = $e->getMessage();
-    } catch (\Throwable $e) {
-        $error = 'Error inesperado: ' . $e->getMessage();
     }
 }
 
@@ -172,6 +179,7 @@ try {
                     </div>
                     <div class="card-body">
                         <form method="POST">
+                            <input type="hidden" name="csrf_token" value="<?= generateCsrfToken('gestionar_categorias') ?>">
                             <input type="hidden" name="accion" value="<?= $editCat ? 'actualizar' : 'crear' ?>">
                             <?php if ($editCat): ?>
                                 <input type="hidden" name="id" value="<?= (int)$editCat['id'] ?>">
@@ -245,6 +253,7 @@ try {
                                         </a>
                                         <?php if ((int)$cat['total_productos'] === 0): ?>
                                         <form method="POST" style="display:inline;">
+                                            <input type="hidden" name="csrf_token" value="<?= generateCsrfToken('gestionar_categorias') ?>">
                                             <input type="hidden" name="accion" value="eliminar">
                                             <input type="hidden" name="id" value="<?= (int)$cat['id'] ?>">
                                             <button type="submit" class="action-btn action-btn-red" title="Eliminar categoría"

--- a/src/perfil_empresa.php
+++ b/src/perfil_empresa.php
@@ -101,6 +101,54 @@ try {
 
         <div style="display:grid;gap:1.5rem;max-width:720px;">
 
+            <!-- ── Datos de cuenta (solo lectura) ─────────────────── -->
+            <div class="card">
+                <div class="card-header">
+                    <h2 class="card-title">Datos de la cuenta</h2>
+                </div>
+                <div class="card-body">
+                    <div style="display:grid;grid-template-columns:1fr 1fr;gap:1rem;">
+                        <div>
+                            <span style="font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-muted);">Identificador (slug)</span>
+                            <p style="margin:.25rem 0 0;font-family:var(--font-mono,monospace);font-size:.9rem;color:var(--text-primary);"><?= htmlspecialchars($business['slug'], ENT_QUOTES, 'UTF-8') ?></p>
+                        </div>
+                        <div>
+                            <span style="font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-muted);">Estado</span>
+                            <p style="margin:.25rem 0 0;">
+                                <?php if ((int)$business['is_active']): ?>
+                                    <span class="badge" style="background:#d1fae5;color:#065f46;">Activo</span>
+                                <?php else: ?>
+                                    <span class="badge" style="background:#fee2e2;color:#991b1b;">Inactivo</span>
+                                <?php endif; ?>
+                            </p>
+                        </div>
+                        <div>
+                            <span style="font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-muted);">Plan actual</span>
+                            <p style="margin:.25rem 0 0;">
+                                <?php
+                                $planLabels = ['free' => 'Gratuito', 'basic' => 'Basic', 'pro' => 'Pro'];
+                                $planColors = ['free' => '#f1f5f9;color:#475569', 'basic' => '#dbeafe;color:#1e40af', 'pro' => '#ede9fe;color:#5b21b6'];
+                                $plan = $business['plan'] ?? 'free';
+                                ?>
+                                <span class="badge" style="background:<?= $planColors[$plan] ?? '#f1f5f9;color:#475569' ?>;"><?= $planLabels[$plan] ?? ucfirst($plan) ?></span>
+                            </p>
+                        </div>
+                        <div>
+                            <span style="font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-muted);">Expiración del plan</span>
+                            <p style="margin:.25rem 0 0;font-size:.9rem;color:var(--text-primary);">
+                                <?= $business['plan_expires_at'] ? date('d/m/Y', strtotime($business['plan_expires_at'])) : 'Sin fecha límite' ?>
+                            </p>
+                        </div>
+                        <div>
+                            <span style="font-size:.78rem;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:var(--text-muted);">Miembro desde</span>
+                            <p style="margin:.25rem 0 0;font-size:.9rem;color:var(--text-primary);">
+                                <?= $business['created_at'] ? date('d/m/Y', strtotime($business['created_at'])) : '—' ?>
+                            </p>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
             <!-- ── Información general ─────────────────────────────── -->
             <div class="card">
                 <div class="card-header">
@@ -124,10 +172,15 @@ try {
                         <input type="text" id="infoAddress" class="field-input"
                                value="<?= htmlspecialchars($business['address'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
                     </div>
-                    <div class="form-field" style="margin-bottom:1.25rem;">
+                    <div class="form-field" style="margin-bottom:1rem;">
                         <label class="field-label">Email de contacto</label>
                         <input type="email" id="infoEmail" class="field-input"
                                value="<?= htmlspecialchars($business['contact_email'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                    </div>
+                    <div class="form-field" style="margin-bottom:1.25rem;">
+                        <label class="field-label">Descripción del negocio</label>
+                        <textarea id="infoDescription" class="field-input" rows="3"
+                                  placeholder="Breve descripción de tu taller o negocio…"><?= htmlspecialchars($business['description'] ?? '', ENT_QUOTES, 'UTF-8') ?></textarea>
                     </div>
                     <button class="btn btn-primary" onclick="saveInfo()">Guardar información</button>
                 </div>
@@ -257,6 +310,7 @@ async function saveInfo() {
             phone:         document.getElementById('infoPhone').value.trim(),
             address:       document.getElementById('infoAddress').value.trim(),
             contact_email: document.getElementById('infoEmail').value.trim(),
+            description:   document.getElementById('infoDescription').value.trim(),
         });
         json.success ? showToast('Información guardada.') : showToast(json.message, 'error');
     } catch { showToast('Error de conexión.', 'error'); }

--- a/src/productos.php
+++ b/src/productos.php
@@ -10,6 +10,7 @@
 require_once __DIR__ . '/includes/auth_check.php';
 require_once __DIR__ . '/includes/AppException.php';
 require_once __DIR__ . '/includes/Database.php';
+require_once __DIR__ . '/includes/csrf.php';
 require_once __DIR__ . '/includes/Producto.php';
 require_once __DIR__ . '/includes/Categoria.php';
 require_once __DIR__ . '/includes/Marca.php';
@@ -17,6 +18,8 @@ require_once __DIR__ . '/includes/Marca.php';
 $flashSuccess = $_SESSION['flash_success'] ?? '';
 $flashError   = $_SESSION['flash_error']   ?? '';
 unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+$csrfImport = generateCsrfToken('importar_productos');
 
 $productos      = [];
 $categorias     = [];
@@ -429,6 +432,7 @@ $sortTh = function(string $campo, string $label) use ($filterQs, $ordenActivo): 
                     <span>Modo actualización (actualizar si la Ref ya existe)</span>
                 </label>
             </div>
+            <input type="hidden" id="csrfImport" value="<?= htmlspecialchars($csrfImport, ENT_QUOTES, 'UTF-8') ?>">
             <!-- Preview primeras 5 filas -->
             <div id="import-preview" style="display:none;margin-top:16px">
                 <h4 style="margin-bottom:8px">Vista previa (primeras 5 filas)</h4>
@@ -503,6 +507,7 @@ function importarCSV() {
     const formData = new FormData();
     formData.append('csv', file);
     formData.append('modo', modo);
+    formData.append('csrf_token', document.getElementById('csrfImport').value);
     const btn = document.getElementById('btn-importar');
     btn.disabled = true;
     btn.textContent = 'Importando…';


### PR DESCRIPTION
## P1 — CSRF categorias.php

Los 3 formularios POST (crear, editar, eliminar) carecian de proteccion.

- categorias.php: require csrf.php, genera csrfToken antes del bloque POST, valida con validateCsrfToken, todo el bloque de acciones en rama else. Error descriptivo si token invalido.
- Hidden csrf_token en el formulario crear/editar y en cada formulario inline de eliminar.

## P2 — CSRF importacion CSV

- productos.php: require csrf.php, genera csrfImport, hidden input csrfImport en el modal, importarCSV() hace formData.append antes del fetch.
- api/productos.php: require csrf.php, handleImport() valida token desde _POST antes de procesar el CSV.

## P3 — perfil_empresa: campo description + card de solo lectura

### Campo description
- database/schema.sql: ALTER condicional idempotente añade description TEXT NULL AFTER address en businesses
- api/perfil_empresa_info.php: description añadido al UPDATE
- perfil_empresa.php: textarea infoDescription bajo el email; saveInfo() envia el campo

### Card informativa (solo lectura)
Nueva card encima de Informacion general con: slug, estado badge, plan badge, expiracion, miembro desde.

Generated with Claude Code