### PR TITLE
fix(security+repo): CSRF+multi-tenant change_password, abs URL, gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Ignorar archivos de entorno (nunca commitear credenciales reales)
 .env
-.env.example
 .env.testing
 
 # Ignorar prompts internos y documentación de Claude Code (uso local)

--- a/src/api/change_password.php
+++ b/src/api/change_password.php
@@ -18,6 +18,7 @@ header('Content-Type: application/json; charset=utf-8');
 
 require_once __DIR__ . '/../includes/AppException.php';
 require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/csrf.php';
 require_once __DIR__ . '/../includes/Usuario.php';
 require_once __DIR__ . '/../includes/Auditoria.php';
 
@@ -35,10 +36,14 @@ function jsonResp(bool $success, mixed $data, string $message, int $status = 200
     exit;
 }
 
-// Solo usuarios autenticados
-if (empty($_SESSION['usuario_id'])) {
+// ── Control de acceso — soporta sesiones locales y multi-tenant ───────────────
+$userId         = (int) ($_SESSION['usuario_id'] ?? 0);
+$businessUserId = (int) ($_SESSION['user_id']    ?? 0);
+$isAuth         = $userId > 0 || ($businessUserId > 0 && !empty($_SESSION['business_id']));
+if (!$isAuth) {
     jsonResp(false, null, 'No autenticado.', 401);
 }
+$resolvedId = $userId > 0 ? $userId : $businessUserId;
 
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     jsonResp(false, null, 'Método no permitido.', 405);
@@ -46,6 +51,11 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 
 try {
     $body = json_decode(file_get_contents('php://input'), true) ?? [];
+
+    $csrfToken = $body['csrf_token'] ?? '';
+    if (!validateCsrfToken('cambiar_password_topbar', $csrfToken)) {
+        jsonResp(false, null, 'Token CSRF inválido.', 403);
+    }
 
     $passwordActual = $body['password_actual'] ?? '';
     $passwordNueva  = $body['password_nueva']  ?? '';
@@ -56,7 +66,7 @@ try {
 
     $model = new Usuario();
     $model->cambiarPassword(
-        (int) $_SESSION['usuario_id'],
+        $resolvedId,
         $passwordActual,
         $passwordNueva,
         Auditoria::instancia()

--- a/src/includes/topbar_user.php
+++ b/src/includes/topbar_user.php
@@ -41,6 +41,7 @@ $_tbPlanMeta = match ($_tbBizPlan) {
 };
 
 $_tbCsrfReturn = $_tbImperson ? generateCsrfToken('sa_return') : '';
+$csrfPwd       = generateCsrfToken('cambiar_password_topbar');
 ?>
 <?php if ($_tbImperson): ?>
 <style>
@@ -209,6 +210,7 @@ $_tbCsrfReturn = $_tbImperson ? generateCsrfToken('sa_return') : '';
         <div id="pwdMsg" style="display:none;padding:.75rem 1rem;border-radius:.5rem;font-size:.85rem;margin-bottom:1rem;"></div>
 
         <form id="formCambiarPassword" onsubmit="submitCambiarPassword(event)">
+            <input type="hidden" id="csrfPwd" value="<?= htmlspecialchars($csrfPwd, ENT_QUOTES, 'UTF-8') ?>">
             <div class="form-field" style="margin-bottom:.9rem;">
                 <label class="field-label">Contraseña actual</label>
                 <input type="password" id="pwdActual" name="password_actual" class="field-input" required>
@@ -298,10 +300,14 @@ async function submitCambiarPassword(e) {
     btn.textContent  = 'Cambiando…';
 
     try {
-        const res  = await fetch('api/change_password.php', {
+        const res  = await fetch('/api/change_password.php', {
             method:  'POST',
             headers: { 'Content-Type': 'application/json' },
-            body:    JSON.stringify({ password_actual: actual, password_nueva: nueva }),
+            body:    JSON.stringify({
+                password_actual: actual,
+                password_nueva:  nueva,
+                csrf_token:      document.getElementById('csrfPwd').value,
+            }),
         });
         const json = await res.json();
 


### PR DESCRIPTION
## P1 — api/change_password.php

**Bug 1 — Sin CSRF:** endpoint aceptaba POST sin validar token.
- require `csrf.php`
- `validateCsrfToken('cambiar_password_topbar', $body['csrf_token'] ?? '')` → 403 si inválido

**Bug 2 — Solo sesiones locales:** `empty($_SESSION['usuario_id'])` devolvía 401 a usuarios multi-tenant.
- Auth check soporta `usuario_id` (local) y `user_id`+`business_id` (tenant)
- `$resolvedId` selecciona el ID correcto según tipo de sesión
- `cambiarPassword($resolvedId, ...)` usa el ID resuelto

## P2 — topbar_user.php

**Bug 1 — URL relativa rota:** `fetch('api/change_password.php')` desde páginas en subdirectorios resolvía a `/soporte/api/...` → 404.
- Cambiado a `fetch('/api/change_password.php')` (ruta absoluta).

**Bug 2 — Sin CSRF en fetch:** body del fetch no incluía token.
- `generateCsrfToken('cambiar_password_topbar')` antes del HTML
- Hidden input `#csrfPwd` en el formulario
- `csrf_token: document.getElementById('csrfPwd').value` en el body JSON

## P3 — .gitignore

Eliminada la entrada `.env.example` — la plantilla pública debe permanecer tracked en el repo.

`php -l` → ✅ ambos archivos · `git ls-files .env.example` → ✅ tracked

Generated with Claude Code