### PR TITLE
fix(api/proveedores): fatal error + wildcard CORS + missing CSRF

### DIFF
--- a/src/api/proveedores.php
+++ b/src/api/proveedores.php
@@ -14,8 +14,9 @@
  * @author   Carlitos6712
  * @version  1.0.0
  */
+if (session_status() === PHP_SESSION_NONE) session_start();
+
 header('Content-Type: application/json; charset=utf-8');
-header('Access-Control-Allow-Origin: *');
 header('Access-Control-Allow-Methods: GET, POST, PUT, PATCH, OPTIONS');
 header('Access-Control-Allow-Headers: Content-Type');
 
@@ -24,10 +25,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
     exit;
 }
 
-session_start();
-
 require_once __DIR__ . '/../includes/AppException.php';
 require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/auth_check.php';
+require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/Auditoria.php';
 require_once __DIR__ . '/../includes/Proveedor.php';
 
@@ -118,7 +119,11 @@ function handleGet(Proveedor $modelo): void
  */
 function handlePost(Proveedor $modelo): void
 {
-    $body = json_decode(file_get_contents('php://input'), true) ?? [];
+    $body      = json_decode(file_get_contents('php://input'), true) ?? [];
+    $csrfToken = $body['csrf_token'] ?? '';
+    if (!validateCsrfToken('gestionar_proveedores', $csrfToken)) {
+        jsonResponse(false, null, 'Token CSRF inválido.', 403);
+    }
     if (trim($body['nombre'] ?? '') === '') {
         jsonResponse(false, ['errors' => ['nombre' => 'El nombre del proveedor es obligatorio.']], 'Errores de validación.', 400);
     }
@@ -139,7 +144,11 @@ function handlePut(Proveedor $modelo): void
     if (!$id) {
         throw new AppException('Se requiere el parámetro id.', 400);
     }
-    $body = json_decode(file_get_contents('php://input'), true) ?? [];
+    $body      = json_decode(file_get_contents('php://input'), true) ?? [];
+    $csrfToken = $body['csrf_token'] ?? '';
+    if (!validateCsrfToken('gestionar_proveedores', $csrfToken)) {
+        jsonResponse(false, null, 'Token CSRF inválido.', 403);
+    }
     $modelo->obtener($id);
     $ok = $modelo->actualizar($id, $body);
     jsonResponse($ok, null, $ok ? 'Proveedor actualizado.' : 'No se pudo actualizar.');
@@ -159,6 +168,11 @@ function handlePatch(Proveedor $modelo): void
     $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
     if (!$id) {
         throw new AppException('Se requiere el parámetro id.', 400);
+    }
+    $body      = json_decode(file_get_contents('php://input'), true) ?? [];
+    $csrfToken = $body['csrf_token'] ?? '';
+    if (!validateCsrfToken('gestionar_proveedores', $csrfToken)) {
+        jsonResponse(false, null, 'Token CSRF inválido.', 403);
     }
     $prov = $modelo->obtener($id);
     if ((int)$prov['activo'] === 1) {


### PR DESCRIPTION
## 3 bugs críticos corregidos

### 1. Fatal Error (500 en producción)
`requireAdmin()` llamaba a `isAdmin()` pero `auth_check.php` nunca se importaba.  
Cualquier POST/PUT/PATCH devolvía 500.  
**Fix:** `require_once auth_check.php` junto al resto de requires.  
También: `session_start()` movido antes de las cabeceras con guard `PHP_SESSION_NONE`.

### 2. CORS wildcard prohibido (CLAUDE.md §9)
`Access-Control-Allow-Origin: *` era innecesario — la app es session-based.  
**Fix:** línea eliminada.

### 3. CSRF ausente en escritura
`handlePost()`, `handlePut()`, `handlePatch()` leían el body pero no validaban token.  
**Fix:** require `csrf.php`, cada handler extrae `$body['csrf_token']` y llama  
`validateCsrfToken('gestionar_proveedores', ...)` → 403 si inválido.

### Nota frontend
`proveedores.php` usa form-POST HTML (no fetch/AJAX al API), por lo que no  
requiere cambios en el frontend para el token de la API REST.

Generated with Claude Code