### PR TITLE
fix(auditoria): aislar registros por business_id en entornos multi-tenant

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -105,12 +105,14 @@ CREATE TABLE IF NOT EXISTS auditoria (
     id               BIGINT       AUTO_INCREMENT PRIMARY KEY,
     tabla            VARCHAR(50)  NOT NULL,
     registro_id      INT          NOT NULL,
-    accion           ENUM('crear','actualizar','eliminar') NOT NULL,
+    business_id      INT          NULL DEFAULT NULL,
+    accion           ENUM('crear','actualizar','eliminar','importacion_csv') NOT NULL,
     datos_anteriores JSON,
     datos_nuevos     JSON,
     usuario          VARCHAR(100) DEFAULT 'admin',
     ip               VARCHAR(45),
-    fecha            TIMESTAMP    DEFAULT CURRENT_TIMESTAMP
+    fecha            TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_auditoria_business (business_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
 -- -------------------------------------------------------------

--- a/src/includes/Auditoria.php
+++ b/src/includes/Auditoria.php
@@ -15,6 +15,7 @@
 
 require_once __DIR__ . '/AppException.php';
 require_once __DIR__ . '/Database.php';
+require_once __DIR__ . '/../core/Session.php';
 
 class Auditoria
 {
@@ -53,16 +54,18 @@ class Auditoria
         ?array $datosAnteriores,
         ?array $datosNuevos
     ): void {
-        $ip = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+        $ip         = $_SERVER['REMOTE_ADDR'] ?? '127.0.0.1';
+        $businessId = Session::getBusinessId();
 
         $stmt = $this->pdo->prepare(
             "INSERT INTO auditoria
-             (tabla, registro_id, accion, datos_anteriores, datos_nuevos, ip)
-             VALUES (:tabla, :registro_id, :accion, :datos_anteriores, :datos_nuevos, :ip)"
+             (tabla, registro_id, business_id, accion, datos_anteriores, datos_nuevos, ip)
+             VALUES (:tabla, :registro_id, :business_id, :accion, :datos_anteriores, :datos_nuevos, :ip)"
         );
         $stmt->execute([
             ':tabla'            => $tabla,
             ':registro_id'      => $registroId,
+            ':business_id'      => $businessId,
             ':accion'           => $accion,
             ':datos_anteriores' => $datosAnteriores !== null
                 ? json_encode($datosAnteriores, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
@@ -151,9 +154,16 @@ class Auditoria
         ?string $fechaHasta,
         bool $contar = false
     ): array {
-        $select = $contar ? "SELECT COUNT(*) FROM auditoria" : "SELECT * FROM auditoria";
-        $where  = [];
-        $params = [];
+        $select     = $contar ? "SELECT COUNT(*) FROM auditoria" : "SELECT * FROM auditoria";
+        $where      = [];
+        $params     = [];
+        $businessId = Session::getBusinessId();
+
+        // Superadmin sin business_id ve todo; cualquier otro taller solo sus registros
+        if ($businessId !== null) {
+            $where[]              = "business_id = :business_id";
+            $params[':business_id'] = $businessId;
+        }
 
         if ($tabla !== null && $tabla !== '') {
             $where[]         = "tabla = :tabla";


### PR DESCRIPTION
## Summary

- Nueva columna `business_id` en tabla `auditoria` + índice
- `Auditoria::registrar()` guarda `Session::getBusinessId()` automáticamente en cada registro
- `Auditoria::construirQuery()` filtra `WHERE business_id = X` — cada taller solo ve sus acciones
- Superadmin (sin `business_id` en sesión) sigue viendo todos los registros
- Backfill ejecutado: registros existentes con `NULL` asignados cruzando con `productos`/`categorias`

## Test plan

- [ ] Taller A hace acción → solo aparece en auditoría de Taller A
- [ ] Taller B no ve acciones de Taller A
- [ ] Superadmin ve registros de todos los talleres
- [ ] Registros históricos (pre-migración) correctamente asignados por backfill

🤖 Generated with [Claude Code](https://claude.com/claude-code)