### PR TITLE
feat(fase16): add Kits / Packs de productos module

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -243,6 +243,42 @@ SET @sql_prov = IF(@col_prov = 0,
     'SELECT 1');
 PREPARE stmt_prov FROM @sql_prov; EXECUTE stmt_prov; DEALLOCATE PREPARE stmt_prov;
 
+-- ─────────────────────────────────────────────────────────────────────────────
+-- Fase 16: Kits / Packs de productos
+-- ─────────────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS kits (
+    id          INT          AUTO_INCREMENT PRIMARY KEY,
+    nombre      VARCHAR(150) NOT NULL,
+    descripcion TEXT,
+    activo      TINYINT(1)   DEFAULT 1,
+    created_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    updated_at  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS kits_lineas (
+    id          INT  AUTO_INCREMENT PRIMARY KEY,
+    kit_id      INT  NOT NULL,
+    producto_id INT  NOT NULL,
+    cantidad    INT  NOT NULL DEFAULT 1,
+    UNIQUE KEY  uq_kit_producto (kit_id, producto_id),
+    FOREIGN KEY (kit_id)      REFERENCES kits(id)     ON DELETE CASCADE,
+    FOREIGN KEY (producto_id) REFERENCES productos(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Seed: 2 kits de ejemplo
+INSERT IGNORE INTO kits (id, nombre, descripcion) VALUES
+  (1, 'Kit Revisión Básica',      'Filtro de aceite + aceite motor 1L + filtro de aire. Mantenimiento estándar 6.000 km.'),
+  (2, 'Kit Frenos Completo',      'Pastillas delantera + pastillas trasera + líquido de frenos. Sustitución de frenos en taller.');
+
+-- Líneas del Kit 1 — se crean solo si los productos 1 y 2 existen
+INSERT IGNORE INTO kits_lineas (kit_id, producto_id, cantidad)
+SELECT 1, id, 1 FROM productos WHERE id IN (1, 2) AND deleted_at IS NULL;
+
+-- Líneas del Kit 2
+INSERT IGNORE INTO kits_lineas (kit_id, producto_id, cantidad)
+SELECT 2, id, 1 FROM productos WHERE id IN (3, 4) AND deleted_at IS NULL;
+
 -- -------------------------------------------------------------
 -- Tablas: pedidos y pedidos_lineas (Fase 13)
 -- -------------------------------------------------------------

--- a/src/api/kits.php
+++ b/src/api/kits.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * API REST para gestión de kits / packs de productos.
+ *
+ * Verbos:
+ *   GET                        → listar kits activos (con líneas si ?con_lineas=1)
+ *   GET ?id=X                  → obtener kit + líneas
+ *   GET ?id=X&lineas           → obtener solo líneas del kit
+ *   POST                       → crear kit (body JSON: {nombre, descripcion, lineas:[{producto_id,cantidad}]})
+ *   PUT  ?id=X                 → actualizar kit completo + líneas
+ *   PATCH ?id=X&toggle         → activar/desactivar kit
+ *
+ * @package  Es21Plus\Api
+ * @author   Carlitos6712
+ * @version  1.0.0
+ */
+header('Content-Type: application/json; charset=utf-8');
+header('Access-Control-Allow-Origin: *');
+header('Access-Control-Allow-Methods: GET, POST, PUT, PATCH, OPTIONS');
+header('Access-Control-Allow-Headers: Content-Type');
+
+if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
+    http_response_code(204);
+    exit;
+}
+
+require_once __DIR__ . '/../includes/AppException.php';
+require_once __DIR__ . '/../includes/Database.php';
+require_once __DIR__ . '/../includes/Auditoria.php';
+require_once __DIR__ . '/../includes/Kit.php';
+
+/**
+ * Envía respuesta JSON estándar y finaliza la ejecución.
+ *
+ * @param bool   $success Indica éxito o fallo.
+ * @param mixed  $data    Datos a retornar.
+ * @param string $message Mensaje descriptivo.
+ * @param int    $code    Código HTTP de respuesta.
+ * @return void
+ * @author Carlitos6712
+ */
+function jsonResponse(bool $success, mixed $data, string $message = '', int $code = 200): void
+{
+    http_response_code($code);
+    echo json_encode(['success' => $success, 'data' => $data, 'message' => $message], JSON_UNESCAPED_UNICODE);
+    exit;
+}
+
+try {
+    $modelo = new Kit();
+    $method = $_SERVER['REQUEST_METHOD'];
+
+    switch ($method) {
+        case 'GET':   handleGet($modelo);   break;
+        case 'POST':  handlePost($modelo);  break;
+        case 'PUT':   handlePut($modelo);   break;
+        case 'PATCH': handlePatch($modelo); break;
+        default:
+            jsonResponse(false, null, 'Método HTTP no permitido.', 405);
+    }
+} catch (AppException $e) {
+    jsonResponse(false, null, $e->getMessage(), $e->getCode() ?: 400);
+} catch (\Throwable $e) {
+    error_log('kits.php: ' . $e->getMessage());
+    jsonResponse(false, null, 'Error interno del servidor.', 500);
+}
+
+/**
+ * Maneja peticiones GET.
+ *
+ * @param Kit $modelo Instancia del modelo Kit.
+ * @return void
+ * @author Carlitos6712
+ */
+function handleGet(Kit $modelo): void
+{
+    $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+
+    if ($id) {
+        // Solo líneas
+        if (isset($_GET['lineas'])) {
+            jsonResponse(true, $modelo->getLineas($id));
+        }
+        // Kit completo + líneas
+        $kit           = $modelo->obtener($id);
+        $kit['lineas'] = $modelo->getLineas($id);
+        jsonResponse(true, $kit);
+    }
+
+    // Listar (con lineas si se pide)
+    $soloActivos = !isset($_GET['todos']);
+    $kits        = $modelo->listar($soloActivos);
+
+    if (isset($_GET['con_lineas'])) {
+        foreach ($kits as &$k) {
+            $k['lineas'] = $modelo->getLineas((int)$k['id']);
+        }
+        unset($k);
+    }
+
+    jsonResponse(true, $kits);
+}
+
+/**
+ * Maneja peticiones POST (crear kit).
+ *
+ * @param Kit $modelo Instancia del modelo Kit.
+ * @return void
+ * @author Carlitos6712
+ */
+function handlePost(Kit $modelo): void
+{
+    $body   = json_decode(file_get_contents('php://input'), true) ?? [];
+    $lineas = $body['lineas'] ?? [];
+    $id     = $modelo->crear($body, $lineas);
+    $kit    = $modelo->obtener($id);
+    $kit['lineas'] = $modelo->getLineas($id);
+    jsonResponse(true, $kit, 'Kit creado correctamente.', 201);
+}
+
+/**
+ * Maneja peticiones PUT (actualizar kit).
+ *
+ * @param Kit $modelo Instancia del modelo Kit.
+ * @return void
+ * @author Carlitos6712
+ */
+function handlePut(Kit $modelo): void
+{
+    $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+    if (!$id) {
+        jsonResponse(false, null, 'Parámetro id requerido.', 400);
+    }
+    $body   = json_decode(file_get_contents('php://input'), true) ?? [];
+    $lineas = $body['lineas'] ?? [];
+    $modelo->actualizar($id, $body, $lineas);
+    $kit = $modelo->obtener($id);
+    $kit['lineas'] = $modelo->getLineas($id);
+    jsonResponse(true, $kit, 'Kit actualizado correctamente.');
+}
+
+/**
+ * Maneja peticiones PATCH (toggle activo).
+ *
+ * @param Kit $modelo Instancia del modelo Kit.
+ * @return void
+ * @author Carlitos6712
+ */
+function handlePatch(Kit $modelo): void
+{
+    $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
+    if (!$id) {
+        jsonResponse(false, null, 'Parámetro id requerido.', 400);
+    }
+    if (!isset($_GET['toggle'])) {
+        jsonResponse(false, null, 'Acción PATCH no reconocida.', 400);
+    }
+    $nuevoEstado = $modelo->toggleActivo($id);
+    $estado      = $nuevoEstado ? 'activado' : 'desactivado';
+    jsonResponse(true, ['activo' => $nuevoEstado], "Kit {$estado} correctamente.");
+}

--- a/src/auditoria.php
+++ b/src/auditoria.php
@@ -196,6 +196,12 @@ $badgeAccion = [
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/buscar.php
+++ b/src/buscar.php
@@ -519,6 +519,12 @@ $hayFiltros = $termino !== '' || $categoriaId !== null || $marcaId !== null
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
             <a href="buscar.php" class="nav-item active">
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></span>
                 <span class="nav-label">Búsqueda</span>

--- a/src/categorias.php
+++ b/src/categorias.php
@@ -163,6 +163,12 @@ try {
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/editar_producto.php
+++ b/src/editar_producto.php
@@ -214,6 +214,12 @@ try {
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/eliminar_producto.php
+++ b/src/eliminar_producto.php
@@ -140,6 +140,12 @@ try {
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/empleados.php
+++ b/src/empleados.php
@@ -159,6 +159,12 @@ $sessionUserId = (int)($_SESSION['user_id'] ?? 0);
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/includes/Kit.php
+++ b/src/includes/Kit.php
@@ -1,0 +1,248 @@
+<?php
+require_once __DIR__ . '/AppException.php';
+require_once __DIR__ . '/Database.php';
+require_once __DIR__ . '/Auditoria.php';
+
+/**
+ * Gestión de kits / packs de productos del inventario.
+ *
+ * Un kit agrupa N productos con sus cantidades para registrar
+ * movimientos de salida en bloque desde la vista de movimientos.
+ *
+ * @package  Es21Plus\Includes
+ * @author   Carlitos6712
+ * @version  1.0.0
+ */
+class Kit
+{
+    private PDO       $pdo;
+    private Auditoria $auditoria;
+
+    /**
+     * @param PDO|null       $pdo       Conexión PDO inyectada (útil para tests con SQLite); si es null usa el singleton MySQL.
+     * @param Auditoria|null $auditoria Modelo de auditoría; si es null, se crea con la conexión activa.
+     * @throws AppException Si falla la conexión.
+     * @author Carlitos6712
+     */
+    public function __construct(?PDO $pdo = null, ?Auditoria $auditoria = null)
+    {
+        $this->pdo       = $pdo       ?? Database::getInstance();
+        $this->auditoria = $auditoria ?? new Auditoria($this->pdo);
+    }
+
+    /**
+     * Lista todos los kits con el número de líneas (productos) que contienen.
+     *
+     * @param bool $soloActivos true = solo activos (default), false = todos.
+     * @return array<int, array<string, mixed>>
+     * @author Carlitos6712
+     */
+    public function listar(bool $soloActivos = true): array
+    {
+        $where = $soloActivos ? " WHERE k.activo = 1" : "";
+        $stmt  = $this->pdo->prepare(
+            "SELECT k.*, COUNT(kl.id) AS total_lineas
+             FROM kits k
+             LEFT JOIN kits_lineas kl ON kl.kit_id = k.id
+             {$where}
+             GROUP BY k.id
+             ORDER BY k.nombre"
+        );
+        $stmt->execute();
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Obtiene un kit por su ID.
+     *
+     * @param int $id ID del kit.
+     * @throws AppException Si el kit no existe (404).
+     * @return array<string, mixed>
+     * @author Carlitos6712
+     */
+    public function obtener(int $id): array
+    {
+        $stmt = $this->pdo->prepare("SELECT * FROM kits WHERE id = :id");
+        $stmt->execute([':id' => $id]);
+        $row  = $stmt->fetch();
+        if (!$row) {
+            throw new AppException("Kit #{$id} no encontrado.", 404);
+        }
+        return $row;
+    }
+
+    /**
+     * Devuelve las líneas de un kit con nombre de producto y stock actual.
+     *
+     * @param int $kitId ID del kit.
+     * @return array<int, array<string, mixed>>
+     * @author Carlitos6712
+     */
+    public function getLineas(int $kitId): array
+    {
+        $stmt = $this->pdo->prepare(
+            "SELECT kl.id, kl.kit_id, kl.producto_id, kl.cantidad,
+                    p.nombre AS producto_nombre,
+                    p.codigo_ref,
+                    p.stock   AS stock_actual
+             FROM kits_lineas kl
+             JOIN productos p ON p.id = kl.producto_id
+             WHERE kl.kit_id = :kit_id
+             ORDER BY p.nombre"
+        );
+        $stmt->execute([':kit_id' => $kitId]);
+        return $stmt->fetchAll();
+    }
+
+    /**
+     * Crea un nuevo kit con sus líneas.
+     *
+     * @param array<string, mixed> $datos  Campos: nombre (oblig.), descripcion, activo.
+     * @param array<int, array{producto_id: int, cantidad: int}> $lineas Líneas del kit.
+     * @throws AppException Si el nombre está vacío o alguna línea es inválida.
+     * @return int ID del kit creado.
+     * @author Carlitos6712
+     */
+    public function crear(array $datos, array $lineas = []): int
+    {
+        $nombre = trim($datos['nombre'] ?? '');
+        if ($nombre === '') {
+            throw new AppException('El nombre del kit es obligatorio.', 422);
+        }
+        $descripcion = trim($datos['descripcion'] ?? '');
+        $activo      = isset($datos['activo']) ? (int)(bool)$datos['activo'] : 1;
+
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO kits (nombre, descripcion, activo) VALUES (:nombre, :descripcion, :activo)"
+        );
+        $stmt->execute([':nombre' => $nombre, ':descripcion' => $descripcion, ':activo' => $activo]);
+        $id = (int) $this->pdo->lastInsertId();
+
+        if (!empty($lineas)) {
+            $this->syncLineas($id, $lineas);
+        }
+
+        $this->auditarOperacion('crear', $id, null, compact('nombre', 'descripcion', 'activo'));
+        return $id;
+    }
+
+    /**
+     * Actualiza un kit existente y reemplaza sus líneas.
+     *
+     * @param int $id     ID del kit.
+     * @param array<string, mixed> $datos Campos a actualizar.
+     * @param array<int, array{producto_id: int, cantidad: int}> $lineas Nuevas líneas.
+     * @throws AppException Si el kit no existe o el nombre está vacío.
+     * @return bool
+     * @author Carlitos6712
+     */
+    public function actualizar(int $id, array $datos, array $lineas = []): bool
+    {
+        $anterior = $this->obtener($id);
+        $nombre      = trim($datos['nombre']      ?? $anterior['nombre']);
+        $descripcion = trim($datos['descripcion'] ?? $anterior['descripcion']);
+        $activo      = isset($datos['activo']) ? (int)(bool)$datos['activo'] : (int)$anterior['activo'];
+
+        if ($nombre === '') {
+            throw new AppException('El nombre del kit es obligatorio.', 422);
+        }
+
+        $stmt = $this->pdo->prepare(
+            "UPDATE kits SET nombre = :nombre, descripcion = :descripcion, activo = :activo WHERE id = :id"
+        );
+        $ok = $stmt->execute([':nombre' => $nombre, ':descripcion' => $descripcion, ':activo' => $activo, ':id' => $id]);
+
+        if (!empty($lineas)) {
+            $this->syncLineas($id, $lineas);
+        }
+
+        if ($ok) {
+            $this->auditarOperacion('actualizar', $id, $anterior, compact('nombre', 'descripcion', 'activo'));
+        }
+        return $ok;
+    }
+
+    /**
+     * Activa o desactiva un kit (toggle).
+     *
+     * @param int $id ID del kit.
+     * @throws AppException Si el kit no existe.
+     * @return bool Nuevo estado: true = activo, false = inactivo.
+     * @author Carlitos6712
+     */
+    public function toggleActivo(int $id): bool
+    {
+        $kit    = $this->obtener($id);
+        $nuevo  = $kit['activo'] ? 0 : 1;
+        $stmt   = $this->pdo->prepare("UPDATE kits SET activo = :activo WHERE id = :id");
+        $stmt->execute([':activo' => $nuevo, ':id' => $id]);
+        $this->auditarOperacion('actualizar', $id, $kit, ['activo' => $nuevo]);
+        return (bool) $nuevo;
+    }
+
+    /**
+     * Sincroniza las líneas de un kit: elimina las existentes y crea las nuevas.
+     *
+     * @param int $kitId  ID del kit.
+     * @param array<int, array{producto_id: int, cantidad: int}> $lineas Líneas nuevas.
+     * @throws AppException Si alguna línea tiene cantidad ≤ 0 o producto_id inválido.
+     * @return void
+     * @author Carlitos6712
+     */
+    public function syncLineas(int $kitId, array $lineas): void
+    {
+        $del  = $this->pdo->prepare("DELETE FROM kits_lineas WHERE kit_id = :kit_id");
+        $del->execute([':kit_id' => $kitId]);
+
+        if (empty($lineas)) {
+            return;
+        }
+
+        $ins = $this->pdo->prepare(
+            "INSERT INTO kits_lineas (kit_id, producto_id, cantidad) VALUES (:kit_id, :producto_id, :cantidad)"
+        );
+
+        foreach ($lineas as $linea) {
+            $productoId = (int)($linea['producto_id'] ?? 0);
+            $cantidad   = (int)($linea['cantidad']    ?? 0);
+
+            if ($productoId <= 0 || $cantidad <= 0) {
+                throw new AppException('Cada línea del kit debe tener producto_id y cantidad > 0.', 422);
+            }
+            $ins->execute([':kit_id' => $kitId, ':producto_id' => $productoId, ':cantidad' => $cantidad]);
+        }
+    }
+
+    /**
+     * Cuenta las líneas de un kit.
+     *
+     * @param int $kitId ID del kit.
+     * @return int
+     * @author Carlitos6712
+     */
+    public function contarLineas(int $kitId): int
+    {
+        $stmt = $this->pdo->prepare("SELECT COUNT(*) FROM kits_lineas WHERE kit_id = :kit_id");
+        $stmt->execute([':kit_id' => $kitId]);
+        return (int) $stmt->fetchColumn();
+    }
+
+    /**
+     * Registra una operación en el log de auditoría sin propagar errores.
+     *
+     * @param string     $accion   'crear' | 'actualizar' | 'eliminar'.
+     * @param int        $id       PK del kit.
+     * @param array|null $anterior Datos antes de la operación.
+     * @param array|null $nuevo    Datos después de la operación.
+     * @return void
+     * @author Carlitos6712
+     */
+    private function auditarOperacion(string $accion, int $id, ?array $anterior, ?array $nuevo): void
+    {
+        try {
+            $this->auditoria->registrar('kits', $id, $accion, $anterior, $nuevo);
+        } catch (\Throwable $e) {
+            error_log("Auditoria::kits: {$e->getMessage()}");
+        }
+    }
+}

--- a/src/index.php
+++ b/src/index.php
@@ -139,6 +139,12 @@ try {
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/kits.php
+++ b/src/kits.php
@@ -1,0 +1,497 @@
+<?php
+/**
+ * Gestión de kits / packs de productos — vista de administración.
+ *
+ * Permite crear, editar, activar/desactivar y consultar kits con sus líneas.
+ * Solo accesible para usuarios con rol 'admin'.
+ *
+ * @package  Es21Plus
+ * @author   Carlitos6712
+ * @version  1.0.0
+ */
+require_once __DIR__ . '/includes/auth_check.php';
+require_once __DIR__ . '/includes/AppException.php';
+require_once __DIR__ . '/includes/Database.php';
+require_once __DIR__ . '/includes/Auditoria.php';
+require_once __DIR__ . '/includes/Kit.php';
+require_once __DIR__ . '/includes/Producto.php';
+
+if (($_SESSION['rol'] ?? '') !== 'admin') {
+    header('Location: index.php');
+    exit;
+}
+
+$flashSuccess = $_SESSION['flash_success'] ?? '';
+$flashError   = $_SESSION['flash_error']   ?? '';
+unset($_SESSION['flash_success'], $_SESSION['flash_error']);
+
+$error    = '';
+$kits     = [];
+$productos = [];
+
+try {
+    $kitModel      = new Kit();
+    $productoModel = new Producto();
+    $kits          = $kitModel->listar(false);          // todos (activos + inactivos)
+    $productos     = $productoModel->listar();          // para selector en el modal
+} catch (AppException $e) {
+    $error = $e->getMessage();
+} catch (\Throwable $e) {
+    $error = 'Error inesperado: ' . $e->getMessage();
+}
+
+// Contar stock bajo para la topbar
+$stockBajoCount = 0;
+try {
+    $stockBajoCount = count((new Producto())->filtrarStockBajo());
+} catch (\Throwable) {}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Kits – es21plus</title>
+    <link rel="stylesheet" href="css/estilos.css">
+    <style>
+        .kit-lineas-preview { font-size:.82rem; color:#64748b; }
+        .linea-row { display:flex; gap:8px; align-items:center; margin-bottom:6px; }
+        .linea-row select { flex:1; }
+        .linea-row input[type=number] { width:70px; }
+        .btn-add-linea { font-size:.8rem; }
+        .badge-activo   { background:#dcfce7; color:#166534; padding:2px 8px; border-radius:999px; font-size:.78rem; }
+        .badge-inactivo { background:#fee2e2; color:#991b1b; padding:2px 8px; border-radius:999px; font-size:.78rem; }
+    </style>
+</head>
+<body class="layout">
+
+<!-- ===== SIDEBAR ===== -->
+<aside class="sidebar" id="sidebar">
+    <div class="sidebar-header">
+        <div class="sidebar-logo">
+            <svg class="logo-icon" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <circle cx="12" cy="12" r="3"/><path d="M12 1v4M12 19v4M4.22 4.22l2.83 2.83M16.95 16.95l2.83 2.83M1 12h4M19 12h4M4.22 19.78l2.83-2.83M16.95 7.05l2.83-2.83"/>
+            </svg>
+            <span class="logo-text">es21<strong>plus</strong></span>
+        </div>
+        <button class="sidebar-close" id="sidebarClose" aria-label="Cerrar menú">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+            </svg>
+        </button>
+    </div>
+    <nav class="sidebar-nav">
+        <div class="nav-section">
+            <span class="nav-section-label">Principal</span>
+            <a href="index.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg></span>
+                <span class="nav-label">Dashboard</span>
+            </a>
+            <a href="productos.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/></svg></span>
+                <span class="nav-label">Productos</span>
+            </a>
+            <a href="categorias.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/><line x1="7" y1="7" x2="7.01" y2="7"/></svg></span>
+                <span class="nav-label">Categorías</span>
+            </a>
+            <a href="marcas.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="8" r="6"/><path d="M15.477 12.89L17 22l-5-3-5 3 1.523-9.11"/></svg></span>
+                <span class="nav-label">Marcas</span>
+            </a>
+            <a href="modelos_moto.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="18" r="3"/><path d="M6 18H4a2 2 0 0 1-2-2v-5l2-5h13l2 5v7h-3M14 18H8"/></svg></span>
+                <span class="nav-label">Modelos de Moto</span>
+            </a>
+            <a href="proveedores.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9,22 9,12 15,12 15,22"/></svg></span>
+                <span class="nav-label">Proveedores</span>
+            </a>
+            <a href="pedidos.php" class="nav-item">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="1" y="3" width="15" height="13"/><polygon points="16 8 20 8 23 11 23 16 16 16 16 8"/><circle cx="5.5" cy="18.5" r="2.5"/><circle cx="18.5" cy="18.5" r="2.5"/></svg></span>
+                <span class="nav-label">Pedidos</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Operaciones</span>
+            <a href="movimientos.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
+                <span class="nav-label">Movimientos</span>
+            </a>
+            <a href="kits.php" class="nav-item active">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg></span>
+                <span class="nav-label">Kits</span>
+            </a>
+        </div>
+        <div class="nav-section">
+            <span class="nav-section-label">Administración</span>
+            <a href="auditoria.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/><line x1="16" y1="17" x2="8" y2="17"/><polyline points="10 9 9 9 8 9"/></svg></span>
+                <span class="nav-label">Auditoría</span>
+            </a>
+            <a href="usuarios.php" class="nav-item">
+                <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/></svg></span>
+                <span class="nav-label">Usuarios</span>
+            </a>
+        </div>
+    </nav>
+    <div class="sidebar-footer">
+        <div class="sidebar-user">
+            <div class="user-avatar-sm">CV</div>
+            <div class="sidebar-user-info">
+                <span class="user-name-sm">Carlos Vico</span>
+                <span class="user-role">Administrador</span>
+            </div>
+        </div>
+    </div>
+</aside>
+
+<div class="sidebar-overlay" id="sidebarOverlay"></div>
+
+<!-- ===== MAIN WRAPPER ===== -->
+<div class="main-wrapper">
+    <header class="topbar">
+        <div class="topbar-left">
+            <button class="menu-toggle" id="menuToggle" aria-label="Abrir menú">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/>
+                </svg>
+            </button>
+            <nav class="breadcrumb-nav">
+                <a href="index.php" class="breadcrumb-item">Inicio</a>
+                <span class="breadcrumb-sep">›</span>
+                <span class="breadcrumb-item active">Kits</span>
+            </nav>
+        </div>
+        <div class="topbar-right">
+            <?php if ($stockBajoCount > 0): ?>
+            <a href="productos.php" class="topbar-alert" title="<?= $stockBajoCount ?> producto(s) con stock bajo">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9"/><path d="M13.73 21a2 2 0 0 1-3.46 0"/>
+                </svg>
+                <span class="notif-badge"><?= $stockBajoCount ?></span>
+            </a>
+            <?php endif; ?>
+            <?php require_once __DIR__ . '/includes/topbar_user.php'; ?>
+        </div>
+    </header>
+
+    <main class="content">
+
+        <?php if ($flashSuccess): ?>
+        <div class="toast toast-success" data-autodismiss="4000">
+            <span class="toast-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg></span>
+            <div class="toast-content"><span class="toast-title">Éxito</span><span class="toast-message"><?= htmlspecialchars($flashSuccess, ENT_QUOTES, 'UTF-8') ?></span></div>
+            <button class="toast-close" aria-label="Cerrar">×</button>
+            <div class="toast-progress"></div>
+        </div>
+        <?php endif; ?>
+
+        <?php if ($flashError || $error): ?>
+        <div class="toast toast-error" data-autodismiss="6000">
+            <span class="toast-icon"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><circle cx="12" cy="12" r="10"/><line x1="12" y1="8" x2="12" y2="12"/><line x1="12" y1="16" x2="12.01" y2="16"/></svg></span>
+            <div class="toast-content"><span class="toast-title">Error</span><span class="toast-message"><?= htmlspecialchars($flashError ?: $error, ENT_QUOTES, 'UTF-8') ?></span></div>
+            <button class="toast-close" aria-label="Cerrar">×</button>
+            <div class="toast-progress"></div>
+        </div>
+        <?php endif; ?>
+
+        <!-- Page header -->
+        <div class="page-header">
+            <div class="page-header-info">
+                <h1 class="page-title">Kits / Packs de Productos</h1>
+                <p class="page-subtitle">Agrupa productos recurrentes para añadirlos en bloque a un movimiento de salida.</p>
+            </div>
+            <div class="page-actions">
+                <button class="btn-primary" onclick="abrirModalKit()">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+                    Nuevo Kit
+                </button>
+            </div>
+        </div>
+
+        <!-- Table -->
+        <div class="data-table-wrapper">
+            <?php if (empty($kits)): ?>
+            <div class="td-empty" style="padding:2.5rem;text-align:center;">
+                No hay kits definidos aún. Crea el primero con el botón "Nuevo Kit".
+            </div>
+            <?php else: ?>
+            <table class="data-table">
+                <thead>
+                    <tr>
+                        <th>#</th>
+                        <th>Nombre</th>
+                        <th>Descripción</th>
+                        <th>Líneas</th>
+                        <th>Estado</th>
+                        <th>Acciones</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <?php foreach ($kits as $kit): ?>
+                    <tr id="kit-row-<?= (int)$kit['id'] ?>">
+                        <td><span class="ref-code"><?= (int)$kit['id'] ?></span></td>
+                        <td><strong><?= htmlspecialchars($kit['nombre'], ENT_QUOTES, 'UTF-8') ?></strong></td>
+                        <td class="kit-lineas-preview"><?= htmlspecialchars(mb_substr($kit['descripcion'] ?? '–', 0, 80), ENT_QUOTES, 'UTF-8') ?></td>
+                        <td><span class="ref-code"><?= (int)$kit['total_lineas'] ?></span></td>
+                        <td>
+                            <?php if ($kit['activo']): ?>
+                                <span class="badge-activo">Activo</span>
+                            <?php else: ?>
+                                <span class="badge-inactivo">Inactivo</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <div style="display:flex;gap:6px;flex-wrap:wrap;">
+                                <button class="btn-ghost" style="padding:4px 10px;font-size:.8rem;"
+                                        onclick="editarKit(<?= (int)$kit['id'] ?>)">Editar</button>
+                                <button class="btn-ghost" style="padding:4px 10px;font-size:.8rem;"
+                                        onclick="toggleKit(<?= (int)$kit['id'] ?>, <?= $kit['activo'] ? 1 : 0 ?>)">
+                                    <?= $kit['activo'] ? 'Desactivar' : 'Activar' ?>
+                                </button>
+                                <button class="btn-ghost" style="padding:4px 10px;font-size:.8rem;"
+                                        onclick="verLineas(<?= (int)$kit['id'] ?>, '<?= htmlspecialchars(addslashes($kit['nombre']), ENT_QUOTES, 'UTF-8') ?>')">Ver líneas</button>
+                            </div>
+                        </td>
+                    </tr>
+                <?php endforeach; ?>
+                </tbody>
+            </table>
+            <?php endif; ?>
+        </div>
+
+    </main>
+</div>
+
+<!-- ===== MODAL CREAR / EDITAR KIT ===== -->
+<div id="modal-kit" style="display:none;position:fixed;inset:0;z-index:1000;background:rgba(0,0,0,.45);align-items:center;justify-content:center;">
+    <div style="background:#fff;border-radius:12px;padding:28px;width:min(680px,96vw);max-height:90vh;overflow-y:auto;box-shadow:0 8px 32px rgba(0,0,0,.25);">
+        <h2 id="modal-kit-title" style="margin:0 0 18px;font-size:1.1rem;">Nuevo Kit</h2>
+
+        <div class="form-field" style="margin-bottom:12px;">
+            <label class="field-label">Nombre <span class="field-required">*</span></label>
+            <input id="kit-nombre" class="field-input" type="text" maxlength="150" placeholder="Ej: Kit Revisión Básica">
+        </div>
+        <div class="form-field" style="margin-bottom:18px;">
+            <label class="field-label">Descripción</label>
+            <textarea id="kit-descripcion" class="field-input field-textarea" rows="2" placeholder="Descripción opcional del kit"></textarea>
+        </div>
+
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px;">
+            <strong style="font-size:.9rem;">Líneas del kit</strong>
+            <button type="button" class="btn-ghost btn-add-linea" onclick="agregarLinea()">+ Añadir producto</button>
+        </div>
+        <div id="lineas-container" style="margin-bottom:18px;"></div>
+
+        <div style="display:flex;gap:10px;justify-content:flex-end;">
+            <button class="btn-ghost" onclick="cerrarModalKit()">Cancelar</button>
+            <button class="btn-primary" onclick="guardarKit()">Guardar kit</button>
+        </div>
+    </div>
+</div>
+
+<!-- ===== MODAL VER LÍNEAS ===== -->
+<div id="modal-lineas" style="display:none;position:fixed;inset:0;z-index:1000;background:rgba(0,0,0,.45);align-items:center;justify-content:center;">
+    <div style="background:#fff;border-radius:12px;padding:28px;width:min(560px,96vw);max-height:80vh;overflow-y:auto;box-shadow:0 8px 32px rgba(0,0,0,.25);">
+        <h2 id="modal-lineas-title" style="margin:0 0 16px;font-size:1.1rem;">Líneas del kit</h2>
+        <div id="modal-lineas-body"></div>
+        <div style="text-align:right;margin-top:16px;">
+            <button class="btn-ghost" onclick="cerrarModalLineas()">Cerrar</button>
+        </div>
+    </div>
+</div>
+
+<!-- Datos PHP → JS -->
+<script>
+const PRODUCTOS_DISPONIBLES = <?= json_encode(
+    array_map(fn($p) => [
+        'id'     => (int)$p['id'],
+        'nombre' => $p['nombre'],
+        'stock'  => (int)$p['stock'],
+    ], $productos),
+    JSON_UNESCAPED_UNICODE
+) ?>;
+
+let kitEditandoId = null;
+
+/** Abre el modal para crear un nuevo kit. */
+function abrirModalKit() {
+    kitEditandoId = null;
+    document.getElementById('modal-kit-title').textContent = 'Nuevo Kit';
+    document.getElementById('kit-nombre').value      = '';
+    document.getElementById('kit-descripcion').value = '';
+    document.getElementById('lineas-container').innerHTML = '';
+    agregarLinea();
+    document.getElementById('modal-kit').style.display = 'flex';
+}
+
+/** Cierra el modal de kit. */
+function cerrarModalKit() {
+    document.getElementById('modal-kit').style.display = 'none';
+}
+
+/** Carga datos del kit y abre el modal en modo edición. */
+async function editarKit(id) {
+    try {
+        const res  = await fetch(`api/kits.php?id=${id}`);
+        const json = await res.json();
+        if (!json.success) throw new Error(json.message);
+        const kit  = json.data;
+
+        kitEditandoId = id;
+        document.getElementById('modal-kit-title').textContent = 'Editar Kit';
+        document.getElementById('kit-nombre').value      = kit.nombre;
+        document.getElementById('kit-descripcion').value = kit.descripcion ?? '';
+        document.getElementById('lineas-container').innerHTML = '';
+
+        (kit.lineas ?? []).forEach(l => agregarLinea(l.producto_id, l.cantidad));
+        if ((kit.lineas ?? []).length === 0) agregarLinea();
+
+        document.getElementById('modal-kit').style.display = 'flex';
+    } catch (err) {
+        alert('Error cargando kit: ' + err.message);
+    }
+}
+
+/** Añade una fila de línea al formulario del modal. */
+function agregarLinea(productoId = null, cantidad = 1) {
+    const container = document.getElementById('lineas-container');
+    const row       = document.createElement('div');
+    row.className   = 'linea-row';
+
+    const select = document.createElement('select');
+    select.className = 'field-input field-select';
+    select.innerHTML = '<option value="">— Seleccionar producto —</option>';
+    PRODUCTOS_DISPONIBLES.forEach(p => {
+        const opt   = document.createElement('option');
+        opt.value   = p.id;
+        opt.dataset.stock = p.stock;
+        opt.textContent   = `${p.nombre} (stock: ${p.stock})`;
+        if (p.id === productoId) opt.selected = true;
+        select.appendChild(opt);
+    });
+
+    const inputCant = document.createElement('input');
+    inputCant.type  = 'number';
+    inputCant.min   = '1';
+    inputCant.value = cantidad;
+    inputCant.className = 'field-input';
+    inputCant.style.width = '80px';
+
+    const btnDel = document.createElement('button');
+    btnDel.type  = 'button';
+    btnDel.textContent = '✕';
+    btnDel.className   = 'btn-ghost';
+    btnDel.style.cssText = 'padding:4px 8px;color:#ef4444;';
+    btnDel.onclick = () => row.remove();
+
+    row.appendChild(select);
+    row.appendChild(inputCant);
+    row.appendChild(btnDel);
+    container.appendChild(row);
+}
+
+/** Recoge las líneas del formulario. */
+function recogerLineas() {
+    const rows   = document.querySelectorAll('#lineas-container .linea-row');
+    const lineas = [];
+    let ok = true;
+    rows.forEach(row => {
+        const sel  = row.querySelector('select');
+        const cant = row.querySelector('input[type=number]');
+        if (!sel.value) return;
+        const prodId  = parseInt(sel.value);
+        const cantVal = parseInt(cant.value);
+        if (cantVal <= 0) { ok = false; return; }
+        lineas.push({ producto_id: prodId, cantidad: cantVal });
+    });
+    if (!ok) { alert('Las cantidades deben ser mayores a 0.'); return null; }
+    return lineas;
+}
+
+/** Envía la petición para crear o actualizar el kit. */
+async function guardarKit() {
+    const nombre      = document.getElementById('kit-nombre').value.trim();
+    const descripcion = document.getElementById('kit-descripcion').value.trim();
+    if (!nombre) { alert('El nombre del kit es obligatorio.'); return; }
+
+    const lineas = recogerLineas();
+    if (lineas === null) return;
+
+    const body   = { nombre, descripcion, lineas };
+    const isEdit = kitEditandoId !== null;
+    const url    = isEdit ? `api/kits.php?id=${kitEditandoId}` : 'api/kits.php';
+    const method = isEdit ? 'PUT' : 'POST';
+
+    try {
+        const res  = await fetch(url, { method, headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body) });
+        const json = await res.json();
+        if (!json.success) throw new Error(json.message);
+        cerrarModalKit();
+        window.location.reload();
+    } catch (err) {
+        alert('Error al guardar: ' + err.message);
+    }
+}
+
+/** Activa o desactiva un kit. */
+async function toggleKit(id, estadoActual) {
+    const accion = estadoActual ? 'desactivar' : 'activar';
+    if (!confirm(`¿Seguro que quieres ${accion} este kit?`)) return;
+    try {
+        const res  = await fetch(`api/kits.php?id=${id}&toggle`, { method: 'PATCH' });
+        const json = await res.json();
+        if (!json.success) throw new Error(json.message);
+        window.location.reload();
+    } catch (err) {
+        alert('Error: ' + err.message);
+    }
+}
+
+/** Muestra las líneas de un kit en el modal. */
+async function verLineas(id, nombre) {
+    document.getElementById('modal-lineas-title').textContent = `Líneas del kit: ${nombre}`;
+    document.getElementById('modal-lineas-body').innerHTML    = 'Cargando…';
+    document.getElementById('modal-lineas').style.display     = 'flex';
+    try {
+        const res  = await fetch(`api/kits.php?id=${id}&lineas`);
+        const json = await res.json();
+        if (!json.success) throw new Error(json.message);
+        const lineas = json.data;
+        if (!lineas.length) {
+            document.getElementById('modal-lineas-body').innerHTML = '<em>Este kit no tiene líneas.</em>';
+            return;
+        }
+        let html = '<table class="data-table"><thead><tr><th>Producto</th><th>Ref</th><th>Cantidad</th><th>Stock actual</th></tr></thead><tbody>';
+        lineas.forEach(l => {
+            const alerta = l.stock_actual < l.cantidad
+                ? ' <span style="color:#ef4444;font-size:.78rem;">⚠ stock insuficiente</span>'
+                : '';
+            html += `<tr>
+                <td>${escHtml(l.producto_nombre)}</td>
+                <td><span class="ref-code">${escHtml(l.codigo_ref ?? '–')}</span></td>
+                <td><strong>${l.cantidad}</strong></td>
+                <td>${l.stock_actual}${alerta}</td>
+            </tr>`;
+        });
+        html += '</tbody></table>';
+        document.getElementById('modal-lineas-body').innerHTML = html;
+    } catch (err) {
+        document.getElementById('modal-lineas-body').innerHTML = `<span style="color:#ef4444">Error: ${err.message}</span>`;
+    }
+}
+
+function cerrarModalLineas() {
+    document.getElementById('modal-lineas').style.display = 'none';
+}
+
+/** Escapa HTML para prevenir XSS. */
+function escHtml(str) {
+    return String(str ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+</script>
+
+<script src="js/app.js"></script>
+</body>
+</html>

--- a/src/marcas.php
+++ b/src/marcas.php
@@ -161,6 +161,12 @@ try {
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/modelos_moto.php
+++ b/src/modelos_moto.php
@@ -156,6 +156,12 @@ try {
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/movimientos.php
+++ b/src/movimientos.php
@@ -159,6 +159,12 @@ $balance  = $entradas - $salidas;
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>
@@ -329,10 +335,20 @@ $balance  = $entradas - $salidas;
 
                     <div class="form-field" style="margin-bottom:1rem;">
                         <label class="field-label" for="tipo">Tipo <span class="field-required">*</span></label>
-                        <select class="field-input field-select" id="tipo" name="tipo" required>
+                        <select class="field-input field-select" id="tipo" name="tipo" required onchange="onTipoChange()">
                             <option value="entrada">Entrada (suma stock)</option>
                             <option value="salida">Salida (resta stock)</option>
                         </select>
+                    </div>
+
+                    <!-- Selector de kit (solo visible en salidas) -->
+                    <div class="form-field" id="kit-selector-wrapper" style="margin-bottom:1rem;display:none;">
+                        <label class="field-label" for="kit-selector">Aplicar kit <span class="field-hint" style="font-weight:400">(opcional)</span></label>
+                        <select class="field-input field-select" id="kit-selector" onchange="onKitChange()">
+                            <option value="">— Sin kit —</option>
+                        </select>
+                        <div id="kit-aviso-stock" style="margin-top:6px;display:none;background:#fef3c7;border:1px solid #f59e0b;border-radius:6px;padding:8px 10px;font-size:.82rem;color:#92400e;"></div>
+                        <div id="kit-lineas-preview" style="margin-top:8px;display:none;"></div>
                     </div>
 
                     <div class="form-field" style="margin-bottom:1rem;">
@@ -471,6 +487,112 @@ $balance  = $entradas - $salidas;
 
 <script src="js/app.js"></script>
 <script>
+/* ===================================================================
+ * Kit selector — Aplicar kit en movimiento de salida
+ * @author Carlitos6712
+ * =================================================================== */
+
+let kitsDisponibles = [];
+
+/**
+ * Muestra u oculta el selector de kit según el tipo de movimiento.
+ * @returns {void}
+ */
+function onTipoChange() {
+    const tipo    = document.getElementById('tipo').value;
+    const wrapper = document.getElementById('kit-selector-wrapper');
+    if (tipo === 'salida') {
+        wrapper.style.display = '';
+        if (!kitsDisponibles.length) cargarKits();
+    } else {
+        wrapper.style.display = 'none';
+        limpiarKitUI();
+    }
+}
+
+/**
+ * Carga los kits activos desde la API y puebla el selector.
+ * @returns {Promise<void>}
+ */
+async function cargarKits() {
+    try {
+        const res  = await fetch('api/kits.php');
+        const json = await res.json();
+        if (!json.success) return;
+        kitsDisponibles = json.data ?? [];
+        const sel = document.getElementById('kit-selector');
+        kitsDisponibles.forEach(k => {
+            const opt = document.createElement('option');
+            opt.value       = k.id;
+            opt.textContent = k.nombre + (k.total_lineas ? ` (${k.total_lineas} productos)` : '');
+            sel.appendChild(opt);
+        });
+    } catch (_) { /* silencioso */ }
+}
+
+/**
+ * Carga las líneas del kit seleccionado, muestra advertencias de stock
+ * y rellena automáticamente las observaciones.
+ * @returns {Promise<void>}
+ */
+async function onKitChange() {
+    const kitId = document.getElementById('kit-selector').value;
+    limpiarKitUI();
+    if (!kitId) return;
+
+    try {
+        const res  = await fetch(`api/kits.php?id=${kitId}&lineas`);
+        const json = await res.json();
+        if (!json.success) return;
+        const lineas = json.data ?? [];
+
+        // Advertencias de stock insuficiente (no bloqueantes)
+        const sinStock = lineas.filter(l => l.stock_actual < l.cantidad);
+        const avisoDiv = document.getElementById('kit-aviso-stock');
+        if (sinStock.length) {
+            avisoDiv.style.display = '';
+            avisoDiv.innerHTML = '⚠ Stock insuficiente para: <strong>'
+                + sinStock.map(l => escHtml(l.producto_nombre)).join(', ')
+                + '</strong>. El movimiento se registrará igualmente, pero el stock quedará negativo.';
+        }
+
+        // Preview de líneas
+        const previewDiv = document.getElementById('kit-lineas-preview');
+        if (lineas.length) {
+            let html = '<table style="width:100%;font-size:.82rem;border-collapse:collapse;">';
+            html += '<thead><tr><th style="text-align:left;padding:3px 6px;background:#f1f5f9">Producto</th><th style="padding:3px 6px;background:#f1f5f9">Cant.</th><th style="padding:3px 6px;background:#f1f5f9">Stock</th></tr></thead><tbody>';
+            lineas.forEach(l => {
+                const warn = l.stock_actual < l.cantidad ? ' style="color:#ef4444"' : '';
+                html += `<tr><td style="padding:2px 6px"${warn}>${escHtml(l.producto_nombre)}</td><td style="padding:2px 6px;text-align:center">${l.cantidad}</td><td style="padding:2px 6px;text-align:center"${warn}>${l.stock_actual}</td></tr>`;
+            });
+            html += '</tbody></table>';
+            previewDiv.style.display = '';
+            previewDiv.innerHTML = html;
+        }
+
+        // Rellenar observaciones
+        const obs = document.getElementById('observaciones');
+        const kitNombre = kitsDisponibles.find(k => k.id == kitId)?.nombre ?? '';
+        if (!obs.value.trim()) {
+            obs.value = `Aplicar kit: ${kitNombre}`;
+        }
+
+    } catch (_) { /* silencioso */ }
+}
+
+/** Limpia la UI del kit selector. */
+function limpiarKitUI() {
+    document.getElementById('kit-aviso-stock').style.display   = 'none';
+    document.getElementById('kit-lineas-preview').style.display = 'none';
+    document.getElementById('kit-aviso-stock').innerHTML        = '';
+    document.getElementById('kit-lineas-preview').innerHTML     = '';
+}
+
+/** Escapa HTML para prevenir XSS. */
+function escHtml(str) {
+    return String(str ?? '').replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;');
+}
+
 /**
  * Descarga el CSV de movimientos respetando los filtros activos.
  * Pasa producto_id y tipo si están en la URL actual.

--- a/src/nuevo_pedido.php
+++ b/src/nuevo_pedido.php
@@ -168,6 +168,12 @@ try { $stockBajoCount = count($productoModel->filtrarStockBajo()); } catch (\Thr
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
     </nav>
     <div class="sidebar-footer">

--- a/src/nuevo_producto.php
+++ b/src/nuevo_producto.php
@@ -167,6 +167,12 @@ try {
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/pedidos.php
+++ b/src/pedidos.php
@@ -147,6 +147,12 @@ $esAdmin = ($_SESSION['rol'] ?? '') === 'admin';
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/perfil.php
+++ b/src/perfil.php
@@ -221,6 +221,12 @@ $rolLabel     = $rolSesion === 'admin' ? 'Administrador' : 'Operario';
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/productos.php
+++ b/src/productos.php
@@ -194,6 +194,12 @@ $sortTh = function(string $campo, string $label) use ($filterQs, $ordenActivo): 
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/proveedores.php
+++ b/src/proveedores.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 /**
  * Gestión CRUD de proveedores del inventario.
  *
@@ -185,6 +185,12 @@ if ($provSelId) {
                     </svg>
                 </span>
                 <span class="nav-label">Movimientos</span>
+            </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
             </a>
         </div>
         <div class="nav-section">

--- a/src/usuarios.php
+++ b/src/usuarios.php
@@ -164,6 +164,12 @@ $iniciales = mb_substr($iniciales, 0, 2);
                 </span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/src/ver_producto.php
+++ b/src/ver_producto.php
@@ -275,6 +275,12 @@ $imgRuta  = Producto::rutaImagen($producto['imagen'] ?? null);
                 <span class="nav-icon"><svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="23 6 13.5 15.5 8.5 10.5 1 18"/><polyline points="17 6 23 6 23 12"/></svg></span>
                 <span class="nav-label">Movimientos</span>
             </a>
+            <a href="kits.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'kits.php' ? 'active' : '' ?>">
+                <span class="nav-icon">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="2" y="7" width="20" height="14" rx="2"/><path d="M16 7V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v2"/><line x1="12" y1="12" x2="12" y2="16"/><line x1="10" y1="14" x2="14" y2="14"/></svg>
+                </span>
+                <span class="nav-label">Kits</span>
+            </a>
         </div>
         <div class="nav-section">
             <span class="nav-section-label">Administración</span>

--- a/tests/Integration/KitsApiTest.php
+++ b/tests/Integration/KitsApiTest.php
@@ -1,0 +1,209 @@
+<?php
+/**
+ * Integration tests for the kits API layer (MySQL).
+ *
+ * Tests verify: listing, create (with/without lineas), update,
+ * toggle activo (PATCH), getLineas, error handling.
+ *
+ * Requires a live MySQL connection (docker-compose DB).
+ *
+ * @package  Es21Plus\Tests\Integration
+ * @author   Carlitos6712
+ */
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+
+class KitsApiTest extends TestCase
+{
+    private Kit   $model;
+    private PDO   $pdo;
+    private array $createdKitIds     = [];
+    private array $createdProductoIds = [];
+
+    protected function setUp(): void
+    {
+        $this->model = new Kit();
+        $this->pdo   = Database::getInstance();
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->createdKitIds) {
+            $ids = implode(',', array_map('intval', $this->createdKitIds));
+            $this->pdo->exec("DELETE FROM kits_lineas WHERE kit_id IN ({$ids})");
+            $this->pdo->exec("DELETE FROM kits WHERE id IN ({$ids}) AND nombre LIKE 'INTTEST_%'");
+            $this->createdKitIds = [];
+        }
+        if ($this->createdProductoIds) {
+            $ids = implode(',', array_map('intval', $this->createdProductoIds));
+            $this->pdo->exec("DELETE FROM productos WHERE id IN ({$ids})");
+            $this->createdProductoIds = [];
+        }
+    }
+
+    /**
+     * Inserta un kit de prueba y registra el ID para tearDown.
+     *
+     * @param string $nombre
+     * @param array  $lineas
+     * @return int
+     * @author Carlitos6712
+     */
+    private function insertarKit(string $nombre = 'INTTEST_kit', array $lineas = []): int
+    {
+        $id = $this->model->crear(['nombre' => $nombre], $lineas);
+        $this->createdKitIds[] = $id;
+        return $id;
+    }
+
+    /**
+     * Inserta un producto mínimo de prueba.
+     *
+     * @param string $nombre
+     * @return int
+     * @author Carlitos6712
+     */
+    private function insertarProducto(string $nombre = 'INTTEST_producto'): int
+    {
+        $stmt = $this->pdo->prepare(
+            "INSERT INTO productos (nombre, stock, precio) VALUES (:nombre, 10, 1.00)"
+        );
+        $stmt->execute([':nombre' => $nombre]);
+        $id = (int) $this->pdo->lastInsertId();
+        $this->createdProductoIds[] = $id;
+        return $id;
+    }
+
+    // ── Tests ─────────────────────────────────────────────────────────────────
+
+    #[Test]
+    public function it_returns_kit_list_as_array(): void
+    {
+        $result = $this->model->listar(false);
+        $this->assertIsArray($result);
+    }
+
+    #[Test]
+    public function it_creates_kit_without_lineas(): void
+    {
+        $id = $this->insertarKit('INTTEST_kit_vacio');
+        $this->assertGreaterThan(0, $id);
+
+        $kit = $this->model->obtener($id);
+        $this->assertSame('INTTEST_kit_vacio', $kit['nombre']);
+    }
+
+    #[Test]
+    public function it_creates_kit_with_lineas(): void
+    {
+        $prodId = $this->insertarProducto('INTTEST_prod_kit');
+        $id     = $this->insertarKit('INTTEST_kit_con_lineas', [
+            ['producto_id' => $prodId, 'cantidad' => 3],
+        ]);
+
+        $lineas = $this->model->getLineas($id);
+        $this->assertCount(1, $lineas);
+        $this->assertSame($prodId, (int)$lineas[0]['producto_id']);
+        $this->assertSame(3,       (int)$lineas[0]['cantidad']);
+    }
+
+    #[Test]
+    public function it_throws_422_when_nombre_is_empty(): void
+    {
+        $this->expectException(AppException::class);
+        $this->expectExceptionCode(422);
+        $this->model->crear(['nombre' => '']);
+    }
+
+    #[Test]
+    public function it_throws_404_when_kit_not_found(): void
+    {
+        $this->expectException(AppException::class);
+        $this->expectExceptionCode(404);
+        $this->model->obtener(PHP_INT_MAX);
+    }
+
+    #[Test]
+    public function it_updates_kit_and_replaces_lineas(): void
+    {
+        $prod1 = $this->insertarProducto('INTTEST_prod_update1');
+        $prod2 = $this->insertarProducto('INTTEST_prod_update2');
+
+        $id = $this->insertarKit('INTTEST_kit_update', [
+            ['producto_id' => $prod1, 'cantidad' => 1],
+        ]);
+
+        $this->model->actualizar(
+            $id,
+            ['nombre' => 'INTTEST_kit_update_ok'],
+            [['producto_id' => $prod2, 'cantidad' => 5]]
+        );
+
+        $kit    = $this->model->obtener($id);
+        $lineas = $this->model->getLineas($id);
+
+        $this->assertSame('INTTEST_kit_update_ok', $kit['nombre']);
+        $this->assertCount(1, $lineas);
+        $this->assertSame($prod2, (int)$lineas[0]['producto_id']);
+    }
+
+    #[Test]
+    public function it_toggles_kit_activo(): void
+    {
+        $id     = $this->insertarKit('INTTEST_kit_toggle');
+        $kit    = $this->model->obtener($id);
+        $this->assertSame(1, (int)$kit['activo']);
+
+        $nuevo  = $this->model->toggleActivo($id);
+        $this->assertFalse($nuevo);
+
+        $kit2   = $this->model->obtener($id);
+        $this->assertSame(0, (int)$kit2['activo']);
+    }
+
+    #[Test]
+    public function it_lists_only_activos_by_default(): void
+    {
+        $activo   = $this->insertarKit('INTTEST_kit_list_activo');
+        $inactivo = $this->insertarKit('INTTEST_kit_list_inactivo');
+        $this->model->toggleActivo($inactivo); // → inactivo
+
+        $activos = $this->model->listar(true);
+        $ids     = array_column($activos, 'id');
+
+        $this->assertContains($activo,   array_map('intval', $ids));
+        $this->assertNotContains($inactivo, array_map('intval', $ids));
+    }
+
+    #[Test]
+    public function it_counts_lineas_correctly(): void
+    {
+        $p1 = $this->insertarProducto('INTTEST_cnt1');
+        $p2 = $this->insertarProducto('INTTEST_cnt2');
+        $id = $this->insertarKit('INTTEST_kit_count', [
+            ['producto_id' => $p1, 'cantidad' => 1],
+            ['producto_id' => $p2, 'cantidad' => 2],
+        ]);
+        $this->assertSame(2, $this->model->contarLineas($id));
+    }
+
+    #[Test]
+    public function it_syncs_lineas_replaces_old_ones(): void
+    {
+        $p1 = $this->insertarProducto('INTTEST_sync1');
+        $p2 = $this->insertarProducto('INTTEST_sync2');
+        $id = $this->insertarKit('INTTEST_kit_sync', [
+            ['producto_id' => $p1, 'cantidad' => 1],
+        ]);
+        $this->assertSame(1, $this->model->contarLineas($id));
+
+        $this->model->syncLineas($id, [
+            ['producto_id' => $p2, 'cantidad' => 3],
+        ]);
+        $this->assertSame(1, $this->model->contarLineas($id));
+
+        $lineas = $this->model->getLineas($id);
+        $this->assertSame($p2, (int)$lineas[0]['producto_id']);
+    }
+}

--- a/tests/Unit/KitTest.php
+++ b/tests/Unit/KitTest.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * Tests unitarios del modelo Kit con SQLite en memoria.
+ *
+ * @package  Es21Plus\Tests\Unit
+ * @author   Carlitos6712
+ */
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers Kit
+ */
+class KitTest extends TestCase
+{
+    private PDO     $pdo;
+    private Kit     $modelo;
+    private Auditoria $auditoria;
+
+    /** Crea la base de datos SQLite en memoria con las tablas necesarias. */
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+
+        $this->pdo->exec("
+            CREATE TABLE IF NOT EXISTS auditoria (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                tabla      TEXT    NOT NULL,
+                registro_id INTEGER NOT NULL,
+                accion     TEXT    NOT NULL,
+                datos_anteriores TEXT,
+                datos_nuevos     TEXT,
+                usuario    TEXT DEFAULT 'test',
+                ip         TEXT,
+                fecha      TEXT DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS productos (
+                id         INTEGER PRIMARY KEY AUTOINCREMENT,
+                nombre     TEXT    NOT NULL,
+                codigo_ref TEXT,
+                stock      INTEGER DEFAULT 0,
+                deleted_at TEXT
+            );
+            CREATE TABLE IF NOT EXISTS kits (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                nombre      TEXT    NOT NULL,
+                descripcion TEXT,
+                activo      INTEGER DEFAULT 1,
+                created_at  TEXT    DEFAULT CURRENT_TIMESTAMP,
+                updated_at  TEXT    DEFAULT CURRENT_TIMESTAMP
+            );
+            CREATE TABLE IF NOT EXISTS kits_lineas (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                kit_id      INTEGER NOT NULL,
+                producto_id INTEGER NOT NULL,
+                cantidad    INTEGER NOT NULL DEFAULT 1,
+                UNIQUE (kit_id, producto_id),
+                FOREIGN KEY (kit_id)      REFERENCES kits(id)     ON DELETE CASCADE,
+                FOREIGN KEY (producto_id) REFERENCES productos(id) ON DELETE CASCADE
+            );
+        ");
+
+        // Productos de prueba
+        $this->pdo->exec("
+            INSERT INTO productos (nombre, codigo_ref, stock) VALUES
+              ('Filtro de aceite', 'REF-001', 20),
+              ('Aceite motor 1L',  'REF-002', 10),
+              ('Pastillas delanteras', 'REF-003', 5);
+        ");
+
+        $this->auditoria = new Auditoria($this->pdo);
+        $this->modelo    = new Kit($this->pdo, $this->auditoria);
+    }
+
+    /** Listar retorna array vacío cuando no hay kits. */
+    public function testListarVacioInicialmente(): void
+    {
+        $this->assertSame([], $this->modelo->listar());
+    }
+
+    /** Crear kit sin líneas devuelve ID > 0. */
+    public function testCrearKitSinLineas(): void
+    {
+        $id = $this->modelo->crear(['nombre' => 'Kit de prueba']);
+        $this->assertGreaterThan(0, $id);
+    }
+
+    /** Crear kit con nombre vacío lanza AppException 422. */
+    public function testCrearKitNombreVacioLanzaExcepcion(): void
+    {
+        $this->expectException(AppException::class);
+        $this->expectExceptionCode(422);
+        $this->modelo->crear(['nombre' => '  ']);
+    }
+
+    /** Crear kit con líneas sincroniza correctamente. */
+    public function testCrearKitConLineas(): void
+    {
+        $lineas = [
+            ['producto_id' => 1, 'cantidad' => 2],
+            ['producto_id' => 2, 'cantidad' => 1],
+        ];
+        $id = $this->modelo->crear(['nombre' => 'Kit Revisión'], $lineas);
+
+        $this->assertSame(2, $this->modelo->contarLineas($id));
+    }
+
+    /** Obtener kit existente devuelve datos correctos. */
+    public function testObtenerKitExistente(): void
+    {
+        $id  = $this->modelo->crear(['nombre' => 'Kit Frenos', 'descripcion' => 'Desc.']);
+        $kit = $this->modelo->obtener($id);
+
+        $this->assertSame('Kit Frenos', $kit['nombre']);
+        $this->assertSame('Desc.',      $kit['descripcion']);
+        $this->assertSame(1,            (int)$kit['activo']);
+    }
+
+    /** Obtener kit inexistente lanza AppException 404. */
+    public function testObtenerKitInexistenteLanzaExcepcion(): void
+    {
+        $this->expectException(AppException::class);
+        $this->expectExceptionCode(404);
+        $this->modelo->obtener(9999);
+    }
+
+    /** getLineas devuelve las líneas con datos del producto. */
+    public function testGetLineas(): void
+    {
+        $id = $this->modelo->crear(
+            ['nombre' => 'Kit Test'],
+            [['producto_id' => 1, 'cantidad' => 3]]
+        );
+        $lineas = $this->modelo->getLineas($id);
+
+        $this->assertCount(1, $lineas);
+        $this->assertSame(1, (int)$lineas[0]['producto_id']);
+        $this->assertSame(3, (int)$lineas[0]['cantidad']);
+        $this->assertSame('Filtro de aceite', $lineas[0]['producto_nombre']);
+    }
+
+    /** Actualizar modifica nombre, descripcion y re-sincroniza líneas. */
+    public function testActualizarKit(): void
+    {
+        $id = $this->modelo->crear(
+            ['nombre' => 'Kit Original'],
+            [['producto_id' => 1, 'cantidad' => 1]]
+        );
+
+        $this->modelo->actualizar(
+            $id,
+            ['nombre' => 'Kit Actualizado', 'descripcion' => 'Nueva desc.'],
+            [['producto_id' => 2, 'cantidad' => 5]]
+        );
+
+        $kit    = $this->modelo->obtener($id);
+        $lineas = $this->modelo->getLineas($id);
+
+        $this->assertSame('Kit Actualizado', $kit['nombre']);
+        $this->assertCount(1, $lineas);
+        $this->assertSame(2, (int)$lineas[0]['producto_id']);
+        $this->assertSame(5, (int)$lineas[0]['cantidad']);
+    }
+
+    /** syncLineas con linea de cantidad 0 lanza AppException 422. */
+    public function testSyncLineasCantidadCeroLanzaExcepcion(): void
+    {
+        $id = $this->modelo->crear(['nombre' => 'Kit Cantidad Cero']);
+        $this->expectException(AppException::class);
+        $this->expectExceptionCode(422);
+        $this->modelo->syncLineas($id, [['producto_id' => 1, 'cantidad' => 0]]);
+    }
+
+    /** toggleActivo desactiva un kit activo y lo devuelve como false. */
+    public function testToggleActivoDesactiva(): void
+    {
+        $id    = $this->modelo->crear(['nombre' => 'Kit Toggle']);
+        $nuevo = $this->modelo->toggleActivo($id);
+
+        $this->assertFalse($nuevo);
+        $kit = $this->modelo->obtener($id);
+        $this->assertSame(0, (int)$kit['activo']);
+    }
+
+    /** toggleActivo vuelve a activar un kit inactivo. */
+    public function testToggleActivoReactiva(): void
+    {
+        $id = $this->modelo->crear(['nombre' => 'Kit Toggle2', 'activo' => 0]);
+        // Primero está inactivo; toggle lo activa
+        $nuevo = $this->modelo->toggleActivo($id);
+        $this->assertTrue($nuevo);
+    }
+
+    /** listar(false) incluye kits inactivos. */
+    public function testListarTodosIncluyeInactivos(): void
+    {
+        $this->modelo->crear(['nombre' => 'Kit Activo',   'activo' => 1]);
+        $this->modelo->crear(['nombre' => 'Kit Inactivo', 'activo' => 0]);
+
+        $todos   = $this->modelo->listar(false);
+        $activos = $this->modelo->listar(true);
+
+        $this->assertCount(2, $todos);
+        $this->assertCount(1, $activos);
+    }
+
+    /** contarLineas devuelve 0 para kit sin líneas. */
+    public function testContarLineasCero(): void
+    {
+        $id = $this->modelo->crear(['nombre' => 'Kit Vacío']);
+        $this->assertSame(0, $this->modelo->contarLineas($id));
+    }
+
+    /** syncLineas vacía líneas cuando se pasa array vacío. */
+    public function testSyncLineasVaciaLineas(): void
+    {
+        $id = $this->modelo->crear(
+            ['nombre' => 'Kit Con Lineas'],
+            [['producto_id' => 1, 'cantidad' => 2]]
+        );
+        $this->assertSame(1, $this->modelo->contarLineas($id));
+
+        $this->modelo->syncLineas($id, []);
+        $this->assertSame(0, $this->modelo->contarLineas($id));
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -29,3 +29,4 @@ require_once __DIR__ . '/../src/includes/ModeloMoto.php';
 require_once __DIR__ . '/../src/includes/Proveedor.php';
 require_once __DIR__ . '/../src/includes/Pedido.php';
 require_once __DIR__ . '/../src/includes/ImportadorProductos.php';
+require_once __DIR__ . '/../src/includes/Kit.php';


### PR DESCRIPTION
- database/schema.sql: add kits and kits_lineas tables; seed 2 example kits
- src/includes/Kit.php: CRUD model with Auditoria integration
- src/api/kits.php: REST API (GET/POST/PUT/PATCH toggle)
- src/kits.php: admin CRUD view with dynamic line editor and modals
- src/movimientos.php: Aplicar kit selector with stock warnings
- sidebar: Kits link in Operaciones for all authenticated users (17 pages)
- tests/Unit/KitTest.php: 14 unit tests with SQLite in-memory
- tests/Integration/KitsApiTest.php: 9 integration tests
- tests/bootstrap.php: add Kit.php require