### PR TITLE
feat(productos): exportar CSV, eliminación masiva y fix importación multi-tenant

### DIFF
--- a/src/api/productos.php
+++ b/src/api/productos.php
@@ -62,6 +62,10 @@ try {
                 break;
             }
             requireAdmin();
+            if (isset($_GET['action']) && $_GET['action'] === 'bulk_delete') {
+                handleBulkDelete($modelo);
+                break;
+            }
             handlePost($modelo);
             break;
         case 'PUT':    handlePut($modelo);    break;
@@ -371,12 +375,53 @@ function handleDelete(Producto $modelo): void
  * @return void
  * @author Carlitos6712
  */
+/**
+ * Elimina en bloque una lista de productos (soft-delete).
+ *
+ * Cuerpo JSON: { "ids": [1, 2, 3] }
+ *
+ * @param Producto $modelo Instancia del modelo.
+ * @return void
+ * @author Carlitos6712
+ */
+function handleBulkDelete(Producto $modelo): void
+{
+    $body = json_decode(file_get_contents('php://input'), true) ?? [];
+    $ids  = array_values(array_filter(
+        array_map('intval', $body['ids'] ?? []),
+        fn($id) => $id > 0
+    ));
+
+    if (empty($ids)) {
+        jsonResponse(false, null, 'No se han proporcionado IDs válidos.', 400);
+    }
+
+    $eliminados = 0;
+    $errores    = [];
+    foreach ($ids as $id) {
+        try {
+            $modelo->obtener($id);
+            $modelo->eliminar($id);
+            $eliminados++;
+        } catch (\Throwable $e) {
+            $errores[] = $id;
+        }
+    }
+
+    jsonResponse(
+        true,
+        ['eliminados' => $eliminados, 'errores' => $errores],
+        "{$eliminados} producto(s) eliminado(s)."
+    );
+}
+
 function requireAdmin(): void
 {
     if (session_status() === PHP_SESSION_NONE) {
         session_start();
     }
-    if (!isAdmin()) {
+    $rol = $_SESSION['user_role'] ?? $_SESSION['rol'] ?? '';
+    if (!in_array($rol, ['admin', 'superadmin'], true)) {
         jsonResponse(false, null, 'Acceso denegado.', 403);
     }
 }

--- a/src/exportar_csv.php
+++ b/src/exportar_csv.php
@@ -1,0 +1,254 @@
+<?php
+/**
+ * Exportación de productos a CSV con filtros y selección de columnas.
+ *
+ * Si se recibe ?exportar=1 genera y descarga el CSV directamente.
+ * En caso contrario muestra el formulario de configuración con preview.
+ *
+ * @package  Es21Plus
+ * @author   Carlitos6712
+ * @version  1.0.0
+ */
+require_once __DIR__ . '/includes/auth_check.php';
+require_once __DIR__ . '/middleware/RoleMiddleware.php';
+RoleMiddleware::requireAdmin();
+require_once __DIR__ . '/includes/AppException.php';
+require_once __DIR__ . '/includes/Database.php';
+require_once __DIR__ . '/includes/Producto.php';
+require_once __DIR__ . '/includes/Categoria.php';
+
+/** Columnas exportables: clave DB → etiqueta legible */
+const COLUMNAS_EXPORT = [
+    'nombre'          => 'Nombre',
+    'codigo_ref'      => 'Código ref.',
+    'categoria_nombre'=> 'Categoría',
+    'marca_nombre'    => 'Marca',
+    'precio'          => 'Precio (€)',
+    'stock'           => 'Stock',
+    'stock_minimo'    => 'Stock mínimo',
+    'descripcion'     => 'Descripción',
+    'proveedor'       => 'Proveedor',
+    'ubicacion'       => 'Ubicación',
+    'codigo_barras'   => 'Código barras',
+    'peso'            => 'Peso (g)',
+    'created_at'      => 'Fecha creación',
+];
+
+/** Columnas seleccionadas por defecto */
+const COLUMNAS_DEFAULT = ['nombre','codigo_ref','categoria_nombre','marca_nombre','precio','stock','stock_minimo'];
+
+$productoModel = new Producto();
+$categorias    = [];
+try {
+    $categorias = (new Categoria())->listar();
+} catch (\Throwable $e) {}
+
+// ── Recoger filtros (GET o POST) ──────────────────────────────────────────────
+$termino     = trim($_REQUEST['q']            ?? '');
+$categoriaId = ($_REQUEST['categoria_id']     ?? '') !== '' ? (int)$_REQUEST['categoria_id']  : null;
+$precioMin   = ($_REQUEST['precio_min']       ?? '') !== '' ? (float)$_REQUEST['precio_min']  : null;
+$precioMax   = ($_REQUEST['precio_max']       ?? '') !== '' ? (float)$_REQUEST['precio_max']  : null;
+$stockMin    = ($_REQUEST['stock_min']        ?? '') !== '' ? (int)$_REQUEST['stock_min']      : null;
+$stockMax    = ($_REQUEST['stock_max']        ?? '') !== '' ? (int)$_REQUEST['stock_max']      : null;
+$soloStockBajo = isset($_REQUEST['stock_bajo']) && $_REQUEST['stock_bajo'] === '1' ? true : null;
+$columnas    = $_REQUEST['columnas'] ?? COLUMNAS_DEFAULT;
+$columnas    = array_intersect($columnas, array_keys(COLUMNAS_EXPORT)); // whitelist
+if (empty($columnas)) {
+    $columnas = COLUMNAS_DEFAULT;
+}
+
+// ── Contar registros que coinciden ────────────────────────────────────────────
+$total = 0;
+try {
+    $total = $productoModel->contarFiltrados($termino ?: null, $categoriaId, $precioMin, $precioMax, $stockMin, $stockMax, $soloStockBajo);
+} catch (\Throwable $e) {}
+
+// ── DESCARGA CSV ──────────────────────────────────────────────────────────────
+if (isset($_GET['exportar']) && $_GET['exportar'] === '1') {
+    try {
+        $productos = $productoModel->listarPaginado(
+            1, 100000,
+            $termino ?: null, $categoriaId, $precioMin, $precioMax,
+            $stockMin, $stockMax, 'nombre_asc', $soloStockBajo
+        );
+    } catch (\Throwable $e) {
+        $_SESSION['flash_error'] = 'Error al exportar: ' . $e->getMessage();
+        header('Location: exportar_csv.php');
+        exit;
+    }
+
+    $filename = 'productos_' . date('Ymd_His') . '.csv';
+    header('Content-Type: text/csv; charset=utf-8');
+    header('Content-Disposition: attachment; filename="' . $filename . '"');
+    header('Cache-Control: no-cache, no-store, must-revalidate');
+
+    $fh = fopen('php://output', 'w');
+    // BOM UTF-8 para compatibilidad con Excel
+    fwrite($fh, "\xEF\xBB\xBF");
+
+    // Cabecera
+    $cabecera = array_map(fn($k) => COLUMNAS_EXPORT[$k], $columnas);
+    fputcsv($fh, $cabecera, ',', '"', '\\');
+
+    foreach ($productos as $p) {
+        $fila = [];
+        foreach ($columnas as $col) {
+            $val = $p[$col] ?? '';
+            // Formatear precio con 2 decimales
+            if ($col === 'precio') {
+                $val = number_format((float)$val, 2, '.', '');
+            }
+            // Recortar timestamp a solo fecha
+            if ($col === 'created_at' && $val) {
+                $val = substr($val, 0, 10);
+            }
+            $fila[] = $val;
+        }
+        fputcsv($fh, $fila, ',', '"', '\\');
+    }
+    fclose($fh);
+    exit;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Exportar CSV — es21plus</title>
+    <link rel="stylesheet" href="css/estilos.css">
+    <style>
+        body { background: #f1f5f9; min-height: 100vh; }
+        .csv-page    { max-width: 860px; margin: 0 auto; padding: 2rem 1rem; }
+        .csv-topbar  { display: flex; align-items: center; gap: 1rem; margin-bottom: 1.5rem; }
+        .csv-topbar h1 { font-size: 1.25rem; font-weight: 700; color: #1e293b; margin: 0; }
+        .csv-card    { background: #fff; border-radius: 8px; box-shadow: 0 1px 4px rgba(0,0,0,.1); padding: 2rem; }
+        .section-title { font-size: .9rem; font-weight: 700; color: #374151; margin: 0 0 .75rem; padding-bottom: .4rem; border-bottom: 1px solid #e5e7eb; }
+        .filters-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: .75rem; }
+        .field-group  { display: flex; flex-direction: column; gap: .3rem; }
+        .field-group label { font-size: .8rem; font-weight: 600; color: #374151; }
+        .field-group input,
+        .field-group select { padding: .4rem .65rem; border: 1px solid #d1d5db; border-radius: .375rem; font-size: .85rem; }
+        .cols-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(170px, 1fr)); gap: .4rem .75rem; margin-top: .5rem; }
+        .col-check { display: flex; align-items: center; gap: .4rem; font-size: .85rem; cursor: pointer; }
+        .col-check input { width: 15px; height: 15px; cursor: pointer; }
+        .preview-badge { display: inline-flex; align-items: center; gap: .4rem; background: #dbeafe; color: #1d4ed8; padding: .35rem .75rem; border-radius: 999px; font-size: .85rem; font-weight: 600; }
+        .action-bar { display: flex; justify-content: space-between; align-items: center; margin-top: 1.5rem; flex-wrap: wrap; gap: .75rem; }
+    </style>
+</head>
+<body>
+
+<?php require_once __DIR__ . '/includes/topbar_user.php'; ?>
+
+<div class="csv-page">
+
+    <div class="csv-topbar">
+        <a href="productos.php" style="display:inline-flex;align-items:center;gap:.4rem;text-decoration:none;font-size:.875rem;color:#374151;font-weight:600;">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="15 18 9 12 15 6"/></svg>
+            Volver a Productos
+        </a>
+        <h1>Exportar productos a CSV</h1>
+    </div>
+
+    <div class="csv-card">
+        <form method="GET" action="exportar_csv.php" id="exportForm">
+
+            <!-- ── Filtros ──────────────────────────────────────── -->
+            <p class="section-title">Filtros</p>
+            <div class="filters-grid">
+                <div class="field-group" style="grid-column:span 2;">
+                    <label for="q">Búsqueda (nombre / ref.)</label>
+                    <input type="text" id="q" name="q" value="<?= htmlspecialchars($termino, ENT_QUOTES, 'UTF-8') ?>" placeholder="Ej: pastilla, brembo…">
+                </div>
+                <div class="field-group">
+                    <label for="categoria_id">Categoría</label>
+                    <select id="categoria_id" name="categoria_id">
+                        <option value="">Todas</option>
+                        <?php foreach ($categorias as $cat): ?>
+                        <option value="<?= (int)$cat['id'] ?>" <?= $categoriaId === (int)$cat['id'] ? 'selected' : '' ?>>
+                            <?= htmlspecialchars($cat['nombre'], ENT_QUOTES, 'UTF-8') ?>
+                        </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="field-group">
+                    <label>
+                        <input type="checkbox" name="stock_bajo" value="1" <?= $soloStockBajo ? 'checked' : '' ?>>
+                        Solo stock bajo
+                    </label>
+                </div>
+                <div class="field-group">
+                    <label for="precio_min">Precio mín. (€)</label>
+                    <input type="number" id="precio_min" name="precio_min" step="0.01" min="0" value="<?= $precioMin !== null ? $precioMin : '' ?>">
+                </div>
+                <div class="field-group">
+                    <label for="precio_max">Precio máx. (€)</label>
+                    <input type="number" id="precio_max" name="precio_max" step="0.01" min="0" value="<?= $precioMax !== null ? $precioMax : '' ?>">
+                </div>
+                <div class="field-group">
+                    <label for="stock_min">Stock mín.</label>
+                    <input type="number" id="stock_min" name="stock_min" min="0" value="<?= $stockMin !== null ? $stockMin : '' ?>">
+                </div>
+                <div class="field-group">
+                    <label for="stock_max">Stock máx.</label>
+                    <input type="number" id="stock_max" name="stock_max" min="0" value="<?= $stockMax !== null ? $stockMax : '' ?>">
+                </div>
+            </div>
+
+            <!-- ── Columnas ─────────────────────────────────────── -->
+            <p class="section-title" style="margin-top:1.5rem;">Columnas a exportar</p>
+            <div style="display:flex;gap:.5rem;margin-bottom:.6rem;">
+                <button type="button" onclick="toggleAll(true)"  style="font-size:.78rem;background:none;border:none;color:#3b82f6;cursor:pointer;padding:0;">Seleccionar todas</button>
+                <span style="color:#d1d5db;">|</span>
+                <button type="button" onclick="toggleAll(false)" style="font-size:.78rem;background:none;border:none;color:#6b7280;cursor:pointer;padding:0;">Deseleccionar</button>
+            </div>
+            <div class="cols-grid">
+                <?php foreach (COLUMNAS_EXPORT as $key => $label): ?>
+                <label class="col-check">
+                    <input type="checkbox" name="columnas[]" value="<?= htmlspecialchars($key, ENT_QUOTES, 'UTF-8') ?>"
+                        <?= in_array($key, $columnas, true) ? 'checked' : '' ?>>
+                    <?= htmlspecialchars($label, ENT_QUOTES, 'UTF-8') ?>
+                </label>
+                <?php endforeach; ?>
+            </div>
+
+            <!-- ── Barra de acción ──────────────────────────────── -->
+            <div class="action-bar">
+                <div>
+                    <span class="preview-badge">
+                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+                        <span id="previewCount"><?= number_format($total) ?></span> producto<?= $total !== 1 ? 's' : '' ?> coinciden
+                    </span>
+                </div>
+                <div style="display:flex;gap:.75rem;align-items:center;">
+                    <button type="submit" name="noop" class="btn btn-secondary btn-sm" style="font-size:.82rem;">
+                        Actualizar filtros
+                    </button>
+                    <button type="submit" name="exportar" value="1" class="btn-primary" <?= $total === 0 ? 'disabled' : '' ?>>
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
+                            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/>
+                            <polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/>
+                        </svg>
+                        Descargar CSV (<?= number_format($total) ?>)
+                    </button>
+                </div>
+            </div>
+
+        </form>
+    </div><!-- .csv-card -->
+
+</div><!-- .csv-page -->
+
+<script>
+/**
+ * Marca o desmarca todas las casillas de columnas.
+ * @param {boolean} estado
+ */
+function toggleAll(estado) {
+    document.querySelectorAll('.cols-grid input[type=checkbox]').forEach(cb => {
+        cb.checked = estado;
+    });
+}
+</script>
+</body>
+</html>

--- a/src/importar_csv.php
+++ b/src/importar_csv.php
@@ -17,6 +17,7 @@ RoleMiddleware::requireAdmin();
 require_once __DIR__ . '/includes/AppException.php';
 require_once __DIR__ . '/includes/Database.php';
 require_once __DIR__ . '/includes/Categoria.php';
+require_once __DIR__ . '/core/Session.php';
 
 // ── Constantes ────────────────────────────────────────────────────────────────
 const CSV_MAX_BYTES  = 5 * 1024 * 1024; // 5 MB
@@ -88,9 +89,9 @@ if ($step === 1 && $_SERVER['REQUEST_METHOD'] === 'POST') {
             if ($bom !== "\xEF\xBB\xBF") {
                 rewind($fh);
             }
-            $headers = fgetcsv($fh, 0, $csvDelim) ?: [];
+            $headers = fgetcsv($fh, 0, $csvDelim, '"', '\\') ?: [];
             $count   = 0;
-            while (($row = fgetcsv($fh, 0, $csvDelim)) !== false && $count < 6) {
+            while (($row = fgetcsv($fh, 0, $csvDelim, '"', '\\')) !== false && $count < 6) {
                 $preview[] = $row;
                 $count++;
             }
@@ -147,9 +148,9 @@ if ($step === 2 && $_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($fh) {
                     $bom = fread($fh, 3);
                     if ($bom !== "\xEF\xBB\xBF") rewind($fh);
-                    $headers = fgetcsv($fh, 0, $csvDelim) ?: [];
+                    $headers = fgetcsv($fh, 0, $csvDelim, '"', '\\') ?: [];
                     $count = 0;
-                    while (($row = fgetcsv($fh, 0, $csvDelim)) !== false && $count < 6) {
+                    while (($row = fgetcsv($fh, 0, $csvDelim, '"', '\\')) !== false && $count < 6) {
                         $preview[] = $row;
                         $count++;
                     }
@@ -163,15 +164,18 @@ if ($step === 2 && $_SERVER['REQUEST_METHOD'] === 'POST') {
                     $catMap[mb_strtolower(trim($cat['nombre']))] = (int) $cat['id'];
                 }
 
-                $pdo = Database::getInstance();
+                $pdo        = Database::getInstance();
+                $businessId = Session::getBusinessId();
+                $bizCol     = $businessId !== null ? ', business_id' : '';
+                $bizVal     = $businessId !== null ? ', :biz_id'     : '';
                 $sql = "INSERT INTO productos
                             (nombre, descripcion, descripcion_larga, precio, stock, stock_minimo,
                              codigo_ref, marca, codigo_barras, url_proveedor, proveedor, ubicacion,
-                             peso, capacidad, longitud, anchura, diametro, alertas_email, categoria_id)
+                             peso, capacidad, longitud, anchura, diametro, alertas_email, categoria_id{$bizCol})
                         VALUES
                             (:nombre, :descripcion, :descripcion_larga, :precio, :stock, :stock_minimo,
                              :codigo_ref, :marca, :codigo_barras, :url_proveedor, :proveedor, :ubicacion,
-                             :peso, :capacidad, :longitud, :anchura, :diametro, :alertas_email, :categoria_id)";
+                             :peso, :capacidad, :longitud, :anchura, :diametro, :alertas_email, :categoria_id{$bizVal})";
                 $stmt = $pdo->prepare($sql);
 
                 $inserted = 0;
@@ -183,9 +187,9 @@ if ($step === 2 && $_SERVER['REQUEST_METHOD'] === 'POST') {
                 // Quitar BOM
                 $bom = fread($fh, 3);
                 if ($bom !== "\xEF\xBB\xBF") rewind($fh);
-                fgetcsv($fh, 0, $csvDelim); // saltar cabecera
+                fgetcsv($fh, 0, $csvDelim, '"', '\\'); // saltar cabecera
 
-                while (($row = fgetcsv($fh, 0, $csvDelim)) !== false) {
+                while (($row = fgetcsv($fh, 0, $csvDelim, '"', '\\')) !== false) {
                     $lineNum++;
                     $data = [
                         'nombre'            => '',
@@ -256,6 +260,9 @@ if ($step === 2 && $_SERVER['REQUEST_METHOD'] === 'POST') {
                         $params = [];
                         foreach ($data as $k => $v) {
                             $params[":$k"] = $v;
+                        }
+                        if ($businessId !== null) {
+                            $params[':biz_id'] = $businessId;
                         }
                         $stmt->execute($params);
                         $inserted++;

--- a/src/includes/ImportadorProductos.php
+++ b/src/includes/ImportadorProductos.php
@@ -17,14 +17,61 @@
 require_once __DIR__ . '/AppException.php';
 require_once __DIR__ . '/Database.php';
 require_once __DIR__ . '/Auditoria.php';
+require_once __DIR__ . '/../core/Session.php';
 
 class ImportadorProductos
 {
     private const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5 MB
     private const COLUMNAS = ['ref','nombre','categoria','marca','precio','stock','stock minimo','descripcion','proveedor','ubicacion'];
 
-    private PDO      $pdo;
+    /** Mapeo de variantes de nombre de columna → clave interna */
+    private const ALIAS_COLS = [
+        // ref / código de referencia
+        'ref'                     => 'ref',
+        'codigo_ref'              => 'ref',
+        'código ref.'             => 'ref',
+        'código ref'              => 'ref',
+        'codigo ref'              => 'ref',
+        'referencia'              => 'ref',
+        'código de referencia'    => 'ref',
+        'codigo de referencia'    => 'ref',
+        'sku'                     => 'ref',
+        // nombre
+        'nombre'                  => 'nombre',
+        'producto'                => 'nombre',
+        'name'                    => 'nombre',
+        // categoría
+        'categoria'               => 'categoria',
+        'categoría'               => 'categoria',
+        'categoria_nombre'        => 'categoria',
+        'category'                => 'categoria',
+        // marca
+        'marca'                   => 'marca',
+        'marca_nombre'            => 'marca',
+        'brand'                   => 'marca',
+        // precio
+        'precio'                  => 'precio',
+        'precio (€)'              => 'precio',
+        'price'                   => 'precio',
+        // stock
+        'stock'                   => 'stock',
+        // stock mínimo / minimo
+        'stock minimo'            => 'stock minimo',
+        'stock mínimo'            => 'stock minimo',
+        'stock_minimo'            => 'stock minimo',
+        // descripción
+        'descripcion'             => 'descripcion',
+        'descripción'             => 'descripcion',
+        // proveedor
+        'proveedor'               => 'proveedor',
+        // ubicación
+        'ubicacion'               => 'ubicacion',
+        'ubicación'               => 'ubicacion',
+    ];
+
+    private PDO       $pdo;
     private Auditoria $auditoria;
+    private ?int      $businessId;
 
     /**
      * @param PDO|null      $pdo       Conexión PDO (usa singleton si no se pasa).
@@ -33,8 +80,9 @@ class ImportadorProductos
      */
     public function __construct(?PDO $pdo = null, ?Auditoria $auditoria = null)
     {
-        $this->pdo       = $pdo       ?? Database::getInstance();
-        $this->auditoria = $auditoria ?? new Auditoria($this->pdo);
+        $this->pdo        = $pdo       ?? Database::getInstance();
+        $this->auditoria  = $auditoria ?? new Auditoria($this->pdo);
+        $this->businessId = Session::getBusinessId();
     }
 
     /**
@@ -82,7 +130,7 @@ class ImportadorProductos
         }
 
         // Leer cabecera
-        $cabeceraRaw = fgetcsv($handle, 0, ',');
+        $cabeceraRaw = fgetcsv($handle, 0, ',', '"', '\\');
         if ($cabeceraRaw === false || $cabeceraRaw === null) {
             fclose($handle);
             throw new AppException('El archivo CSV está vacío o mal formado.', 400);
@@ -91,8 +139,11 @@ class ImportadorProductos
         // Limpiar BOM UTF-8 de la primera columna
         $cabeceraRaw[0] = ltrim($cabeceraRaw[0], "\xEF\xBB\xBF");
 
-        // Normalizar cabeceras
-        $cabeceras = array_map(fn($c) => strtolower(trim($c)), $cabeceraRaw);
+        // Normalizar cabeceras aplicando alias
+        $cabeceras = array_map(function ($c) {
+            $key = strtolower(trim($c));
+            return self::ALIAS_COLS[$key] ?? $key;
+        }, $cabeceraRaw);
 
         // Validar columna mínima obligatoria
         if (!in_array('nombre', $cabeceras, true)) {
@@ -106,7 +157,7 @@ class ImportadorProductos
 
         // Leer todas las filas de datos
         $filas = [];
-        while (($fila = fgetcsv($handle, 0, ',')) !== false) {
+        while (($fila = fgetcsv($handle, 0, ',', '"', '\\')) !== false) {
             if ($fila === [null]) {
                 continue; // fila vacía
             }
@@ -202,11 +253,13 @@ class ImportadorProductos
                 }
 
                 // INSERT
+                $bizCol = $this->businessId !== null ? ', business_id' : '';
+                $bizVal = $this->businessId !== null ? ', :biz_id'     : '';
                 $stmt = $this->pdo->prepare(
-                    "INSERT INTO productos (nombre, descripcion, precio, stock, stock_minimo, codigo_ref, categoria_id, proveedor, ubicacion)
-                     VALUES (:nombre, :descripcion, :precio, :stock, :stock_minimo, :codigo_ref, :categoria_id, :proveedor, :ubicacion)"
+                    "INSERT INTO productos (nombre, descripcion, precio, stock, stock_minimo, codigo_ref, categoria_id, proveedor, ubicacion{$bizCol})
+                     VALUES (:nombre, :descripcion, :precio, :stock, :stock_minimo, :codigo_ref, :categoria_id, :proveedor, :ubicacion{$bizVal})"
                 );
-                $stmt->execute([
+                $params = [
                     ':nombre'       => $nombre,
                     ':descripcion'  => $descripcion,
                     ':precio'       => $precio,
@@ -216,7 +269,11 @@ class ImportadorProductos
                     ':categoria_id' => $categoriaId,
                     ':proveedor'    => $proveedor,
                     ':ubicacion'    => $ubicacion,
-                ]);
+                ];
+                if ($this->businessId !== null) {
+                    $params[':biz_id'] = $this->businessId;
+                }
+                $stmt->execute($params);
                 $insertados++;
             }
 
@@ -269,10 +326,15 @@ class ImportadorProductos
      */
     private function buscarPorRef(string $ref): ?int
     {
+        $bizWhere = $this->businessId !== null ? " AND business_id = :biz_id" : "";
         $stmt = $this->pdo->prepare(
-            "SELECT id FROM productos WHERE codigo_ref = :ref AND deleted_at IS NULL LIMIT 1"
+            "SELECT id FROM productos WHERE codigo_ref = :ref AND deleted_at IS NULL{$bizWhere} LIMIT 1"
         );
-        $stmt->execute([':ref' => $ref]);
+        $params = [':ref' => $ref];
+        if ($this->businessId !== null) {
+            $params[':biz_id'] = $this->businessId;
+        }
+        $stmt->execute($params);
         $row = $stmt->fetch();
         return $row ? (int)$row['id'] : null;
     }
@@ -289,10 +351,15 @@ class ImportadorProductos
         if (empty(trim($nombre))) {
             return null;
         }
+        $bizWhere = $this->businessId !== null ? " AND business_id = :biz_id" : "";
         $stmt = $this->pdo->prepare(
-            "SELECT id FROM categorias WHERE nombre = :nombre LIMIT 1"
+            "SELECT id FROM categorias WHERE nombre = :nombre{$bizWhere} LIMIT 1"
         );
-        $stmt->execute([':nombre' => trim($nombre)]);
+        $params = [':nombre' => trim($nombre)];
+        if ($this->businessId !== null) {
+            $params[':biz_id'] = $this->businessId;
+        }
+        $stmt->execute($params);
         $row = $stmt->fetch();
         return $row ? (int)$row['id'] : null;
     }

--- a/src/includes/_sidebar.php
+++ b/src/includes/_sidebar.php
@@ -80,6 +80,10 @@ $sidebarBasePath ??= '';
                 <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="17 8 12 3 7 8"/><line x1="12" y1="3" x2="12" y2="15"/></svg></span>
                 <span class="nav-label">Importar CSV</span>
             </a>
+            <a href="<?= $sidebarBasePath ?>exportar_csv.php" class="nav-item <?= basename($_SERVER['PHP_SELF']) === 'exportar_csv.php' ? 'active' : '' ?>">
+                <span class="nav-icon"><svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" y1="15" x2="12" y2="3"/></svg></span>
+                <span class="nav-label">Exportar CSV</span>
+            </a>
             <?php endif; ?>
         </div>
         <div class="nav-section">

--- a/src/productos.php
+++ b/src/productos.php
@@ -253,6 +253,16 @@ $sortTh = function(string $campo, string $label) use ($filterQs, $ordenActivo): 
             </select>
         </form>
 
+        <!-- Bulk action bar -->
+        <div id="bulk-bar" style="display:none;padding:.7rem 1rem;background:#eff6ff;border:1px solid #bfdbfe;border-radius:var(--radius-md);margin-bottom:.75rem;align-items:center;gap:1rem;flex-wrap:wrap;">
+            <span id="bulk-count" style="font-weight:600;color:#1d4ed8;font-size:.875rem;"></span>
+            <button type="button" onclick="eliminarSeleccionados()" class="btn btn-sm btn-danger" style="display:inline-flex;align-items:center;gap:.35rem;">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg>
+                Eliminar seleccionados
+            </button>
+            <button type="button" onclick="deseleccionarTodo()" class="btn btn-sm btn-ghost">Cancelar</button>
+        </div>
+
         <!-- Data table -->
         <div class="data-table-wrapper">
             <table class="data-table" id="tabla-productos">
@@ -277,7 +287,7 @@ $sortTh = function(string $campo, string $label) use ($filterQs, $ordenActivo): 
                         $inicial   = mb_strtoupper(mb_substr($p['nombre'], 0, 1, 'UTF-8'), 'UTF-8');
                     ?>
                     <tr class="<?= $esBajo ? 'row-low-stock' : '' ?>">
-                        <td class="td-check"><input type="checkbox" aria-label="Seleccionar fila"></td>
+                        <td class="td-check"><input type="checkbox" class="row-check" data-id="<?= (int)$p['id'] ?>" aria-label="Seleccionar fila"></td>
                         <td>
                             <span class="ref-code"><?= htmlspecialchars($p['codigo_ref'] ?? '–', ENT_QUOTES, 'UTF-8') ?></span>
                         </td>
@@ -521,6 +531,82 @@ function importarCSV() {
             document.getElementById('import-result').style.display = 'block';
         })
         .finally(() => { btn.disabled = false; btn.textContent = 'Importar'; });
+}
+</script>
+<script>
+/* ── Selección masiva y eliminación bulk ───────────────────────────────────── */
+
+const selectAll   = document.getElementById('selectAll');
+const tbodyProds  = document.getElementById('tbody-productos');
+const bulkBar     = document.getElementById('bulk-bar');
+const bulkCount   = document.getElementById('bulk-count');
+
+/**
+ * Actualiza la barra de acciones masivas según los checkboxes marcados.
+ */
+function actualizarBulkBar() {
+    const total   = document.querySelectorAll('.row-check').length;
+    const checked = document.querySelectorAll('.row-check:checked').length;
+    bulkBar.style.display    = checked > 0 ? 'flex' : 'none';
+    bulkCount.textContent    = `${checked} producto${checked !== 1 ? 's' : ''} seleccionado${checked !== 1 ? 's' : ''}`;
+    selectAll.checked        = checked === total && total > 0;
+    selectAll.indeterminate  = checked > 0 && checked < total;
+}
+
+/** Desmarca todos los checkboxes y oculta la barra. */
+function deseleccionarTodo() {
+    document.querySelectorAll('.row-check').forEach(cb => cb.checked = false);
+    selectAll.checked       = false;
+    selectAll.indeterminate = false;
+    bulkBar.style.display   = 'none';
+}
+
+if (selectAll) {
+    selectAll.addEventListener('change', function () {
+        document.querySelectorAll('.row-check').forEach(cb => cb.checked = this.checked);
+        actualizarBulkBar();
+    });
+}
+
+if (tbodyProds) {
+    tbodyProds.addEventListener('change', function (e) {
+        if (e.target.classList.contains('row-check')) {
+            actualizarBulkBar();
+        }
+    });
+}
+
+/**
+ * Elimina en bloque los productos seleccionados mediante la API.
+ * @returns {Promise<void>}
+ */
+async function eliminarSeleccionados() {
+    const ids = [...document.querySelectorAll('.row-check:checked')]
+        .map(cb => parseInt(cb.dataset.id, 10));
+    if (!ids.length) return;
+    if (!confirm(`¿Eliminar ${ids.length} producto${ids.length !== 1 ? 's' : ''}? Esta acción no se puede deshacer.`)) return;
+
+    try {
+        const res  = await fetch('api/productos.php?action=bulk_delete', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ ids })
+        });
+        const json = await res.json();
+        if (json.success) {
+            ids.forEach(id => {
+                const cb = document.querySelector(`.row-check[data-id="${id}"]`);
+                if (cb) cb.closest('tr').remove();
+            });
+            deseleccionarTodo();
+            // Recargar para actualizar paginación y contadores
+            window.location.reload();
+        } else {
+            alert('Error: ' + (json.message ?? 'Error desconocido'));
+        }
+    } catch {
+        alert('Error de red al eliminar.');
+    }
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary

- Nuevo módulo `exportar_csv.php`: filtros combinables, selección de columnas, descarga con BOM UTF-8
- `ImportadorProductos`: `ALIAS_COLS` aplicado en `procesar()` — reconoce `Código ref.` y otras variantes (fix round-trip export→import)
- Fix `business_id` ausente en INSERT de productos importados (no aparecían en el taller)
- Fix deprecation PHP 8.1 en `fgetcsv`/`fputcsv` (parámetro `$escape` explícito)
- `productos.php`: checkbox "seleccionar todo" + barra de eliminación masiva
- `api/productos.php`: endpoint `POST ?action=bulk_delete` + `requireAdmin()` sin depender de `isAdmin()` (fix error interno en contexto API)
- Sidebar: enlace a Exportar CSV

## Test plan

- [ ] Exportar CSV con filtros → verificar columnas y encoding en Excel
- [ ] Re-importar el CSV exportado → columna `Código ref.` reconocida correctamente
- [ ] Importar productos → aparecen en el taller correcto (business_id)
- [ ] Seleccionar varios productos → barra bulk aparece → eliminar → recarga sin los productos
- [ ] Usuario no-admin → bulk delete devuelve 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)