### PR TITLE
fix(tests): añadir business_id al schema SQLite en todos los unit tests

### DIFF
--- a/tests/Unit/AuditoriaTest.php
+++ b/tests/Unit/AuditoriaTest.php
@@ -32,6 +32,7 @@ class AuditoriaTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )
         ");

--- a/tests/Unit/BusquedaTest.php
+++ b/tests/Unit/BusquedaTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para el query builder de búsqueda avanzada.
  *
@@ -52,6 +52,7 @@ class BusquedaTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )
         ");

--- a/tests/Unit/CategoriaTest.php
+++ b/tests/Unit/CategoriaTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para el modelo Categoria.
  *
@@ -52,6 +52,7 @@ class CategoriaTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )
         ");

--- a/tests/Unit/ImagenTest.php
+++ b/tests/Unit/ImagenTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para la validación y gestión de imágenes de producto.
  *
@@ -56,6 +56,7 @@ class ImagenTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )
         ");

--- a/tests/Unit/MovimientoExportTest.php
+++ b/tests/Unit/MovimientoExportTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para el método listarParaExportar del modelo Movimiento.
  *
@@ -61,6 +61,7 @@ class MovimientoExportTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )
         ");

--- a/tests/Unit/MovimientoTest.php
+++ b/tests/Unit/MovimientoTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para el modelo Movimiento.
  *
@@ -60,6 +60,7 @@ class MovimientoTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )
         ");

--- a/tests/Unit/PedidoTest.php
+++ b/tests/Unit/PedidoTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para el modelo Pedido.
  *
@@ -52,6 +52,7 @@ class PedidoTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )"
         );

--- a/tests/Unit/ProductoImportTest.php
+++ b/tests/Unit/ProductoImportTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para ImportadorProductos.
  *
@@ -53,6 +53,7 @@ class ProductoImportTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )"
         );

--- a/tests/Unit/ProductoTest.php
+++ b/tests/Unit/ProductoTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para el modelo Producto.
  *
@@ -53,6 +53,7 @@ class ProductoTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )
         ");

--- a/tests/Unit/ProveedorTest.php
+++ b/tests/Unit/ProveedorTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para el modelo Proveedor.
  *
@@ -52,6 +52,7 @@ class ProveedorTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )"
         );

--- a/tests/Unit/UsuarioTest.php
+++ b/tests/Unit/UsuarioTest.php
@@ -1,4 +1,4 @@
-<?php
+﻿<?php
 /**
  * Tests unitarios para el modelo Usuario.
  *
@@ -55,6 +55,7 @@ class UsuarioTest extends TestCase
                 datos_nuevos     TEXT    NULL,
                 usuario          TEXT    DEFAULT 'admin',
                 ip               TEXT,
+                business_id      INTEGER NULL,
                 fecha            TEXT    DEFAULT CURRENT_TIMESTAMP
             )
         ");


### PR DESCRIPTION
Auditoria::registrar() inserta business_id desde el commit anterior, pero los 11 test files creaban la tabla auditoria en memoria sin esa columna → PDOException en cada test que tocaba auditoría.